### PR TITLE
Milestone 2: multi-slide decks and §14 distribution layout

### DIFF
--- a/crates/peitho-core/src/check.rs
+++ b/crates/peitho-core/src/check.rs
@@ -3,37 +3,17 @@ use std::collections::BTreeMap;
 use crate::{
     domain::{Accepts, FragmentKind, SlotName, SourceFragment},
     error::{BuildError, ErrorKind, Result},
-    phase::{Checked, CheckedSlide, Deck, Mapped, MappedSlot, UnassignedFragment},
+    phase::{Checked, CheckedSlide, Deck, Mapped, MappedSlide, MappedSlot, UnassignedFragment},
     template::Template,
 };
 
 pub fn check_deck(deck: Deck<Mapped>, template: &Template) -> Result<Deck<Checked>> {
     let mut slides = Vec::new();
     for slide in deck.into_mapped_slides() {
-        for (slot, mapped_slot) in &slide.slots {
-            let contract = mapped_slot.contract();
-            for fragment in mapped_slot.fragments() {
-                if !accepts_fragment(contract.accepts, fragment) {
-                    return Err(BuildError::new(
-                        ErrorKind::Accepts,
-                        Some(fragment.line()),
-                        format!(
-                            "slot '{}' accepts {}, but got {}",
-                            slot.as_str(),
-                            contract.accepts,
-                            fragment.kind()
-                        ),
-                        format!(
-                            "change the template accepts to '{}' or move this content to a {} slot",
-                            fragment.kind().default_accepts(),
-                            fragment.kind().default_accepts()
-                        ),
-                    ));
-                }
-            }
-        }
-        check_arity(&slide.slots, template)?;
-        check_no_unassigned(&slide.unassigned)?;
+        let slide_number = slide.index + 1;
+        let slide_key = slide.key.as_str().to_owned();
+        check_slide(&slide, template)
+            .map_err(|err| err.with_slide(slide_number, Some(&slide_key)))?;
         let checked_slots = slide
             .slots
             .into_iter()
@@ -42,6 +22,38 @@ pub fn check_deck(deck: Deck<Mapped>, template: &Template) -> Result<Deck<Checke
         slides.push(CheckedSlide::new(slide.index, slide.key, checked_slots));
     }
     Ok(Deck::checked(slides))
+}
+
+fn check_slide(slide: &MappedSlide, template: &Template) -> Result<()> {
+    check_accepts(&slide.slots)?;
+    check_arity(&slide.slots, template)?;
+    check_no_unassigned(&slide.unassigned)
+}
+
+fn check_accepts(slots: &BTreeMap<SlotName, MappedSlot>) -> Result<()> {
+    for (slot, mapped_slot) in slots {
+        let contract = mapped_slot.contract();
+        for fragment in mapped_slot.fragments() {
+            if !accepts_fragment(contract.accepts, fragment) {
+                return Err(BuildError::new(
+                    ErrorKind::Accepts,
+                    Some(fragment.line()),
+                    format!(
+                        "slot '{}' accepts {}, but got {}",
+                        slot.as_str(),
+                        contract.accepts,
+                        fragment.kind()
+                    ),
+                    format!(
+                        "change the template accepts to '{}' or move this content to a {} slot",
+                        fragment.kind().default_accepts(),
+                        fragment.kind().default_accepts()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn accepts_fragment(accepts: Accepts, fragment: &SourceFragment) -> bool {
@@ -232,5 +244,25 @@ mod tests {
             err.help,
             "add a 'body' slot to the template or remove the heading"
         );
+    }
+
+    #[test]
+    fn arity_error_in_second_slide_includes_slide_context() {
+        let markdown = "# Intro\n\n---\n<!-- {\"key\":\"code-slide\"} -->\n# Code\n\n```rust\nfn a() {}\n```\n\n```rust\nfn b() {}\n```";
+        let template = parse_template(
+            "title-body-code",
+            r#"<section>
+               <slot name="title" accepts="inline" arity="1"></slot>
+               <slot name="code" accepts="code" arity="0..1"></slot>
+               </section>"#,
+        )
+        .unwrap();
+        let mapped = map_by_convention(parse_markdown(markdown).unwrap(), &template).unwrap();
+
+        let err = check_deck(mapped, &template).unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Arity);
+        assert!(err.to_string().contains("slide 2 ('code-slide'), line 7"));
+        assert!(err.to_string().contains("slot 'code' got 2 item(s)"));
     }
 }

--- a/crates/peitho-core/src/domain.rs
+++ b/crates/peitho-core/src/domain.rs
@@ -1,6 +1,8 @@
 use std::{fmt, str::FromStr};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct SlideKey(String);
 
 impl SlideKey {
@@ -293,6 +295,10 @@ impl RenderedSlide {
 
     pub fn html(&self) -> &str {
         &self.html
+    }
+
+    pub fn src(&self) -> String {
+        crate::manifest::fragment_src(self.index, &self.key)
     }
 }
 

--- a/crates/peitho-core/src/error.rs
+++ b/crates/peitho-core/src/error.rs
@@ -8,6 +8,13 @@ pub enum ErrorKind {
     Arity,
     ResidualContent,
     Theme,
+    Manifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorSlide {
+    pub number: usize,
+    pub key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,7 +23,7 @@ pub struct BuildError {
     pub line: Option<usize>,
     pub message: String,
     pub help: String,
-    rendered: String,
+    pub slide: Option<ErrorSlide>,
 }
 
 impl BuildError {
@@ -26,25 +33,58 @@ impl BuildError {
         message: impl Into<String>,
         help: impl Into<String>,
     ) -> Self {
-        let message = message.into();
-        let help = help.into();
-        let rendered = match line {
-            Some(line) => format!("line {line}: {message}\n  = help: {help}"),
-            None => format!("{message}\n  = help: {help}"),
-        };
         Self {
             kind,
             line,
-            message,
-            help,
-            rendered,
+            message: message.into(),
+            help: help.into(),
+            slide: None,
         }
+    }
+
+    pub fn with_slide(mut self, number: usize, key: Option<&str>) -> Self {
+        self.slide = Some(ErrorSlide {
+            number,
+            key: key.map(str::to_owned),
+        });
+        self
     }
 }
 
 impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.rendered)
+        match (&self.slide, self.line) {
+            (Some(slide), Some(line)) => match &slide.key {
+                Some(key) => write!(
+                    f,
+                    "slide {} ('{}'), line {}: {}\n  = help: {}",
+                    slide.number, key, line, self.message, self.help
+                ),
+                None => write!(
+                    f,
+                    "slide {}, line {}: {}\n  = help: {}",
+                    slide.number, line, self.message, self.help
+                ),
+            },
+            (Some(slide), None) => match &slide.key {
+                Some(key) => write!(
+                    f,
+                    "slide {} ('{}'): {}\n  = help: {}",
+                    slide.number, key, self.message, self.help
+                ),
+                None => write!(
+                    f,
+                    "slide {}: {}\n  = help: {}",
+                    slide.number, self.message, self.help
+                ),
+            },
+            (None, Some(line)) => write!(
+                f,
+                "line {}: {}\n  = help: {}",
+                line, self.message, self.help
+            ),
+            (None, None) => write!(f, "{}\n  = help: {}", self.message, self.help),
+        }
     }
 }
 
@@ -72,5 +112,28 @@ mod tests {
         );
         assert!(err.to_string().contains("line 12"));
         assert!(err.to_string().contains("slot 'code' got 2 item(s)"));
+    }
+
+    #[test]
+    fn display_includes_slide_context_before_line() {
+        let err = BuildError::new(
+            ErrorKind::Arity,
+            Some(12),
+            "slot 'code' got 2 item(s), but layout 'title-body-code' allows 0..1",
+            "use a layout with more code capacity or remove one code block",
+        )
+        .with_slide(2, Some("arch-1"));
+
+        assert_eq!(
+            err.slide,
+            Some(ErrorSlide {
+                number: 2,
+                key: Some("arch-1".to_owned())
+            })
+        );
+        assert!(err.to_string().contains("slide 2 ('arch-1'), line 12"));
+        assert!(err
+            .to_string()
+            .contains("help: use a layout with more code capacity or remove one code block"));
     }
 }

--- a/crates/peitho-core/src/lib.rs
+++ b/crates/peitho-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod check;
 pub mod domain;
 pub mod error;
+pub mod manifest;
 pub mod mapping;
 pub mod parser;
 pub mod phase;
@@ -10,9 +11,10 @@ pub mod theme;
 
 pub use check::check_deck;
 pub use error::{BuildError, Result};
+pub use manifest::{build_manifest, fragment_src, manifest_json, Manifest, ManifestSlide};
 pub use mapping::map_by_convention;
 pub use parser::parse_markdown;
-pub use phase::{require_checked_for_render, Deck, Mapped};
-pub use render::{render_deck, render_index};
+pub use phase::{require_checked_for_render, Deck, Mapped, Rendered};
+pub use render::{render_deck, render_distribution_index};
 pub use template::parse_template;
 pub use theme::build_theme_css;

--- a/crates/peitho-core/src/manifest.rs
+++ b/crates/peitho-core/src/manifest.rs
@@ -1,0 +1,192 @@
+use serde::Serialize;
+
+use crate::{
+    domain::SlideKey,
+    error::{BuildError, ErrorKind, Result},
+    phase::{Checked, CheckedSlide, Deck},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Manifest {
+    version: u8,
+    #[serde(rename = "peithoVersion")]
+    peitho_version: String,
+    title: String,
+    #[serde(rename = "slideCount")]
+    slide_count: usize,
+    slides: Vec<ManifestSlide>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ManifestSlide {
+    index: usize,
+    key: SlideKey,
+    src: String,
+    #[serde(rename = "hasNotes")]
+    has_notes: bool,
+}
+
+impl ManifestSlide {
+    pub fn new(index: usize, key: SlideKey, src: impl Into<String>, has_notes: bool) -> Self {
+        Self {
+            index,
+            key,
+            src: src.into(),
+            has_notes,
+        }
+    }
+}
+
+impl Manifest {
+    pub fn new(title: impl Into<String>, slides: Vec<ManifestSlide>) -> Self {
+        let slide_count = slides.len();
+        Self {
+            version: 1,
+            peitho_version: env!("CARGO_PKG_VERSION").to_owned(),
+            title: title.into(),
+            slide_count,
+            slides,
+        }
+    }
+}
+
+pub fn manifest_json(manifest: &Manifest) -> Result<String> {
+    let mut json = serde_json::to_string_pretty(manifest).map_err(|err| {
+        BuildError::new(
+            ErrorKind::Manifest,
+            None,
+            format!("failed to serialize manifest: {err}"),
+            "keep manifest fields serializable",
+        )
+    })?;
+    json.push('\n');
+    Ok(json)
+}
+
+pub fn build_manifest(deck: &Deck<Checked>) -> Manifest {
+    let title = deck
+        .checked_slides()
+        .first()
+        .and_then(CheckedSlide::title_text)
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or_else(|| "Untitled".to_owned());
+
+    let slides = deck
+        .checked_slides()
+        .iter()
+        .map(|slide| {
+            ManifestSlide::new(
+                slide.index(),
+                slide.key().clone(),
+                fragment_src(slide.index(), slide.key()),
+                false,
+            )
+        })
+        .collect();
+
+    Manifest::new(title, slides)
+}
+
+pub fn fragment_src(index: usize, key: &SlideKey) -> String {
+    format!("slides/{index:03}-{}.html", key.as_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        check::check_deck,
+        domain::SlideKey,
+        mapping::map_by_convention,
+        parser::parse_markdown,
+        template::{parse_template, Template},
+    };
+
+    #[test]
+    fn serializes_manifest_schema_exactly() {
+        let manifest = Manifest::new(
+            "Peitho Architecture",
+            vec![
+                ManifestSlide::new(
+                    0,
+                    SlideKey::new("arch-1").unwrap(),
+                    "slides/000-arch-1.html",
+                    false,
+                ),
+                ManifestSlide::new(
+                    1,
+                    SlideKey::new("details").unwrap(),
+                    "slides/001-details.html",
+                    false,
+                ),
+            ],
+        );
+
+        let json = manifest_json(&manifest).unwrap();
+
+        assert_eq!(
+            json,
+            concat!(
+                "{\n",
+                "  \"version\": 1,\n",
+                "  \"peithoVersion\": \"0.1.0\",\n",
+                "  \"title\": \"Peitho Architecture\",\n",
+                "  \"slideCount\": 2,\n",
+                "  \"slides\": [\n",
+                "    {\n",
+                "      \"index\": 0,\n",
+                "      \"key\": \"arch-1\",\n",
+                "      \"src\": \"slides/000-arch-1.html\",\n",
+                "      \"hasNotes\": false\n",
+                "    },\n",
+                "    {\n",
+                "      \"index\": 1,\n",
+                "      \"key\": \"details\",\n",
+                "      \"src\": \"slides/001-details.html\",\n",
+                "      \"hasNotes\": false\n",
+                "    }\n",
+                "  ]\n",
+                "}\n"
+            )
+        );
+    }
+
+    #[test]
+    fn builds_manifest_from_checked_deck() {
+        let checked = checked_deck(
+            "<!-- {\"key\":\"arch-1\"} -->\n# Peitho Architecture\n\n---\n# Details",
+            title_body_template(),
+        );
+
+        let manifest = build_manifest(&checked);
+        let json = manifest_json(&manifest).unwrap();
+
+        assert!(json.contains(r#""title": "Peitho Architecture""#));
+        assert!(json.contains(r#""slideCount": 2"#));
+        assert!(json.contains(r#""src": "slides/000-arch-1.html""#));
+        assert!(json.contains(r#""src": "slides/001-details.html""#));
+        assert!(json.contains(r#""hasNotes": false"#));
+    }
+
+    fn checked_deck(
+        markdown: &str,
+        template: Template,
+    ) -> crate::phase::Deck<crate::phase::Checked> {
+        check_deck(
+            map_by_convention(parse_markdown(markdown).unwrap(), &template).unwrap(),
+            &template,
+        )
+        .unwrap()
+    }
+
+    fn title_body_template() -> Template {
+        parse_template(
+            "title-body",
+            r#"<section>
+               <slot name="title" accepts="inline" arity="1"></slot>
+               <slot name="body" accepts="blocks" arity="0..*"></slot>
+               </section>"#,
+        )
+        .unwrap()
+    }
+}

--- a/crates/peitho-core/src/manifest.rs
+++ b/crates/peitho-core/src/manifest.rs
@@ -129,7 +129,9 @@ mod tests {
             concat!(
                 "{\n",
                 "  \"version\": 1,\n",
-                "  \"peithoVersion\": \"0.1.0\",\n",
+                "  \"peithoVersion\": \"",
+                env!("CARGO_PKG_VERSION"),
+                "\",\n",
                 "  \"title\": \"Peitho Architecture\",\n",
                 "  \"slideCount\": 2,\n",
                 "  \"slides\": [\n",

--- a/crates/peitho-core/src/mapping.rs
+++ b/crates/peitho-core/src/mapping.rs
@@ -98,4 +98,34 @@ mod tests {
         );
         assert!(slide.unassigned.is_empty());
     }
+
+    #[test]
+    fn maps_each_slide_independently() {
+        let markdown = "# Intro\n\nBody\n\n---\n# Architecture\n\n```rust\nfn main() {}\n```";
+        let template = parse_template(
+            "title-body-code",
+            r#"<section>
+               <slot name="title" accepts="inline" arity="1"></slot>
+               <slot name="body" accepts="blocks" arity="0..*"></slot>
+               <slot name="code" accepts="code" arity="0..1"></slot>
+               </section>"#,
+        )
+        .unwrap();
+
+        let mapped = map_by_convention(parse_markdown(markdown).unwrap(), &template).unwrap();
+
+        assert_eq!(mapped.mapped_slides().len(), 2);
+        assert_eq!(
+            mapped.mapped_slides()[0].slots[&SlotName::new("body").unwrap()]
+                .fragments()
+                .len(),
+            1
+        );
+        assert_eq!(
+            mapped.mapped_slides()[1].slots[&SlotName::new("code").unwrap()]
+                .fragments()
+                .len(),
+            1
+        );
+    }
 }

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeMap;
+
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use serde::Deserialize;
 
 use crate::{
-    domain::{SlideKey, SourceFragment},
+    domain::{FragmentKind, SlideKey, SourceFragment},
     error::{BuildError, ErrorKind, Result},
-    phase::{Deck, Parsed, ParsedSlide},
+    phase::{Deck, KeySource, Parsed, ParsedSlide},
 };
 
 #[derive(Debug, Deserialize)]
@@ -28,51 +30,146 @@ enum OpenBlock {
     },
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SlideRange {
+    start: usize,
+    end: usize,
+}
+
 pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
-    let mut explicit_key = None;
+    let ranges = split_slide_ranges(source)?;
+    if ranges.is_empty() {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            None,
+            "deck has no slides",
+            "add at least one slide with content before building",
+        ));
+    }
+
+    let mut slides = Vec::new();
+    for (index, range) in ranges.into_iter().enumerate() {
+        slides.push(parse_slide(source, range, index)?);
+    }
+    validate_unique_keys(&slides)?;
+    Ok(Deck::parsed(slides))
+}
+
+fn split_slide_ranges(source: &str) -> Result<Vec<SlideRange>> {
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut list_depth = 0usize;
+
+    for (event, range) in Parser::new_ext(source, parser_options()).into_offset_iter() {
+        match event {
+            Event::Start(Tag::List(_)) => list_depth += 1,
+            Event::End(TagEnd::List(_)) => list_depth = list_depth.saturating_sub(1),
+            Event::Rule if list_depth == 0 => {
+                ranges.push(SlideRange {
+                    start,
+                    end: range.start,
+                });
+                start = range.end;
+            }
+            Event::Rule => {}
+            _ => {}
+        }
+    }
+
+    ranges.push(SlideRange {
+        start,
+        end: source.len(),
+    });
+    Ok(ranges
+        .into_iter()
+        .filter(|range| !source[range.start..range.end].trim().is_empty())
+        .collect())
+}
+
+fn parse_slide(source: &str, range: SlideRange, index: usize) -> Result<ParsedSlide> {
+    let slice = &source[range.start..range.end];
+    let mut explicit_key: Option<(SlideKey, usize)> = None;
     let mut fragments = Vec::new();
     let mut block: Option<OpenBlock> = None;
     let mut list_depth = 0usize;
     let mut list_start = None;
-    let options = Options::ENABLE_TABLES | Options::ENABLE_FOOTNOTES;
+    let mut seen_content = false;
 
-    for (event, range) in Parser::new_ext(source, options).into_offset_iter() {
-        let line = line_for_offset(source, range.start);
+    for (event, local_range) in Parser::new_ext(slice, parser_options()).into_offset_iter() {
+        let global_start = range.start + local_range.start;
+        let global_end = range.start + local_range.end;
+        let line = line_for_offset(source, global_start);
         match event {
+            Event::Rule => {
+                let err = unsupported_construct(line, "thematic break inside slide");
+                return Err(attach_slide_context(
+                    err,
+                    index,
+                    explicit_key.as_ref(),
+                    &fragments,
+                ));
+            }
             Event::Start(Tag::List(_)) => {
                 if list_depth == 0 {
-                    list_start = Some(range.start);
+                    list_start = Some(global_start);
                 }
                 list_depth += 1;
             }
             Event::End(TagEnd::List(_)) => {
                 if list_depth == 0 {
-                    return Err(unsupported_construct(line, "list end without list start"));
+                    let err = unsupported_construct(line, "list end without list start");
+                    return Err(attach_slide_context(
+                        err,
+                        index,
+                        explicit_key.as_ref(),
+                        &fragments,
+                    ));
                 }
                 list_depth -= 1;
                 if list_depth == 0 {
                     if let Some(start) = list_start.take() {
                         fragments.push(SourceFragment::list(
                             line_for_offset(source, start),
-                            source_slice(source, start, range.end),
+                            source_slice(source, start, global_end),
                         ));
+                        seen_content = true;
                     }
                 }
             }
             Event::Html(html) | Event::InlineHtml(html) => {
-                if let Some(key) = parse_key_comment(html.as_ref(), line)? {
-                    if list_depth == 0 {
-                        explicit_key = Some(key);
+                if let Some(key) = parse_key_comment(html.as_ref(), line).map_err(|err| {
+                    attach_slide_context(err, index, explicit_key.as_ref(), &fragments)
+                })? {
+                    if list_depth > 0 || seen_content {
+                        let err = BuildError::new(
+                            ErrorKind::Parse,
+                            Some(line),
+                            "slide key comment must appear before slide content",
+                            "move the key comment to the first non-blank line of the slide",
+                        );
+                        return Err(attach_slide_context(
+                            err,
+                            index,
+                            explicit_key.as_ref(),
+                            &fragments,
+                        ));
                     }
+                    explicit_key = Some((key, line));
                 } else if !is_html_comment(html.as_ref()) && !html.trim().is_empty() {
-                    return Err(unsupported_construct(line, "html"));
+                    let err = unsupported_construct(line, "html");
+                    return Err(attach_slide_context(
+                        err,
+                        index,
+                        explicit_key.as_ref(),
+                        &fragments,
+                    ));
                 }
             }
             _ if list_depth > 0 => {}
             Event::Start(Tag::Heading { level, .. }) => {
                 block = Some(OpenBlock::Heading {
                     level: heading_level_to_u8(level),
-                    start: range.start,
+                    start: global_start,
                     text: String::new(),
                 });
             }
@@ -84,13 +181,16 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
                     fragments.push(SourceFragment::heading(
                         line_for_offset(source, start),
                         level,
-                        source_slice(source, start, range.end),
+                        source_slice(source, start, global_end),
                         text.trim(),
                     ));
+                    seen_content = true;
                 }
             }
             Event::Start(Tag::Paragraph) => {
-                block = Some(OpenBlock::Paragraph { start: range.start });
+                block = Some(OpenBlock::Paragraph {
+                    start: global_start,
+                });
             }
             Event::End(TagEnd::Paragraph) => {
                 if matches!(block, Some(OpenBlock::Paragraph { .. })) {
@@ -99,8 +199,9 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
                     };
                     fragments.push(SourceFragment::paragraph(
                         line_for_offset(source, start),
-                        source_slice(source, start, range.end),
+                        source_slice(source, start, global_end),
                     ));
+                    seen_content = true;
                 }
             }
             Event::Start(Tag::CodeBlock(kind)) => {
@@ -111,7 +212,7 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
                     _ => None,
                 };
                 block = Some(OpenBlock::Code {
-                    start: range.start,
+                    start: global_start,
                     language,
                     text: String::new(),
                 });
@@ -131,6 +232,7 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
                         language,
                         text,
                     ));
+                    seen_content = true;
                 }
             }
             Event::Text(text) | Event::Code(text) => match block.as_mut() {
@@ -142,7 +244,15 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
                 }) => code_text.push_str(&text),
                 Some(OpenBlock::Paragraph { .. }) => {}
                 None if text.trim().is_empty() => {}
-                None => return Err(unsupported_construct(line, "text outside block")),
+                None => {
+                    let err = unsupported_construct(line, "text outside block");
+                    return Err(attach_slide_context(
+                        err,
+                        index,
+                        explicit_key.as_ref(),
+                        &fragments,
+                    ));
+                }
             },
             Event::SoftBreak | Event::HardBreak => {
                 if let Some(OpenBlock::Code { text, .. }) = block.as_mut() {
@@ -151,7 +261,13 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
             }
             Event::Start(Tag::HtmlBlock) | Event::End(TagEnd::HtmlBlock) => {}
             Event::Start(tag) if unsupported_tag(&tag) => {
-                return Err(unsupported_construct(line, unsupported_tag_name(&tag)));
+                let err = unsupported_construct(line, unsupported_tag_name(&tag));
+                return Err(attach_slide_context(
+                    err,
+                    index,
+                    explicit_key.as_ref(),
+                    &fragments,
+                ));
             }
             Event::Start(Tag::Item)
             | Event::End(TagEnd::Item)
@@ -161,16 +277,73 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
             | Event::End(TagEnd::Strong)
             | Event::Start(Tag::Link { .. })
             | Event::End(TagEnd::Link) => {}
-            other => return Err(unsupported_construct(line, event_name(&other))),
+            other => {
+                let err = unsupported_construct(line, event_name(&other));
+                return Err(attach_slide_context(
+                    err,
+                    index,
+                    explicit_key.as_ref(),
+                    &fragments,
+                ));
+            }
         }
     }
 
-    let key = explicit_key.unwrap_or_else(|| derive_key_from_fragments(&fragments, 0));
-    Ok(Deck::parsed(vec![ParsedSlide {
-        index: 0,
+    let (key, key_source) = explicit_key
+        .map(|(key, line)| (key, KeySource::Explicit { line }))
+        .unwrap_or_else(|| {
+            let key = derive_key_from_fragments(&fragments, index);
+            let key_source = derived_key_source(&fragments);
+            (key, key_source)
+        });
+
+    Ok(ParsedSlide {
+        index,
         key,
+        key_source,
         fragments,
-    }]))
+    })
+}
+
+fn attach_slide_context(
+    err: BuildError,
+    index: usize,
+    explicit_key: Option<&(SlideKey, usize)>,
+    fragments: &[SourceFragment],
+) -> BuildError {
+    let key = explicit_key
+        .map(|(key, _line)| key.clone())
+        .unwrap_or_else(|| derive_key_from_fragments(fragments, index));
+    err.with_slide(index + 1, Some(key.as_str()))
+}
+
+fn parser_options() -> Options {
+    Options::ENABLE_TABLES | Options::ENABLE_FOOTNOTES
+}
+
+fn validate_unique_keys(slides: &[ParsedSlide]) -> Result<()> {
+    let mut seen = BTreeMap::<String, usize>::new();
+    for slide in slides {
+        let key = slide.key.as_str().to_owned();
+        if seen.insert(key.clone(), slide.index).is_some() {
+            let line = match slide.key_source {
+                KeySource::Explicit { line } => Some(line),
+                KeySource::Derived { line } => line,
+            };
+            let help = match slide.key_source {
+                KeySource::Explicit { .. } => "choose a unique explicit slide key",
+                KeySource::Derived { .. } => "add an explicit unique key comment before this slide",
+            };
+            return Err(BuildError::new(
+                ErrorKind::Parse,
+                line,
+                format!("duplicate slide key '{key}'"),
+                help,
+            )
+            .with_slide(slide.index + 1, Some(slide.key.as_str())));
+        }
+    }
+    Ok(())
 }
 
 fn parse_key_comment(raw: &str, line: usize) -> Result<Option<SlideKey>> {
@@ -271,6 +444,14 @@ fn heading_level_to_u8(level: HeadingLevel) -> u8 {
     }
 }
 
+fn derived_key_source(fragments: &[SourceFragment]) -> KeySource {
+    let line = fragments
+        .iter()
+        .find(|fragment| matches!(fragment.kind(), FragmentKind::Heading { .. }))
+        .map(SourceFragment::line);
+    KeySource::Derived { line }
+}
+
 fn derive_key_from_fragments(fragments: &[SourceFragment], index: usize) -> SlideKey {
     let title = fragments.iter().find_map(SourceFragment::heading_text);
     let raw = title.unwrap_or_else(|| format!("slide-{}", index + 1));
@@ -294,7 +475,7 @@ fn derive_key_from_fragments(fragments: &[SourceFragment], index: usize) -> Slid
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{domain::FragmentKind, error::ErrorKind};
+    use crate::{domain::FragmentKind, error::ErrorKind, phase::KeySource};
 
     #[test]
     fn preserves_inline_markdown_and_generates_list_fragments() {
@@ -433,5 +614,144 @@ After list
     fn explicit_key_wins_over_derived_key() {
         let deck = parse_markdown("<!-- {\"key\":\"arch-1\"} -->\n# Renamed Title").unwrap();
         assert_eq!(deck.parsed_slides()[0].key.as_str(), "arch-1");
+    }
+
+    #[test]
+    fn parsed_slide_records_explicit_and_derived_key_sources() {
+        let deck =
+            parse_markdown("<!-- {\"key\":\"arch-1\"} -->\n# Architecture\n\n---\n# Derived Title")
+                .unwrap();
+        let slides = deck.parsed_slides();
+
+        assert_eq!(slides[0].key.as_str(), "arch-1");
+        assert_eq!(slides[0].key_source, KeySource::Explicit { line: 1 });
+        assert_eq!(slides[1].key.as_str(), "derived-title");
+        assert_eq!(slides[1].key_source, KeySource::Derived { line: Some(5) });
+    }
+
+    #[test]
+    fn derives_slide_number_key_when_slide_has_no_heading() {
+        let deck = parse_markdown("Body only\n\n---\nSecond body").unwrap();
+
+        assert_eq!(deck.parsed_slides()[0].key.as_str(), "slide-1");
+        assert_eq!(
+            deck.parsed_slides()[0].key_source,
+            KeySource::Derived { line: None }
+        );
+        assert_eq!(deck.parsed_slides()[1].key.as_str(), "slide-2");
+        assert_eq!(
+            deck.parsed_slides()[1].key_source,
+            KeySource::Derived { line: None }
+        );
+    }
+
+    #[test]
+    fn splits_slides_on_thematic_break() {
+        let deck = parse_markdown("# One\n\n---\n\n# Two\n\nBody").unwrap();
+        let slides = deck.parsed_slides();
+
+        assert_eq!(slides.len(), 2);
+        assert_eq!(slides[0].index, 0);
+        assert_eq!(slides[0].key.as_str(), "one");
+        assert_eq!(slides[1].index, 1);
+        assert_eq!(slides[1].key.as_str(), "two");
+        assert_eq!(slides[1].fragments[0].line(), 5);
+    }
+
+    #[test]
+    fn rejects_empty_deck_after_splitting_delimiters() {
+        let err = parse_markdown("  \n\n---\n\n---\n").unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, None);
+        assert!(err.to_string().contains("deck has no slides"));
+        assert_eq!(
+            err.help,
+            "add at least one slide with content before building"
+        );
+    }
+
+    #[test]
+    fn unsupported_construct_after_delimiter_reports_global_line_and_slide() {
+        let err = parse_markdown("# One\n\n---\n\n# Two\n\n> quote").unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(7));
+        assert!(err.to_string().contains("slide 2 ('two'), line 7"));
+        assert!(err
+            .to_string()
+            .contains("unsupported construct 'blockquote'"));
+    }
+
+    #[test]
+    fn unsupported_image_after_delimiter_is_not_silently_dropped() {
+        let err = parse_markdown("# One\n\n---\n\n![alt](image.png)").unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(5));
+        assert!(err.to_string().contains("slide 2 ('slide-2'), line 5"));
+        assert!(err.to_string().contains("unsupported construct 'image'"));
+    }
+
+    #[test]
+    fn unsupported_table_after_delimiter_is_not_silently_dropped() {
+        let err = parse_markdown("# One\n\n---\n\n| a |\n| - |").unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(5));
+        assert!(err.to_string().contains("slide 2 ('slide-2'), line 5"));
+        assert!(err.to_string().contains("unsupported construct 'table'"));
+    }
+
+    #[test]
+    fn key_comment_after_delimiter_belongs_to_next_slide() {
+        let markdown = "# Intro\n\n---\n<!-- {\"key\":\"arch-1\"} -->\n# Architecture";
+        let deck = parse_markdown(markdown).unwrap();
+
+        assert_eq!(deck.parsed_slides()[0].key.as_str(), "intro");
+        assert_eq!(deck.parsed_slides()[1].key.as_str(), "arch-1");
+        assert_eq!(
+            deck.parsed_slides()[1].key_source,
+            KeySource::Explicit { line: 4 }
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_explicit_slide_keys() {
+        let err = parse_markdown(
+            "<!-- {\"key\":\"same\"} -->\n# One\n\n---\n<!-- {\"key\":\"same\"} -->\n# Two",
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(5));
+        assert!(err.to_string().contains("slide 2 ('same'), line 5"));
+        assert!(err.to_string().contains("duplicate slide key 'same'"));
+        assert_eq!(err.help, "choose a unique explicit slide key");
+    }
+
+    #[test]
+    fn rejects_derived_slide_key_collision_with_explicit_key() {
+        let err =
+            parse_markdown("<!-- {\"key\":\"intro\"} -->\n# One\n\n---\n# Intro").unwrap_err();
+
+        assert_eq!(err.line, Some(5));
+        assert!(err.to_string().contains("duplicate slide key 'intro'"));
+        assert_eq!(
+            err.help,
+            "add an explicit unique key comment before this slide"
+        );
+    }
+
+    #[test]
+    fn rejects_derived_slide_key_collision_with_derived_key() {
+        let err = parse_markdown("# Intro\n\n---\n# Intro").unwrap_err();
+
+        assert_eq!(err.line, Some(4));
+        assert!(err.to_string().contains("duplicate slide key 'intro'"));
+        assert_eq!(
+            err.help,
+            "add an explicit unique key comment before this slide"
+        );
     }
 }

--- a/crates/peitho-core/src/phase.rs
+++ b/crates/peitho-core/src/phase.rs
@@ -12,10 +12,17 @@ pub struct Parsed {
     slides: Vec<ParsedSlide>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeySource {
+    Explicit { line: usize },
+    Derived { line: Option<usize> },
+}
+
 #[derive(Debug, Clone)]
 pub struct ParsedSlide {
     pub index: usize,
     pub key: SlideKey,
+    pub key_source: KeySource,
     pub fragments: Vec<SourceFragment>,
 }
 
@@ -152,6 +159,14 @@ impl CheckedSlide {
     pub(crate) fn slots(&self) -> &BTreeMap<SlotName, Vec<SourceFragment>> {
         &self.slots
     }
+
+    pub(crate) fn title_text(&self) -> Option<String> {
+        let title = SlotName::new("title").ok()?;
+        self.slots
+            .get(&title)?
+            .iter()
+            .find_map(SourceFragment::heading_text)
+    }
 }
 
 impl Deck<Checked> {
@@ -167,6 +182,10 @@ impl Deck<Checked> {
 
     pub fn slide_keys(&self) -> impl Iterator<Item = &SlideKey> {
         self.phase.slides.iter().map(|slide| &slide.key)
+    }
+
+    pub(crate) fn checked_slides(&self) -> &[CheckedSlide] {
+        &self.phase.slides
     }
 
     pub(crate) fn into_checked_slides(self) -> Vec<CheckedSlide> {
@@ -213,6 +232,7 @@ mod tests {
         let deck = Deck::parsed(vec![ParsedSlide {
             key: SlideKey::new("arch-1").unwrap(),
             index: 0,
+            key_source: KeySource::Explicit { line: 1 },
             fragments: vec![SourceFragment::paragraph(3, "body")],
         }]);
 

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -176,15 +176,32 @@ pub fn render_distribution_index() -> String {
 <body>
   <main id="peitho-slides"></main>
   <script>
-    async function loadDeck() {
-      const manifest = await fetch('manifest.json').then((response) => response.json());
-      document.title = manifest.title || 'Peitho Deck';
+    function showError(message) {
       const root = document.getElementById('peitho-slides');
-      for (const slide of manifest.slides) {
-        const html = await fetch(slide.src).then((response) => response.text());
-        const holder = document.createElement('div');
-        holder.innerHTML = html;
-        while (holder.firstChild) root.appendChild(holder.firstChild);
+      root.textContent = message;
+    }
+
+    async function fetchOk(url) {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to load ${url}: ${response.status}`);
+      }
+      return response;
+    }
+
+    async function loadDeck() {
+      try {
+        const manifest = await fetchOk('manifest.json').then((response) => response.json());
+        document.title = manifest.title || 'Peitho Deck';
+        const root = document.getElementById('peitho-slides');
+        for (const slide of manifest.slides) {
+          const html = await fetchOk(slide.src).then((response) => response.text());
+          const holder = document.createElement('div');
+          holder.innerHTML = html;
+          while (holder.firstChild) root.appendChild(holder.firstChild);
+        }
+      } catch (error) {
+        showError(error.message);
       }
     }
     loadDeck();
@@ -304,8 +321,9 @@ mod tests {
         let html = render_distribution_index();
 
         assert!(html.contains(r#"<link rel="stylesheet" href="peitho.css">"#));
-        assert!(html.contains("fetch('manifest.json')"));
-        assert!(html.contains("fetch(slide.src)"));
+        assert!(html.contains("fetchOk('manifest.json')"));
+        assert!(html.contains("fetchOk(slide.src)"));
+        assert!(html.contains("response.ok"));
         assert!(html.contains(r#"id="peitho-slides""#));
         assert!(!html.contains("data-slide-key="));
     }

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -164,14 +164,8 @@ fn render_error(err: RewritingError) -> BuildError {
     }
 }
 
-pub fn render_index(slides: &[RenderedSlide]) -> String {
-    let body = slides
-        .iter()
-        .map(RenderedSlide::html)
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!(
-        r#"<!doctype html>
+pub fn render_distribution_index() -> String {
+    r#"<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -180,10 +174,24 @@ pub fn render_index(slides: &[RenderedSlide]) -> String {
   <title>Peitho Deck</title>
 </head>
 <body>
-{body}
+  <main id="peitho-slides"></main>
+  <script>
+    async function loadDeck() {
+      const manifest = await fetch('manifest.json').then((response) => response.json());
+      document.title = manifest.title || 'Peitho Deck';
+      const root = document.getElementById('peitho-slides');
+      for (const slide of manifest.slides) {
+        const html = await fetch(slide.src).then((response) => response.text());
+        const holder = document.createElement('div');
+        holder.innerHTML = html;
+        while (holder.firstChild) root.appendChild(holder.firstChild);
+      }
+    }
+    loadDeck();
+  </script>
 </body>
 </html>"#
-    )
+        .to_owned()
 }
 
 #[cfg(test)]
@@ -281,5 +289,38 @@ mod tests {
             .to_owned();
         assert!(atx_html.contains(r#"<span class="slot-title">Architecture</span>"#));
         assert!(!atx_html.contains("Architecture #"));
+    }
+
+    #[test]
+    fn rendered_slides_have_manifest_fragment_sources() {
+        let rendered = render_checked_deck("# Intro\n\n---\n# Details");
+
+        assert_eq!(rendered.slides()[0].src(), "slides/000-intro.html");
+        assert_eq!(rendered.slides()[1].src(), "slides/001-details.html");
+    }
+
+    #[test]
+    fn distribution_index_fetches_manifest_and_slide_sources_without_embedding_slides() {
+        let html = render_distribution_index();
+
+        assert!(html.contains(r#"<link rel="stylesheet" href="peitho.css">"#));
+        assert!(html.contains("fetch('manifest.json')"));
+        assert!(html.contains("fetch(slide.src)"));
+        assert!(html.contains(r#"id="peitho-slides""#));
+        assert!(!html.contains("data-slide-key="));
+    }
+
+    fn render_checked_deck(markdown: &str) -> Deck<Rendered> {
+        let template = parse_template(
+            "title-only",
+            r#"<section><h1><slot name="title" accepts="inline" arity="1"></slot></h1></section>"#,
+        )
+        .unwrap();
+        let checked = check_deck(
+            map_by_convention(parse_markdown(markdown).unwrap(), &template).unwrap(),
+            &template,
+        )
+        .unwrap();
+        render_deck(checked, &template).unwrap()
     }
 }

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -60,6 +60,8 @@ fn build(
     let mapped = core(peitho_core::map_by_convention(parsed, &template))?;
     let checked = core(peitho_core::check_deck(mapped, &template))?;
     let slide_count = checked.slide_count();
+    let manifest = peitho_core::build_manifest(&checked);
+    let manifest_json = core(peitho_core::manifest_json(&manifest))?;
     let css = core(peitho_core::build_theme_css(
         &base_css,
         &overrides_css,
@@ -70,12 +72,26 @@ fn build(
 
     fs::create_dir_all(out).into_diagnostic()?;
     fs::write(out.join("peitho.css"), css).into_diagnostic()?;
+    write_slide_fragments(out, &rendered)?;
+    fs::write(out.join("manifest.json"), manifest_json).into_diagnostic()?;
     fs::write(
         out.join("index.html"),
-        peitho_core::render_index(rendered.slides()),
+        peitho_core::render_distribution_index(),
     )
     .into_diagnostic()?;
     println!("built {} slide(s) into {}", slide_count, out.display());
+    Ok(())
+}
+
+fn write_slide_fragments(
+    out: &Path,
+    rendered: &peitho_core::Deck<peitho_core::Rendered>,
+) -> miette::Result<()> {
+    let slides_dir = out.join("slides");
+    fs::create_dir_all(&slides_dir).into_diagnostic()?;
+    for slide in rendered.slides() {
+        fs::write(out.join(slide.src()), slide.html()).into_diagnostic()?;
+    }
     Ok(())
 }
 

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -88,6 +88,9 @@ fn write_slide_fragments(
     rendered: &peitho_core::Deck<peitho_core::Rendered>,
 ) -> miette::Result<()> {
     let slides_dir = out.join("slides");
+    if slides_dir.exists() {
+        fs::remove_dir_all(&slides_dir).into_diagnostic()?;
+    }
     fs::create_dir_all(&slides_dir).into_diagnostic()?;
     for slide in rendered.slides() {
         fs::write(out.join(slide.src()), slide.html()).into_diagnostic()?;

--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -53,7 +53,7 @@ fn build_writes_index_html_and_css() {
 
     let index = fs::read_to_string(out.join("index.html")).unwrap();
     let first = fs::read_to_string(out.join("slides/000-arch-1.html")).unwrap();
-    assert!(index.contains("fetch('manifest.json')"));
+    assert!(index.contains("fetchOk('manifest.json')"));
     assert!(!index.contains(r#"data-slide-key="arch-1""#));
     assert!(first.contains(r#"data-slide-key="arch-1""#));
     assert!(fs::read_to_string(out.join("peitho.css"))
@@ -193,7 +193,10 @@ fn build_writes_manifest_json_with_refs_not_html() {
     let manifest = fs::read_to_string(out.join("manifest.json")).unwrap();
 
     assert!(manifest.contains(r#""version": 1"#));
-    assert!(manifest.contains(r#""peithoVersion": "0.1.0""#));
+    assert!(manifest.contains(&format!(
+        r#""peithoVersion": "{}""#,
+        env!("CARGO_PKG_VERSION")
+    )));
     assert!(manifest.contains(r#""title": "Peitho Architecture""#));
     assert!(manifest.contains(r#""slideCount": 3"#));
     assert!(manifest.contains(r#""src": "slides/000-arch-1.html""#));
@@ -206,8 +209,8 @@ fn build_writes_fetching_index_without_embedded_slide_html() {
     let (_dir, out) = build_multi_slide_fixture();
     let index = fs::read_to_string(out.join("index.html")).unwrap();
 
-    assert!(index.contains("fetch('manifest.json')"));
-    assert!(index.contains("fetch(slide.src)"));
+    assert!(index.contains("fetchOk('manifest.json')"));
+    assert!(index.contains("fetchOk(slide.src)"));
     assert!(index.contains(r#"<main id="peitho-slides"></main>"#));
     assert!(!index.contains("Peitho Architecture"));
     assert!(!index.contains("data-slide-key=\"arch-1\""));
@@ -300,6 +303,56 @@ fn build_keeps_slide_html_only_in_fragment_files() {
     assert!(first.contains(r#"data-slide-key="arch-1""#));
 }
 
+#[test]
+fn build_clears_stale_slide_fragments_before_writing_new_ones() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(dir.path(), "");
+    let out = dir.path().join("dist");
+
+    write_multi_slide_fixture(&deck);
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+            "--base-css",
+            base.to_str().unwrap(),
+            "--overrides-css",
+            overrides.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(slide_fragment_count(&out), 3);
+
+    fs::write(&deck, "# Solo").unwrap();
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+            "--base-css",
+            base.to_str().unwrap(),
+            "--overrides-css",
+            overrides.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(slide_fragment_count(&out), 1);
+    assert!(out.join("slides/000-solo.html").exists());
+}
+
 fn workspace_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -358,6 +411,10 @@ fn write_overrides_css(dir: &Path, css: &str) -> PathBuf {
     let path = dir.join("overrides.css");
     fs::write(&path, css).unwrap();
     path
+}
+
+fn slide_fragment_count(out: &Path) -> usize {
+    fs::read_dir(out.join("slides")).unwrap().count()
 }
 
 fn build_multi_slide_fixture() -> (TempDir, PathBuf) {

--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -1,8 +1,11 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 
 #[test]
 fn build_writes_index_html_and_css() {
@@ -48,9 +51,11 @@ fn build_writes_index_html_and_css() {
         .success()
         .stdout(predicate::str::contains("built 1 slide"));
 
-    assert!(fs::read_to_string(out.join("index.html"))
-        .unwrap()
-        .contains(r#"data-slide-key="arch-1""#));
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+    let first = fs::read_to_string(out.join("slides/000-arch-1.html")).unwrap();
+    assert!(index.contains("fetch('manifest.json')"));
+    assert!(!index.contains(r#"data-slide-key="arch-1""#));
+    assert!(first.contains(r#"data-slide-key="arch-1""#));
     assert!(fs::read_to_string(out.join("peitho.css"))
         .unwrap()
         .contains(r#"[data-slide-key="arch-1"] .slot-code"#));
@@ -139,11 +144,120 @@ fn contract_error_uses_template_file_stem_as_layout_name() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("layout 'custom-layout' allows"));
+        .stderr(predicate::str::contains("layout"))
+        .stderr(predicate::str::contains("custom-layout"))
+        .stderr(predicate::str::contains("allows 0..1"));
 }
 
 #[test]
-fn repository_example_builds() {
+fn build_writes_slide_fragments_in_slides_directory() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let out = dir.path().join("dist");
+    write_multi_slide_fixture(&deck);
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(
+        dir.path(),
+        r#"[data-slide-key="arch-1"] .slot-code { outline: 3px solid #f40; }"#,
+    );
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+            "--base-css",
+            base.to_str().unwrap(),
+            "--overrides-css",
+            overrides.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(out.join("slides/000-arch-1.html").exists());
+    assert!(out.join("slides/001-convention-mapping.html").exists());
+    assert!(out.join("slides/002-dist-1.html").exists());
+    assert!(fs::read_to_string(out.join("slides/000-arch-1.html"))
+        .unwrap()
+        .contains(r#"data-slide-key="arch-1""#));
+}
+
+#[test]
+fn build_writes_manifest_json_with_refs_not_html() {
+    let (_dir, out) = build_multi_slide_fixture();
+    let manifest = fs::read_to_string(out.join("manifest.json")).unwrap();
+
+    assert!(manifest.contains(r#""version": 1"#));
+    assert!(manifest.contains(r#""peithoVersion": "0.1.0""#));
+    assert!(manifest.contains(r#""title": "Peitho Architecture""#));
+    assert!(manifest.contains(r#""slideCount": 3"#));
+    assert!(manifest.contains(r#""src": "slides/000-arch-1.html""#));
+    assert!(manifest.contains(r#""hasNotes": false"#));
+    assert!(!manifest.contains("<section"));
+}
+
+#[test]
+fn build_writes_fetching_index_without_embedded_slide_html() {
+    let (_dir, out) = build_multi_slide_fixture();
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+
+    assert!(index.contains("fetch('manifest.json')"));
+    assert!(index.contains("fetch(slide.src)"));
+    assert!(index.contains(r#"<main id="peitho-slides"></main>"#));
+    assert!(!index.contains("Peitho Architecture"));
+    assert!(!index.contains("data-slide-key=\"arch-1\""));
+}
+
+#[test]
+fn build_accepts_override_targeting_derived_second_slide_key() {
+    let (_dir, out) = build_multi_slide_fixture_with_override(
+        r#"[data-slide-key="convention-mapping"] .slot-body { color: red; }"#,
+    );
+
+    let css = fs::read_to_string(out.join("peitho.css")).unwrap();
+    assert!(css.contains(r#"[data-slide-key="convention-mapping"] .slot-body"#));
+}
+
+#[test]
+fn build_fails_on_duplicate_slide_keys_with_line_help_and_slide_context() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    fs::write(&deck, "# Intro\n\n---\n# Intro").unwrap();
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(dir.path(), "");
+    let out = dir.path().join("dist");
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+            "--base-css",
+            base.to_str().unwrap(),
+            "--overrides-css",
+            overrides.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("slide 2 ('intro'), line 4"))
+        .stderr(predicate::str::contains("duplicate slide key 'intro'"))
+        .stderr(predicate::str::contains(
+            "help: add an explicit unique key comment before this slide",
+        ));
+}
+
+#[test]
+fn repository_example_builds_three_slide_distribution() {
     let out = tempdir().unwrap();
 
     Command::cargo_bin("peitho")
@@ -162,13 +276,28 @@ fn repository_example_builds() {
             out.path().to_str().unwrap(),
         ])
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains("built 3 slide(s)"));
 
-    let html = fs::read_to_string(out.path().join("index.html")).unwrap();
-    let css = fs::read_to_string(out.path().join("peitho.css")).unwrap();
-    assert!(html.contains(r#"data-slide-key="arch-1""#));
-    assert!(html.contains(r#"class="slot-code""#));
-    assert!(css.contains(r#"[data-slide-key="arch-1"] .slot-code"#));
+    assert!(out.path().join("slides/000-arch-1.html").exists());
+    assert!(out
+        .path()
+        .join("slides/001-convention-mapping.html")
+        .exists());
+    assert!(out.path().join("slides/002-dist-1.html").exists());
+    assert!(fs::read_to_string(out.path().join("manifest.json"))
+        .unwrap()
+        .contains(r#""slideCount": 3"#));
+}
+
+#[test]
+fn build_keeps_slide_html_only_in_fragment_files() {
+    let (_dir, out) = build_multi_slide_fixture();
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+    let first = fs::read_to_string(out.join("slides/000-arch-1.html")).unwrap();
+
+    assert!(!index.contains("data-slide-key"));
+    assert!(first.contains(r#"data-slide-key="arch-1""#));
 }
 
 fn workspace_root() -> PathBuf {
@@ -178,4 +307,90 @@ fn workspace_root() -> PathBuf {
         .parent()
         .unwrap()
         .to_owned()
+}
+
+fn write_multi_slide_fixture(path: &Path) {
+    fs::write(
+        path,
+        r#"<!-- {"key":"arch-1"} -->
+# Peitho Architecture
+
+Body
+
+```rust
+fn main() {}
+```
+
+---
+
+# Convention Mapping
+
+- title
+- body
+
+---
+<!-- {"key":"dist-1"} -->
+# Distribution
+
+Fragments and manifest.
+"#,
+    )
+    .unwrap();
+}
+
+fn write_template(dir: &Path) -> PathBuf {
+    let path = dir.join("title-body-code.html");
+    fs::write(
+        &path,
+        r#"<section><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot></section>"#,
+    )
+    .unwrap();
+    path
+}
+
+fn write_base_css(dir: &Path) -> PathBuf {
+    let path = dir.join("base.css");
+    fs::write(&path, ".slot-title { font-weight: 700; }").unwrap();
+    path
+}
+
+fn write_overrides_css(dir: &Path, css: &str) -> PathBuf {
+    let path = dir.join("overrides.css");
+    fs::write(&path, css).unwrap();
+    path
+}
+
+fn build_multi_slide_fixture() -> (TempDir, PathBuf) {
+    build_multi_slide_fixture_with_override(
+        r#"[data-slide-key="arch-1"] .slot-code { outline: 3px solid #f40; }"#,
+    )
+}
+
+fn build_multi_slide_fixture_with_override(override_css: &str) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    write_multi_slide_fixture(&deck);
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(dir.path(), override_css);
+    let out = dir.path().join("dist");
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+            "--base-css",
+            base.to_str().unwrap(),
+            "--overrides-css",
+            overrides.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    (dir, out)
 }

--- a/docs/plans/2026-07-02-milestone-2-multi-slide.md
+++ b/docs/plans/2026-07-02-milestone-2-multi-slide.md
@@ -1,0 +1,1736 @@
+# Peitho Milestone 2 Multi-Slide Distribution Plan
+
+<!-- constrained-by ../PEITHO_KICKOFF.md#13-共通中間表現から-emit-で射影する -->
+<!-- constrained-by ../PEITHO_KICKOFF.md#14-2エントリポイント構成実体は単一 -->
+<!-- constrained-by ../PEITHO_KICKOFF.md#17-manifest--notes-スキーマと契約の単一-source -->
+
+## Purpose
+
+マイルストーン2は、1つの Markdown deck から複数スライドを解析・検査し、§14 の配布用 `dist/` 構成を生成する。解析・マッピング・検査は1回だけ行い、その検査済みモデルから `slides/` 断片、`manifest.json`、配布用 `index.html`、`peitho.css` を emit する。
+
+スコープは Rust 側の `build` のみ。`present.html`、`notes.json`、`present` / `publish` コマンド、`--watch`、fenced div 明示スロット、複数テンプレート選択、`ts-rs` / `schemars` 生成は作らない。
+
+## File Structure Map
+
+| Path | Responsibility | Depends on |
+| --- | --- | --- |
+| `crates/peitho-core/src/domain.rs` | `SlideKey` の slug 制約、fragment と `RenderedSlide` の accessor | none |
+| `crates/peitho-core/src/error.rs` | slide context 付き `BuildError` 表示 | `domain.rs` |
+| `crates/peitho-core/src/phase.rs` | `Deck<Parsed/Mapped/Checked/Rendered>` の複数 slide accessor、checked title extraction | `domain.rs` |
+| `crates/peitho-core/src/parser.rs` | `---` top-level thematic break による slide 分割、key ownership、重複 key 検査 | `domain.rs`, `error.rs`, `phase.rs` |
+| `crates/peitho-core/src/mapping.rs` | 各 slide を convention mapping | `phase.rs`, `template.rs` |
+| `crates/peitho-core/src/check.rs` | 各 slide の4段検査と slide context 付与 | `error.rs`, `phase.rs`, `template.rs` |
+| `crates/peitho-core/src/render.rs` | checked slides を HTML 断片へ render、配布 `index.html` 生成 | `domain.rs`, `phase.rs`, `template.rs` |
+| `crates/peitho-core/src/manifest.rs` | §17 `manifest.json` の Rust source of truth と JSON 生成 | `phase.rs`, `domain.rs`, `serde` |
+| `crates/peitho-core/src/theme.rs` | 全 slide key と template slot に対する override 検査 | `phase.rs`, `template.rs` |
+| `crates/peitho-core/src/lib.rs` | `manifest` exports、distribution index export | all core modules |
+| `crates/peitho/src/main.rs` | `peitho build` が `dist/slides/*.html`, `manifest.json`, `index.html`, `peitho.css` を書く | `peitho-core` |
+| `crates/peitho/tests/build.rs` | CLI black-box tests: multi-slide dist, manifest markers, error context | CLI binary |
+| `examples/deck.md` | 3-slide deck fixture: explicit key, derived key, delimiter直後 key comment | parser, CLI |
+| `themes/overrides.css` | multi-slide deck 内の既知 key を狙う override | manifest keys |
+
+Dependency direction remains one-way: CLI writes files, `peitho-core` owns parsing, typestate, checking, rendering, manifest schema, and distribution index string generation. `manifest.json` is serialized from `peitho-core` types, not assembled as ad hoc CLI strings.
+
+## Implementation Tasks
+
+### Task 1 - Add Slide Context to BuildError
+
+Goal: every parse/check/theme error can optionally report `slide N ('key')` while preserving existing line/help output.
+
+Files:
+
+- `crates/peitho-core/src/error.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/error.rs
+#[test]
+fn display_includes_slide_context_before_line() {
+    let err = BuildError::new(
+        ErrorKind::Arity,
+        Some(12),
+        "slot 'code' got 2 item(s), but layout 'title-body-code' allows 0..1",
+        "use a layout with more code capacity or remove one code block",
+    )
+    .with_slide(2, Some("arch-1"));
+
+    assert_eq!(err.slide, Some(ErrorSlide { number: 2, key: Some("arch-1".to_owned()) }));
+    assert!(err.to_string().contains("slide 2 ('arch-1'), line 12"));
+    assert!(err.to_string().contains("help: use a layout with more code capacity or remove one code block"));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/error.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorSlide {
+    pub number: usize,
+    pub key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildError {
+    pub kind: ErrorKind,
+    pub line: Option<usize>,
+    pub message: String,
+    pub help: String,
+    pub slide: Option<ErrorSlide>,
+}
+
+impl BuildError {
+    pub fn new(
+        kind: ErrorKind,
+        line: Option<usize>,
+        message: impl Into<String>,
+        help: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            line,
+            message: message.into(),
+            help: help.into(),
+            slide: None,
+        }
+    }
+
+    pub fn with_slide(mut self, number: usize, key: Option<&str>) -> Self {
+        self.slide = Some(ErrorSlide {
+            number,
+            key: key.map(str::to_owned),
+        });
+        self
+    }
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match (&self.slide, self.line) {
+            (Some(slide), Some(line)) => match &slide.key {
+                Some(key) => write!(f, "slide {} ('{}'), line {}: {}\n  = help: {}", slide.number, key, line, self.message, self.help),
+                None => write!(f, "slide {}, line {}: {}\n  = help: {}", slide.number, line, self.message, self.help),
+            },
+            (Some(slide), None) => match &slide.key {
+                Some(key) => write!(f, "slide {} ('{}'): {}\n  = help: {}", slide.number, key, self.message, self.help),
+                None => write!(f, "slide {}: {}\n  = help: {}", slide.number, self.message, self.help),
+            },
+            (None, Some(line)) => write!(f, "line {}: {}\n  = help: {}", line, self.message, self.help),
+            (None, None) => write!(f, "{}\n  = help: {}", self.message, self.help),
+        }
+    }
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core error::tests::display_includes_slide_context_before_line
+```
+
+### Task 2 - Represent Parsed Slide Key Source
+
+Goal: retain key origin and line so duplicate-key errors can distinguish explicit and derived keys.
+
+Files:
+
+- `crates/peitho-core/src/phase.rs`
+- `crates/peitho-core/src/parser.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/parser.rs
+#[test]
+fn parsed_slide_records_explicit_and_derived_key_sources() {
+    let deck = parse_markdown("<!-- {\"key\":\"arch-1\"} -->\n# Architecture\n\n---\n# Derived Title").unwrap();
+    let slides = deck.parsed_slides();
+
+    assert_eq!(slides[0].key.as_str(), "arch-1");
+    assert_eq!(slides[0].key_source, KeySource::Explicit { line: 1 });
+    assert_eq!(slides[1].key.as_str(), "derived-title");
+    assert_eq!(slides[1].key_source, KeySource::Derived { line: Some(5) });
+}
+
+#[test]
+fn derives_slide_number_key_when_slide_has_no_heading() {
+    let deck = parse_markdown("Body only\n\n---\nSecond body").unwrap();
+
+    assert_eq!(deck.parsed_slides()[0].key.as_str(), "slide-1");
+    assert_eq!(deck.parsed_slides()[0].key_source, KeySource::Derived { line: None });
+    assert_eq!(deck.parsed_slides()[1].key.as_str(), "slide-2");
+    assert_eq!(deck.parsed_slides()[1].key_source, KeySource::Derived { line: None });
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/phase.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeySource {
+    Explicit { line: usize },
+    Derived { line: Option<usize> },
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedSlide {
+    pub index: usize,
+    pub key: SlideKey,
+    pub key_source: KeySource,
+    pub fragments: Vec<SourceFragment>,
+}
+```
+
+```rust
+// crates/peitho-core/src/parser.rs
+fn derived_key_source(fragments: &[SourceFragment]) -> KeySource {
+    let line = fragments
+        .iter()
+        .find(|fragment| matches!(fragment.kind(), FragmentKind::Heading { .. }))
+        .map(SourceFragment::line);
+    KeySource::Derived { line }
+}
+
+fn derive_key_from_fragments(fragments: &[SourceFragment], index: usize) -> SlideKey {
+    let raw = fragments
+        .iter()
+        .find_map(SourceFragment::heading_text)
+        .unwrap_or_else(|| format!("slide-{}", index + 1));
+    let slug = raw
+        .chars()
+        .flat_map(char::to_lowercase)
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    SlideKey::new(if slug.is_empty() { format!("slide-{}", index + 1) } else { slug })
+        .expect("derived slide keys use lowercase ascii, digits, or '-'")
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core parser::tests::parsed_slide_records_explicit_and_derived_key_sources
+cargo test -p peitho-core parser::tests::derives_slide_number_key_when_slide_has_no_heading
+```
+
+### Task 3 - Split Markdown on Top-Level Thematic Breaks
+
+Goal: support `---` as a slide delimiter while keeping other unsupported constructs as errors.
+
+Files:
+
+- `crates/peitho-core/src/parser.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/parser.rs
+#[test]
+fn splits_slides_on_thematic_break() {
+    let deck = parse_markdown("# One\n\n---\n\n# Two\n\nBody").unwrap();
+    let slides = deck.parsed_slides();
+
+    assert_eq!(slides.len(), 2);
+    assert_eq!(slides[0].index, 0);
+    assert_eq!(slides[0].key.as_str(), "one");
+    assert_eq!(slides[1].index, 1);
+    assert_eq!(slides[1].key.as_str(), "two");
+    assert_eq!(slides[1].fragments[0].line(), 5);
+}
+
+#[test]
+fn rejects_empty_deck_after_splitting_delimiters() {
+    let err = parse_markdown("  \n\n---\n\n---\n").unwrap_err();
+
+    assert_eq!(err.kind, ErrorKind::Parse);
+    assert_eq!(err.line, None);
+    assert!(err.to_string().contains("deck has no slides"));
+    assert_eq!(err.help, "add at least one slide with content before building");
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/parser.rs
+#[derive(Debug, Clone, Copy)]
+struct SlideRange {
+    start: usize,
+    end: usize,
+}
+
+fn split_slide_ranges(source: &str) -> Result<Vec<SlideRange>> {
+    let mut ranges = Vec::new();
+    let mut start = 0usize;
+    let mut list_depth = 0usize;
+
+    for (event, range) in Parser::new_ext(source, parser_options()).into_offset_iter() {
+        match event {
+            Event::Start(Tag::List(_)) => list_depth += 1,
+            Event::End(TagEnd::List(_)) => list_depth = list_depth.saturating_sub(1),
+            Event::Rule if list_depth == 0 => {
+                ranges.push(SlideRange { start, end: range.start });
+                start = range.end;
+            }
+            Event::Rule => {}
+            _ => {}
+        }
+    }
+
+    ranges.push(SlideRange { start, end: source.len() });
+    Ok(ranges
+        .into_iter()
+        .filter(|range| !source[range.start..range.end].trim().is_empty())
+        .collect())
+}
+
+pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
+    let ranges = split_slide_ranges(source)?;
+    if ranges.is_empty() {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            None,
+            "deck has no slides",
+            "add at least one slide with content before building",
+        ));
+    }
+
+    let mut slides = Vec::new();
+    for (index, range) in ranges.into_iter().enumerate() {
+        slides.push(parse_slide(source, range, index)?);
+    }
+    Ok(Deck::parsed(slides))
+}
+
+fn parser_options() -> Options {
+    Options::ENABLE_TABLES | Options::ENABLE_FOOTNOTES
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core parser::tests::splits_slides_on_thematic_break
+cargo test -p peitho-core parser::tests::rejects_empty_deck_after_splitting_delimiters
+```
+
+### Task 4 - Parse Each Slide with Global Line Numbers
+
+Goal: reuse the current pulldown parser per slide range, but keep all error and fragment line numbers relative to the full source. The accepted diff is only global offset correction, leading key ownership, and `Rule` rejection; the M1 event validation structure remains intact with `Html` checked before `_ if list_depth > 0`, `unsupported_tag` preserved, `text outside block` preserved, heading text trimmed, and the final `other => Err(...)` arm preserved.
+
+Files:
+
+- `crates/peitho-core/src/parser.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/parser.rs
+#[test]
+fn unsupported_construct_after_delimiter_reports_global_line_and_slide() {
+    let err = parse_markdown("# One\n\n---\n\n# Two\n\n> quote").unwrap_err();
+
+    assert_eq!(err.kind, ErrorKind::Parse);
+    assert_eq!(err.line, Some(7));
+    assert!(err.to_string().contains("slide 2 ('two'), line 7"));
+    assert!(err.to_string().contains("unsupported construct 'blockquote'"));
+}
+
+#[test]
+fn unsupported_image_after_delimiter_is_not_silently_dropped() {
+    let err = parse_markdown("# One\n\n---\n\n![alt](image.png)").unwrap_err();
+
+    assert_eq!(err.kind, ErrorKind::Parse);
+    assert_eq!(err.line, Some(5));
+    assert!(err.to_string().contains("slide 2 ('slide-2'), line 5"));
+    assert!(err.to_string().contains("unsupported construct 'image'"));
+}
+
+#[test]
+fn unsupported_table_after_delimiter_is_not_silently_dropped() {
+    let err = parse_markdown("# One\n\n---\n\n| a |\n| - |").unwrap_err();
+
+    assert_eq!(err.kind, ErrorKind::Parse);
+    assert_eq!(err.line, Some(5));
+    assert!(err.to_string().contains("slide 2 ('slide-2'), line 5"));
+    assert!(err.to_string().contains("unsupported construct 'table'"));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/parser.rs
+fn parse_slide(source: &str, range: SlideRange, index: usize) -> Result<ParsedSlide> {
+    let slice = &source[range.start..range.end];
+    let mut explicit_key: Option<(SlideKey, usize)> = None;
+    let mut fragments = Vec::new();
+    let mut block: Option<OpenBlock> = None;
+    let mut list_depth = 0usize;
+    let mut list_start = None;
+    let mut seen_content = false;
+
+    for (event, local_range) in Parser::new_ext(slice, parser_options()).into_offset_iter() {
+        let global_start = range.start + local_range.start;
+        let global_end = range.start + local_range.end;
+        let line = line_for_offset(source, global_start);
+        match event {
+            Event::Rule => {
+                let err = unsupported_construct(line, "thematic break inside slide");
+                return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+            }
+            Event::Start(Tag::List(_)) => {
+                if list_depth == 0 {
+                    list_start = Some(global_start);
+                }
+                list_depth += 1;
+            }
+            Event::End(TagEnd::List(_)) => {
+                if list_depth == 0 {
+                    let err = unsupported_construct(line, "list end without list start");
+                    return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+                }
+                list_depth -= 1;
+                if list_depth == 0 {
+                    let Some(start) = list_start.take() else {
+                        let err = unsupported_construct(line, "list end without list start");
+                        return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+                    };
+                    fragments.push(SourceFragment::list(
+                        line_for_offset(source, start),
+                        source_slice(source, start, global_end),
+                    ));
+                    seen_content = true;
+                }
+            }
+            Event::Html(html) | Event::InlineHtml(html) => {
+                let key = parse_key_comment(html.as_ref(), line)
+                    .map_err(|err| attach_slide_context(err, index, explicit_key.as_ref(), &fragments))?;
+                if let Some(key) = key {
+                    if list_depth > 0 || seen_content {
+                        let err = BuildError::new(
+                            ErrorKind::Parse,
+                            Some(line),
+                            "slide key comment must appear before slide content",
+                            "move the key comment to the first non-blank line of the slide",
+                        );
+                        return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+                    }
+                    explicit_key = Some((key, line));
+                } else if !is_html_comment(html.as_ref()) && !html.trim().is_empty() {
+                    let err = unsupported_construct(line, "html");
+                    return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+                }
+            }
+            _ if list_depth > 0 => {}
+            Event::Start(Tag::Heading { level, .. }) => {
+                block = Some(OpenBlock::Heading {
+                    level: heading_level_to_u8(level),
+                    start: global_start,
+                    text: String::new(),
+                });
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if matches!(block, Some(OpenBlock::Heading { .. })) {
+                    let Some(OpenBlock::Heading { level, start, text }) = block.take() else {
+                        unreachable!();
+                    };
+                    fragments.push(SourceFragment::heading(
+                        line_for_offset(source, start),
+                        level,
+                        source_slice(source, start, global_end),
+                        text.trim(),
+                    ));
+                    seen_content = true;
+                }
+            }
+            Event::Start(Tag::Paragraph) => {
+                block = Some(OpenBlock::Paragraph { start: global_start });
+            }
+            Event::End(TagEnd::Paragraph) => {
+                if matches!(block, Some(OpenBlock::Paragraph { .. })) {
+                    let Some(OpenBlock::Paragraph { start }) = block.take() else {
+                        unreachable!();
+                    };
+                    fragments.push(SourceFragment::paragraph(
+                        line_for_offset(source, start),
+                        source_slice(source, start, global_end),
+                    ));
+                    seen_content = true;
+                }
+            }
+            Event::Start(Tag::CodeBlock(kind)) => {
+                let language = match kind {
+                    CodeBlockKind::Fenced(language) if !language.is_empty() => Some(language.to_string()),
+                    _ => None,
+                };
+                block = Some(OpenBlock::Code {
+                    start: global_start,
+                    language,
+                    text: String::new(),
+                });
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                if matches!(block, Some(OpenBlock::Code { .. })) {
+                    let Some(OpenBlock::Code { start, language, text }) = block.take() else {
+                        unreachable!();
+                    };
+                    fragments.push(SourceFragment::code(
+                        line_for_offset(source, start),
+                        language,
+                        text,
+                    ));
+                    seen_content = true;
+                }
+            }
+            Event::Text(text) | Event::Code(text) => match block.as_mut() {
+                Some(OpenBlock::Heading { text: heading_text, .. }) => heading_text.push_str(text.as_ref()),
+                Some(OpenBlock::Code { text: code_text, .. }) => code_text.push_str(text.as_ref()),
+                Some(OpenBlock::Paragraph { .. }) => {}
+                None if text.trim().is_empty() => {}
+                None => {
+                    let err = unsupported_construct(line, "text outside block");
+                    return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+                }
+            },
+            Event::SoftBreak | Event::HardBreak => {
+                if let Some(OpenBlock::Code { text, .. }) = block.as_mut() {
+                    text.push('\n');
+                }
+            }
+            Event::Start(Tag::HtmlBlock) | Event::End(TagEnd::HtmlBlock) => {}
+            Event::Start(tag) if unsupported_tag(&tag) => {
+                let err = unsupported_construct(line, unsupported_tag_name(&tag));
+                return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+            }
+            Event::Start(Tag::Item)
+            | Event::End(TagEnd::Item)
+            | Event::Start(Tag::Emphasis)
+            | Event::End(TagEnd::Emphasis)
+            | Event::Start(Tag::Strong)
+            | Event::End(TagEnd::Strong)
+            | Event::Start(Tag::Link { .. })
+            | Event::End(TagEnd::Link) => {}
+            other => {
+                let err = unsupported_construct(line, event_name(&other));
+                return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+            }
+        }
+    }
+
+    let (key, key_source) = explicit_key
+        .map(|(key, line)| (key, KeySource::Explicit { line }))
+        .unwrap_or_else(|| {
+            let key = derive_key_from_fragments(&fragments, index);
+            let key_source = derived_key_source(&fragments);
+            (key, key_source)
+        });
+
+    Ok(ParsedSlide { index, key, key_source, fragments })
+}
+
+fn attach_slide_context(
+    err: BuildError,
+    index: usize,
+    explicit_key: Option<&(SlideKey, usize)>,
+    fragments: &[SourceFragment],
+) -> BuildError {
+    let key = explicit_key
+        .map(|(key, _line)| key.clone())
+        .unwrap_or_else(|| derive_key_from_fragments(fragments, index));
+    err.with_slide(index + 1, Some(key.as_str()))
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core parser::tests::unsupported_construct_after_delimiter_reports_global_line_and_slide
+cargo test -p peitho-core parser::tests::unsupported_image_after_delimiter_is_not_silently_dropped
+cargo test -p peitho-core parser::tests::unsupported_table_after_delimiter_is_not_silently_dropped
+```
+
+### Task 5 - Attach Key Comments to the Following Slide
+
+Goal: each slide's leading key comment owns that slide key, including the common `---` then key comment pattern.
+
+Files:
+
+- `crates/peitho-core/src/parser.rs`
+- `examples/deck.md`
+
+Test:
+
+```rust
+// crates/peitho-core/src/parser.rs
+#[test]
+fn key_comment_after_delimiter_belongs_to_next_slide() {
+    let markdown = "# Intro\n\n---\n<!-- {\"key\":\"arch-1\"} -->\n# Architecture";
+    let deck = parse_markdown(markdown).unwrap();
+
+    assert_eq!(deck.parsed_slides()[0].key.as_str(), "intro");
+    assert_eq!(deck.parsed_slides()[1].key.as_str(), "arch-1");
+    assert_eq!(deck.parsed_slides()[1].key_source, KeySource::Explicit { line: 4 });
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/parser.rs
+Event::Html(html) | Event::InlineHtml(html) => {
+    let key = parse_key_comment(html.as_ref(), line)
+        .map_err(|err| attach_slide_context(err, index, explicit_key.as_ref(), &fragments))?;
+    if let Some(key) = key {
+        if list_depth > 0 || seen_content {
+            let err = BuildError::new(
+                ErrorKind::Parse,
+                Some(line),
+                "slide key comment must appear before slide content",
+                "move the key comment to the first non-blank line of the slide",
+            );
+            return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+        }
+        explicit_key = Some((key, line));
+    } else if !is_html_comment(html.as_ref()) && !html.trim().is_empty() {
+        let err = unsupported_construct(line, "html");
+        return Err(attach_slide_context(err, index, explicit_key.as_ref(), &fragments));
+    }
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core parser::tests::key_comment_after_delimiter_belongs_to_next_slide
+```
+
+### Task 6 - Reject Duplicate Slide Keys
+
+Goal: duplicate keys across all slides are build errors whether explicit or derived.
+
+Files:
+
+- `crates/peitho-core/src/parser.rs`
+- `crates/peitho-core/src/error.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/parser.rs
+#[test]
+fn rejects_duplicate_explicit_slide_keys() {
+    let err = parse_markdown("<!-- {\"key\":\"same\"} -->\n# One\n\n---\n<!-- {\"key\":\"same\"} -->\n# Two").unwrap_err();
+
+    assert_eq!(err.kind, ErrorKind::Parse);
+    assert_eq!(err.line, Some(5));
+    assert!(err.to_string().contains("slide 2 ('same'), line 5"));
+    assert!(err.to_string().contains("duplicate slide key 'same'"));
+    assert_eq!(err.help, "choose a unique explicit slide key");
+}
+
+#[test]
+fn rejects_derived_slide_key_collision_with_explicit_key() {
+    let err = parse_markdown("<!-- {\"key\":\"intro\"} -->\n# One\n\n---\n# Intro").unwrap_err();
+
+    assert_eq!(err.line, Some(5));
+    assert!(err.to_string().contains("duplicate slide key 'intro'"));
+    assert_eq!(err.help, "add an explicit unique key comment before this slide");
+}
+
+#[test]
+fn rejects_derived_slide_key_collision_with_derived_key() {
+    let err = parse_markdown("# Intro\n\n---\n# Intro").unwrap_err();
+
+    assert_eq!(err.line, Some(4));
+    assert!(err.to_string().contains("duplicate slide key 'intro'"));
+    assert_eq!(err.help, "add an explicit unique key comment before this slide");
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/parser.rs
+fn validate_unique_keys(slides: &[ParsedSlide]) -> Result<()> {
+    let mut seen = BTreeMap::<String, usize>::new();
+    for slide in slides {
+        let key = slide.key.as_str().to_owned();
+        if seen.insert(key.clone(), slide.index).is_some() {
+            let line = match slide.key_source {
+                KeySource::Explicit { line } => Some(line),
+                KeySource::Derived { line } => line,
+            };
+            let help = match slide.key_source {
+                KeySource::Explicit { .. } => "choose a unique explicit slide key",
+                KeySource::Derived { .. } => "add an explicit unique key comment before this slide",
+            };
+            return Err(BuildError::new(
+                ErrorKind::Parse,
+                line,
+                format!("duplicate slide key '{key}'"),
+                help,
+            )
+            .with_slide(slide.index + 1, Some(slide.key.as_str())));
+        }
+    }
+    Ok(())
+}
+
+pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
+    let ranges = split_slide_ranges(source)?;
+    if ranges.is_empty() {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            None,
+            "deck has no slides",
+            "add at least one slide with content before building",
+        ));
+    }
+
+    let mut slides = Vec::new();
+    for (index, range) in ranges.into_iter().enumerate() {
+        slides.push(parse_slide(source, range, index)?);
+    }
+    validate_unique_keys(&slides)?;
+    Ok(Deck::parsed(slides))
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core parser::tests::rejects_duplicate_explicit_slide_keys
+cargo test -p peitho-core parser::tests::rejects_derived_slide_key_collision_with_explicit_key
+cargo test -p peitho-core parser::tests::rejects_derived_slide_key_collision_with_derived_key
+```
+
+### Task 7 - Confirm Mapping Handles Multiple Slides
+
+Goal: convention mapping should map each parsed slide independently without introducing shared state.
+
+Files:
+
+- `crates/peitho-core/src/mapping.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/mapping.rs
+#[test]
+fn maps_each_slide_independently() {
+    let markdown = "# Intro\n\nBody\n\n---\n# Architecture\n\n```rust\nfn main() {}\n```";
+    let template = parse_template(
+        "title-body-code",
+        r#"<section>
+           <slot name="title" accepts="inline" arity="1"></slot>
+           <slot name="body" accepts="blocks" arity="0..*"></slot>
+           <slot name="code" accepts="code" arity="0..1"></slot>
+           </section>"#,
+    )
+    .unwrap();
+
+    let mapped = map_by_convention(parse_markdown(markdown).unwrap(), &template).unwrap();
+
+    assert_eq!(mapped.mapped_slides().len(), 2);
+    assert_eq!(mapped.mapped_slides()[0].slots[&SlotName::new("body").unwrap()].fragments().len(), 1);
+    assert_eq!(mapped.mapped_slides()[1].slots[&SlotName::new("code").unwrap()].fragments().len(), 1);
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/mapping.rs
+pub fn map_by_convention(deck: Deck<Parsed>, template: &Template) -> Result<Deck<Mapped>> {
+    let mut slides = Vec::new();
+    for slide in deck.into_parsed_slides() {
+        let title_line = shallowest_heading_line(&slide.fragments);
+        let mut slots: BTreeMap<SlotName, MappedSlot> = BTreeMap::new();
+        let mut unassigned = Vec::new();
+
+        for fragment in slide.fragments {
+            let target = match fragment.kind() {
+                FragmentKind::Heading { .. } if Some(fragment.line()) == title_line => "title",
+                FragmentKind::Code => "code",
+                FragmentKind::Heading { .. }
+                | FragmentKind::Paragraph
+                | FragmentKind::List
+                | FragmentKind::Image
+                | FragmentKind::Text => "body",
+            };
+            let slot = SlotName::new(target).expect("conventional slot names are valid");
+            if let Some(contract) = template.slot_by_name(&slot).cloned() {
+                slots
+                    .entry(slot.clone())
+                    .or_insert_with(|| MappedSlot::new(contract))
+                    .push(fragment);
+            } else {
+                unassigned.push(UnassignedFragment::new(slot, fragment));
+            }
+        }
+
+        slides.push(MappedSlide { index: slide.index, key: slide.key, slots, unassigned });
+    }
+    Ok(Deck::mapped(slides))
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core mapping::tests::maps_each_slide_independently
+```
+
+### Task 8 - Add Slide Context to Check Errors
+
+Goal: accepts, arity, and residual-content failures show the failing slide number and key.
+
+Files:
+
+- `crates/peitho-core/src/check.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/check.rs
+#[test]
+fn arity_error_in_second_slide_includes_slide_context() {
+    let markdown = "# Intro\n\n---\n<!-- {\"key\":\"code-slide\"} -->\n# Code\n\n```rust\nfn a() {}\n```\n\n```rust\nfn b() {}\n```";
+    let template = parse_template(
+        "title-body-code",
+        r#"<section>
+           <slot name="title" accepts="inline" arity="1"></slot>
+           <slot name="code" accepts="code" arity="0..1"></slot>
+           </section>"#,
+    )
+    .unwrap();
+    let mapped = map_by_convention(parse_markdown(markdown).unwrap(), &template).unwrap();
+
+    let err = check_deck(mapped, &template).unwrap_err();
+
+    assert_eq!(err.kind, ErrorKind::Arity);
+    assert!(err.to_string().contains("slide 2 ('code-slide'), line 7"));
+    assert!(err.to_string().contains("slot 'code' got 2 item(s)"));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/check.rs
+pub fn check_deck(deck: Deck<Mapped>, template: &Template) -> Result<Deck<Checked>> {
+    let mut slides = Vec::new();
+    for slide in deck.into_mapped_slides() {
+        let slide_number = slide.index + 1;
+        let slide_key = slide.key.as_str().to_owned();
+        check_slide(&slide, template)
+            .map_err(|err| err.with_slide(slide_number, Some(&slide_key)))?;
+        let checked_slots = slide
+            .slots
+            .into_iter()
+            .map(|(slot, mapped_slot)| (slot, mapped_slot.fragments().to_vec()))
+            .collect();
+        slides.push(CheckedSlide::new(slide.index, slide.key, checked_slots));
+    }
+    Ok(Deck::checked(slides))
+}
+
+fn check_slide(slide: &MappedSlide, template: &Template) -> Result<()> {
+    check_accepts(&slide.slots)?;
+    check_arity(&slide.slots, template)?;
+    check_no_unassigned(&slide.unassigned)
+}
+
+fn check_accepts(slots: &BTreeMap<SlotName, MappedSlot>) -> Result<()> {
+    for (slot, mapped_slot) in slots {
+        let contract = mapped_slot.contract();
+        for fragment in mapped_slot.fragments() {
+            if !accepts_fragment(contract.accepts, fragment) {
+                return Err(BuildError::new(
+                    ErrorKind::Accepts,
+                    Some(fragment.line()),
+                    format!(
+                        "slot '{}' accepts {}, but got {}",
+                        slot.as_str(),
+                        contract.accepts,
+                        fragment.kind()
+                    ),
+                    format!(
+                        "change the template accepts to '{}' or move this content to a {} slot",
+                        fragment.kind().default_accepts(),
+                        fragment.kind().default_accepts()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core check::tests::arity_error_in_second_slide_includes_slide_context
+```
+
+### Task 9 - Add Manifest Types as Core Contract
+
+Goal: define §17 `manifest.json` schema in `peitho-core` with serde serialization.
+
+Files:
+
+- `crates/peitho-core/src/manifest.rs`
+- `crates/peitho-core/src/lib.rs`
+- `crates/peitho-core/Cargo.toml`
+- `crates/peitho-core/src/domain.rs`
+- `crates/peitho-core/src/error.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/manifest.rs
+#[test]
+fn serializes_manifest_schema_exactly() {
+    let manifest = Manifest::new(
+        "Peitho Architecture",
+        vec![
+            ManifestSlide::new(0, SlideKey::new("arch-1").unwrap(), "slides/000-arch-1.html", false),
+            ManifestSlide::new(1, SlideKey::new("details").unwrap(), "slides/001-details.html", false),
+        ],
+    );
+
+    let json = manifest_json(&manifest).unwrap();
+
+    assert_eq!(
+        json,
+        concat!(
+            "{\n",
+            "  \"version\": 1,\n",
+            "  \"peithoVersion\": \"0.1.0\",\n",
+            "  \"title\": \"Peitho Architecture\",\n",
+            "  \"slideCount\": 2,\n",
+            "  \"slides\": [\n",
+            "    {\n",
+            "      \"index\": 0,\n",
+            "      \"key\": \"arch-1\",\n",
+            "      \"src\": \"slides/000-arch-1.html\",\n",
+            "      \"hasNotes\": false\n",
+            "    },\n",
+            "    {\n",
+            "      \"index\": 1,\n",
+            "      \"key\": \"details\",\n",
+            "      \"src\": \"slides/001-details.html\",\n",
+            "      \"hasNotes\": false\n",
+            "    }\n",
+            "  ]\n",
+            "}\n"
+        )
+    );
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/manifest.rs
+use serde::Serialize;
+
+use crate::{
+    domain::SlideKey,
+    error::{BuildError, ErrorKind, Result},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Manifest {
+    version: u8,
+    #[serde(rename = "peithoVersion")]
+    peitho_version: String,
+    title: String,
+    #[serde(rename = "slideCount")]
+    slide_count: usize,
+    slides: Vec<ManifestSlide>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ManifestSlide {
+    index: usize,
+    key: SlideKey,
+    src: String,
+    #[serde(rename = "hasNotes")]
+    has_notes: bool,
+}
+
+impl ManifestSlide {
+    pub fn new(index: usize, key: SlideKey, src: impl Into<String>, has_notes: bool) -> Self {
+        Self {
+            index,
+            key,
+            src: src.into(),
+            has_notes,
+        }
+    }
+}
+
+impl Manifest {
+    pub fn new(title: impl Into<String>, slides: Vec<ManifestSlide>) -> Self {
+        let slide_count = slides.len();
+        Self {
+            version: 1,
+            peitho_version: env!("CARGO_PKG_VERSION").to_owned(),
+            title: title.into(),
+            slide_count,
+            slides,
+        }
+    }
+}
+
+pub fn manifest_json(manifest: &Manifest) -> Result<String> {
+    let mut json = serde_json::to_string_pretty(manifest).map_err(|err| {
+        BuildError::new(ErrorKind::Manifest, None, format!("failed to serialize manifest: {err}"), "keep manifest fields serializable")
+    })?;
+    json.push('\n');
+    Ok(json)
+}
+```
+
+```rust
+// crates/peitho-core/src/domain.rs
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub struct SlideKey(String);
+```
+
+```rust
+// crates/peitho-core/src/error.rs
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorKind {
+    Parse,
+    Template,
+    Accepts,
+    Arity,
+    ResidualContent,
+    Theme,
+    Manifest,
+}
+```
+
+```rust
+// crates/peitho-core/src/lib.rs
+pub mod manifest;
+pub use manifest::{manifest_json, Manifest, ManifestSlide};
+pub use phase::{require_checked_for_render, Deck, Mapped, Rendered};
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core manifest::tests::serializes_manifest_schema_exactly
+```
+
+### Task 10 - Build Manifest from Checked Deck
+
+Goal: derive manifest title, slide count, fragment `src`, and `hasNotes=false` from `Deck<Checked>`.
+
+Files:
+
+- `crates/peitho-core/src/phase.rs`
+- `crates/peitho-core/src/manifest.rs`
+- `crates/peitho-core/src/domain.rs`
+- `crates/peitho-core/src/lib.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/manifest.rs
+#[test]
+fn builds_manifest_from_checked_deck() {
+    let checked = checked_deck(
+        "<!-- {\"key\":\"arch-1\"} -->\n# Peitho Architecture\n\n---\n# Details",
+        title_body_template(),
+    );
+
+    let manifest = build_manifest(&checked);
+    let json = manifest_json(&manifest).unwrap();
+
+    assert!(json.contains(r#""title": "Peitho Architecture""#));
+    assert!(json.contains(r#""slideCount": 2"#));
+    assert!(json.contains(r#""src": "slides/000-arch-1.html""#));
+    assert!(json.contains(r#""src": "slides/001-details.html""#));
+    assert!(json.contains(r#""hasNotes": false"#));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/domain.rs
+impl SourceFragment {
+    pub(crate) fn heading_text_ref(&self) -> Option<&str> {
+        matches!(self.kind, FragmentKind::Heading { .. }).then_some(self.plain_text())
+    }
+}
+```
+
+```rust
+// crates/peitho-core/src/phase.rs
+impl CheckedSlide {
+    pub(crate) fn title_text(&self) -> Option<&str> {
+        let title = SlotName::new("title").ok()?;
+        self.slots
+            .get(&title)?
+            .iter()
+            .find_map(|fragment| fragment.heading_text_ref())
+    }
+}
+
+impl Deck<Checked> {
+    pub(crate) fn checked_slides(&self) -> &[CheckedSlide] {
+        &self.phase.slides
+    }
+}
+```
+
+```rust
+// crates/peitho-core/src/manifest.rs
+pub fn build_manifest(deck: &Deck<Checked>) -> Manifest {
+    let title = deck
+        .checked_slides()
+        .first()
+        .and_then(CheckedSlide::title_text)
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or("Untitled");
+
+    let slides = deck
+        .checked_slides()
+        .iter()
+        .map(|slide| ManifestSlide::new(
+            slide.index(),
+            slide.key().clone(),
+            fragment_src(slide.index(), slide.key()),
+            false,
+        ))
+        .collect();
+
+    Manifest::new(title, slides)
+}
+
+pub fn fragment_src(index: usize, key: &SlideKey) -> String {
+    format!("slides/{index:03}-{}.html", key.as_str())
+}
+```
+
+```rust
+// crates/peitho-core/src/lib.rs
+pub use manifest::{build_manifest, fragment_src, manifest_json, Manifest, ManifestSlide};
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core manifest::tests::builds_manifest_from_checked_deck
+```
+
+### Task 11 - Render Fragment Source Metadata
+
+Goal: expose deterministic per-slide fragment paths while keeping rendered slide fields private.
+
+Files:
+
+- `crates/peitho-core/src/domain.rs`
+- `crates/peitho-core/src/render.rs`
+- `crates/peitho-core/src/manifest.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/render.rs
+#[test]
+fn rendered_slides_have_manifest_fragment_sources() {
+    let rendered = render_checked_deck("# Intro\n\n---\n# Details");
+
+    assert_eq!(rendered.slides()[0].src(), "slides/000-intro.html");
+    assert_eq!(rendered.slides()[1].src(), "slides/001-details.html");
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/domain.rs
+impl RenderedSlide {
+    pub fn src(&self) -> String {
+        crate::manifest::fragment_src(self.index, &self.key)
+    }
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core render::tests::rendered_slides_have_manifest_fragment_sources
+```
+
+### Task 12 - Generate Distribution index.html
+
+Goal: replace embedded-slide `index.html` with a distribution entry that fetches `manifest.json` and each slide fragment.
+
+Files:
+
+- `crates/peitho-core/src/render.rs`
+- `crates/peitho-core/src/lib.rs`
+
+Test:
+
+```rust
+// crates/peitho-core/src/render.rs
+#[test]
+fn distribution_index_fetches_manifest_and_slide_sources_without_embedding_slides() {
+    let html = render_distribution_index();
+
+    assert!(html.contains(r#"<link rel="stylesheet" href="peitho.css">"#));
+    assert!(html.contains("fetch('manifest.json')"));
+    assert!(html.contains("fetch(slide.src)"));
+    assert!(html.contains(r#"id="peitho-slides""#));
+    assert!(!html.contains("data-slide-key="));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho-core/src/render.rs
+pub fn render_distribution_index() -> String {
+    r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="peitho.css">
+  <title>Peitho Deck</title>
+</head>
+<body>
+  <main id="peitho-slides"></main>
+  <script>
+    async function loadDeck() {
+      const manifest = await fetch('manifest.json').then((response) => response.json());
+      document.title = manifest.title || 'Peitho Deck';
+      const root = document.getElementById('peitho-slides');
+      for (const slide of manifest.slides) {
+        const html = await fetch(slide.src).then((response) => response.text());
+        const holder = document.createElement('div');
+        holder.innerHTML = html;
+        while (holder.firstChild) root.appendChild(holder.firstChild);
+      }
+    }
+    loadDeck();
+  </script>
+</body>
+</html>"#.to_owned()
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho-core render::tests::distribution_index_fetches_manifest_and_slide_sources_without_embedding_slides
+```
+
+### Task 13 - Write slides/ Fragments from the CLI
+
+Goal: `peitho build` writes one fragment file per rendered slide under `dist/slides/`.
+
+Files:
+
+- `crates/peitho/src/main.rs`
+- `crates/peitho/tests/build.rs`
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn build_writes_slide_fragments_in_slides_directory() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let out = dir.path().join("dist");
+    write_multi_slide_fixture(&deck);
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(dir.path(), r#"[data-slide-key="arch-1"] .slot-code { outline: 3px solid #f40; }"#);
+
+    Command::cargo_bin("peitho").unwrap()
+        .args(["build", deck.to_str().unwrap(), "--template", template.to_str().unwrap(), "--base-css", base.to_str().unwrap(), "--overrides-css", overrides.to_str().unwrap(), "--out", out.to_str().unwrap()])
+        .assert()
+        .success();
+
+    assert!(out.join("slides/000-arch-1.html").exists());
+    assert!(out.join("slides/001-convention-mapping.html").exists());
+    assert!(out.join("slides/002-dist-1.html").exists());
+    assert!(fs::read_to_string(out.join("slides/000-arch-1.html")).unwrap().contains(r#"data-slide-key="arch-1""#));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/main.rs
+fn write_slide_fragments(out: &Path, rendered: &peitho_core::Deck<peitho_core::Rendered>) -> miette::Result<()> {
+    let slides_dir = out.join("slides");
+    fs::create_dir_all(&slides_dir).into_diagnostic()?;
+    for slide in rendered.slides() {
+        fs::write(out.join(slide.src()), slide.html()).into_diagnostic()?;
+    }
+    Ok(())
+}
+```
+
+```rust
+// crates/peitho/tests/build.rs
+use tempfile::{tempdir, TempDir};
+
+fn write_multi_slide_fixture(path: &Path) {
+    fs::write(
+        path,
+        r#"<!-- {"key":"arch-1"} -->
+# Peitho Architecture
+
+Body
+
+```rust
+fn main() {}
+```
+
+---
+
+# Convention Mapping
+
+- title
+- body
+
+---
+<!-- {"key":"dist-1"} -->
+# Distribution
+
+Fragments and manifest.
+"#,
+    )
+    .unwrap();
+}
+
+fn write_template(dir: &Path) -> PathBuf {
+    let path = dir.join("title-body-code.html");
+    fs::write(
+        &path,
+        r#"<section><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot></section>"#,
+    )
+    .unwrap();
+    path
+}
+
+fn write_base_css(dir: &Path) -> PathBuf {
+    let path = dir.join("base.css");
+    fs::write(&path, ".slot-title { font-weight: 700; }").unwrap();
+    path
+}
+
+fn write_overrides_css(dir: &Path, css: &str) -> PathBuf {
+    let path = dir.join("overrides.css");
+    fs::write(&path, css).unwrap();
+    path
+}
+
+fn build_multi_slide_fixture() -> (TempDir, PathBuf) {
+    build_multi_slide_fixture_with_override(
+        r#"[data-slide-key="arch-1"] .slot-code { outline: 3px solid #f40; }"#,
+    )
+}
+
+fn build_multi_slide_fixture_with_override(override_css: &str) -> (TempDir, PathBuf) {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    write_multi_slide_fixture(&deck);
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(dir.path(), override_css);
+    let out = dir.path().join("dist");
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+            "--base-css",
+            base.to_str().unwrap(),
+            "--overrides-css",
+            overrides.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    (dir, out)
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build build_writes_slide_fragments_in_slides_directory
+```
+
+### Task 14 - Write manifest.json from Core Manifest
+
+Goal: CLI writes `manifest.json` using `peitho-core` manifest serialization, not string concatenation.
+
+Files:
+
+- `crates/peitho/src/main.rs`
+- `crates/peitho/tests/build.rs`
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn build_writes_manifest_json_with_refs_not_html() {
+    let (_dir, out) = build_multi_slide_fixture();
+    let manifest = fs::read_to_string(out.join("manifest.json")).unwrap();
+
+    assert!(manifest.contains(r#""version": 1"#));
+    assert!(manifest.contains(r#""peithoVersion": "0.1.0""#));
+    assert!(manifest.contains(r#""title": "Peitho Architecture""#));
+    assert!(manifest.contains(r#""slideCount": 3"#));
+    assert!(manifest.contains(r#""src": "slides/000-arch-1.html""#));
+    assert!(manifest.contains(r#""hasNotes": false"#));
+    assert!(!manifest.contains("<section"));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/main.rs
+let checked = core(peitho_core::check_deck(mapped, &template))?;
+let manifest = peitho_core::build_manifest(&checked);
+let manifest_json = core(peitho_core::manifest_json(&manifest))?;
+let rendered = core(peitho_core::render_deck(checked, &template))?;
+
+fs::write(out.join("manifest.json"), manifest_json).into_diagnostic()?;
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build build_writes_manifest_json_with_refs_not_html
+```
+
+### Task 15 - Write Distribution index.html without Embedded Slides
+
+Goal: CLI writes an index that fetches manifest and fragments and does not duplicate slide bodies.
+
+Files:
+
+- `crates/peitho/src/main.rs`
+- `crates/peitho/tests/build.rs`
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn build_writes_fetching_index_without_embedded_slide_html() {
+    let (_dir, out) = build_multi_slide_fixture();
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+
+    assert!(index.contains("fetch('manifest.json')"));
+    assert!(index.contains("fetch(slide.src)"));
+    assert!(index.contains(r#"<main id="peitho-slides"></main>"#));
+    assert!(!index.contains("Peitho Architecture"));
+    assert!(!index.contains("data-slide-key=\"arch-1\""));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/main.rs
+fs::write(out.join("index.html"), peitho_core::render_distribution_index()).into_diagnostic()?;
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build build_writes_fetching_index_without_embedded_slide_html
+```
+
+### Task 16 - Validate Overrides Against All Slide Keys
+
+Goal: theme override validation uses every checked slide key from a multi-slide deck.
+
+Files:
+
+- `crates/peitho/src/main.rs`
+- `crates/peitho/tests/build.rs`
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn build_accepts_override_targeting_derived_second_slide_key() {
+    let (_dir, out) = build_multi_slide_fixture_with_override(
+        r#"[data-slide-key="convention-mapping"] .slot-body { color: red; }"#,
+    );
+
+    let css = fs::read_to_string(out.join("peitho.css")).unwrap();
+    assert!(css.contains(r#"[data-slide-key="convention-mapping"] .slot-body"#));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/main.rs
+let slide_keys = checked.slide_keys().collect::<Vec<_>>();
+let css = core(peitho_core::build_theme_css(
+    &base_css,
+    &overrides_css,
+    slide_keys.into_iter(),
+    &template,
+))?;
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build build_accepts_override_targeting_derived_second_slide_key
+```
+
+### Task 17 - Surface Duplicate Key Failures Through CLI
+
+Goal: CLI prints line/help for duplicate keys with slide context.
+
+Files:
+
+- `crates/peitho/tests/build.rs`
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn build_fails_on_duplicate_slide_keys_with_line_help_and_slide_context() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    fs::write(&deck, "# Intro\n\n---\n# Intro").unwrap();
+    let template = write_template(dir.path());
+    let base = write_base_css(dir.path());
+    let overrides = write_overrides_css(dir.path(), "");
+    let out = dir.path().join("dist");
+
+    Command::cargo_bin("peitho").unwrap()
+        .args(["build", deck.to_str().unwrap(), "--template", template.to_str().unwrap(), "--base-css", base.to_str().unwrap(), "--overrides-css", overrides.to_str().unwrap(), "--out", out.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("slide 2 ('intro'), line 4"))
+        .stderr(predicate::str::contains("duplicate slide key 'intro'"))
+        .stderr(predicate::str::contains("help: add an explicit unique key comment before this slide"));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/main.rs
+fn core<T>(result: peitho_core::Result<T>) -> miette::Result<T> {
+    result.map_err(|err| miette::miette!("{err}"))
+}
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build build_fails_on_duplicate_slide_keys_with_line_help_and_slide_context
+```
+
+### Task 18 - Update Example Deck to Three Slides
+
+Goal: repository example exercises explicit keys, derived keys, and a key comment immediately after a delimiter.
+
+Files:
+
+- `examples/deck.md`
+- `themes/overrides.css`
+- `crates/peitho/tests/build.rs`
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn repository_example_builds_three_slide_distribution() {
+    let out = tempdir().unwrap();
+
+    Command::cargo_bin("peitho").unwrap()
+        .current_dir(workspace_root())
+        .args(["build", "examples/deck.md", "--template", "templates/title-body-code.html", "--base-css", "themes/base.css", "--overrides-css", "themes/overrides.css", "--out", out.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("built 3 slide(s)"));
+
+    assert!(out.path().join("slides/000-arch-1.html").exists());
+    assert!(out.path().join("slides/001-convention-mapping.html").exists());
+    assert!(out.path().join("slides/002-dist-1.html").exists());
+    assert!(fs::read_to_string(out.path().join("manifest.json")).unwrap().contains(r#""slideCount": 3"#));
+}
+```
+
+Implementation:
+
+```markdown
+<!-- examples/deck.md -->
+<!-- {"key":"arch-1"} -->
+# Peitho Architecture
+
+Markdown is the source of truth, while HTML and CSS own layout.
+
+```rust
+enum Phase { Parsed, Mapped, Checked, Rendered }
+```
+
+---
+
+# Convention Mapping
+
+- Shallowest heading maps to title
+- Code blocks map to code
+- Remaining blocks map to body
+
+---
+<!-- {"key":"dist-1"} -->
+# Distribution
+
+The build output writes slide fragments plus a manifest.
+```
+
+```css
+/* themes/overrides.css */
+[data-slide-key="arch-1"] .slot-code { outline: 3px solid #f40; }
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build repository_example_builds_three_slide_distribution
+```
+
+### Task 19 - Remove Obsolete Embedded Index Expectations
+
+Goal: delete the old embedded-slide `render_index` API and update tests that expected `dist/index.html` to contain slide bodies.
+
+Files:
+
+- `crates/peitho/tests/build.rs`
+- `crates/peitho-core/src/render.rs`
+- `crates/peitho-core/src/lib.rs`
+- `crates/peitho/src/main.rs`
+
+Existing tests to update:
+
+- `crates/peitho/tests/build.rs::build_writes_index_html_and_css`: keep the CSS assertion, but assert slide HTML exists under `slides/000-arch-1.html` and is not embedded in `index.html`.
+- `crates/peitho/tests/build.rs::repository_example_builds`: replace with `repository_example_builds_three_slide_distribution` from Task 18.
+
+Test:
+
+```rust
+// crates/peitho/tests/build.rs
+#[test]
+fn build_keeps_slide_html_only_in_fragment_files() {
+    let (_dir, out) = build_multi_slide_fixture();
+    let index = fs::read_to_string(out.join("index.html")).unwrap();
+    let first = fs::read_to_string(out.join("slides/000-arch-1.html")).unwrap();
+
+    assert!(!index.contains("data-slide-key"));
+    assert!(first.contains(r#"data-slide-key="arch-1""#));
+}
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/main.rs
+fs::write(out.join("index.html"), peitho_core::render_distribution_index()).into_diagnostic()?;
+```
+
+```rust
+// crates/peitho-core/src/lib.rs
+pub use render::{render_deck, render_distribution_index};
+```
+
+```text
+Delete `pub fn render_index(slides: &[RenderedSlide]) -> String` from `crates/peitho-core/src/render.rs`.
+No caller may refer to `peitho_core::render_index`; `cargo clippy --workspace --all-targets -- -D warnings` verifies the old helper is gone instead of becoming dead code.
+```
+
+Verification:
+
+```bash
+cargo test -p peitho --test build build_keeps_slide_html_only_in_fragment_files
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+### Task 20 - Final Verification
+
+Goal: verify the milestone end-to-end contract and CI-facing commands.
+
+Files:
+
+- all files touched by Tasks 1-19
+
+Test:
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all --check
+cargo run -p peitho -- build examples/deck.md --template templates/title-body-code.html --base-css themes/base.css --overrides-css themes/overrides.css --out dist
+test -f dist/slides/000-arch-1.html
+test -f dist/slides/001-convention-mapping.html
+test -f dist/slides/002-dist-1.html
+rg -n '"slideCount": 3|"src": "slides/000-arch-1.html"|"hasNotes": false' dist/manifest.json
+rg -n "fetch\\('manifest.json'\\)|fetch\\(slide.src\\)" dist/index.html
+! rg -n 'data-slide-key="arch-1"' dist/index.html
+rg -n 'data-slide-key="arch-1"' dist/slides/000-arch-1.html
+rg -n '\[data-slide-key="arch-1"\] \.slot-code' dist/peitho.css
+```
+
+Implementation:
+
+```text
+This task only runs commands; it does not modify repository files.
+```
+
+Verification:
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all --check
+cargo run -p peitho -- build examples/deck.md --template templates/title-body-code.html --base-css themes/base.css --overrides-css themes/overrides.css --out dist
+```
+
+## Summary
+
+全20タスクで、まず error と parsed slide metadata を複数スライド向けに整え、`---` 区切り・slide key ownership・重複 key 検査を parser に入れる。次に mapping/check の multi-slide error context を固定し、`peitho-core` に manifest schema と JSON 生成、fragment path、fetch-only distribution index を追加する。最後に CLI を `slides/` 断片 + `manifest.json` + `index.html` emit に切り替え、3枚の example deck と integration tests で §14 の「実体は slides/ に一度だけ」を確認する。

--- a/examples/deck.md
+++ b/examples/deck.md
@@ -3,14 +3,20 @@
 
 Markdown is the source of truth, while HTML and CSS own layout.
 
-- Markdown content stays separate from design
-- Template slots are checked before render
-
 ```rust
-enum Phase {
-    Parsed,
-    Mapped,
-    Checked,
-    Rendered,
-}
+enum Phase { Parsed, Mapped, Checked, Rendered }
 ```
+
+---
+
+# Convention Mapping
+
+- Shallowest heading maps to title
+- Code blocks map to code
+- Remaining blocks map to body
+
+---
+<!-- {"key":"dist-1"} -->
+# Distribution
+
+The build output writes slide fragments plus a manifest.


### PR DESCRIPTION
## Summary

Along the kickoff spec's §13 · §14 · §17, build multiple slides from a single Markdown file and emit the distribution dist layout.

- **Multiple slides**: split by top-level `---` (thematic break) — the deck-style convention. Per-slide convention mapping + 4-stage check. M1's check structure (line-numbered errors on unsupported structures, anti-silent-drop) preserved
- **Multiple keys**: a key comment at the head of each slide is the explicit key; absent = derived (heading slug → slide-N). **Duplicate keys are a build error** ("change to a unique key" help for explicit, "add an explicit key" help for derived). Empty deck also errors
- **Slide-context in errors**: format is `slide 2 ('code-slide'), line 7: slot 'code' got 2 item(s)...` — you can see which slide failed
- **§14 dist layout**:
  - `dist/slides/NNN-key.html` — slide bodies live here once (rebuilds clear `slides/` to prevent stale fragments leaking through)
  - `dist/manifest.json` — §17 schema (version / peithoVersion / title / slideCount / slides[index,key,src,hasNotes]). Serialized via serde from peitho-core types; a stepping stone toward a single-source contract
  - `dist/index.html` — no embedded bodies. Minimal distribution entry that fetches manifest → fragments. Fetch failures are visualized on screen and the shell stops
- examples/deck.md becomes a 3-slide setup (explicit key, derived key, key comment immediately after `---`)

## Verification

- `cargo test --workspace`: 66 tests all pass (core 53 + CLI 12 + compile_fail doctest)
- clippy (-D warnings) · fmt: clean
- Real build: verified 3 fragments + slideCount 3 manifest + fetch-based index.html
- Error demos: duplicate key (`slide 2 ('intro'), line 4: duplicate slide key 'intro'`), arity violation on slide 2 (`slide 2 ('code-slide'), line 7: ...`)

## Notes

- Because index.html is fetch-based, browsing `dist/` requires HTTP (`file://` direct-open doesn't work. Verify via `python3 -m http.server`, etc.). Faithful to §14: "index.html just reads the manifest and displays slides/", "bodies live only in slides/"
- Plan review: 1 round (reverted a parser rewrite that reintroduced silent drops) + 5 rounds of post-implementation self-review with 3 fixes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
