### PR TITLE
Milestone 9: make fullscreen launch and multi-display placement actually work

### DIFF
--- a/crates/peitho/src/browser.rs
+++ b/crates/peitho/src/browser.rs
@@ -1,4 +1,8 @@
-use std::{ffi::OsString, path::Path, process::Command};
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BrowserPlatform {
@@ -12,6 +16,7 @@ pub struct BrowserEnvironment {
     pub platform: BrowserPlatform,
     pub mac_google_chrome_available: bool,
     pub linux_browser: Option<OsString>,
+    pub chrome_profile_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,37 +25,60 @@ pub struct BrowserCommand {
     pub args: Vec<OsString>,
 }
 
+fn chrome_args(url: &str, profile_dir: &Path) -> Vec<OsString> {
+    vec![
+        OsString::from(format!("--user-data-dir={}", profile_dir.display())),
+        OsString::from("--no-first-run"),
+        OsString::from("--no-default-browser-check"),
+        OsString::from(format!("--app={url}")),
+        OsString::from("--start-fullscreen"),
+    ]
+}
+
 pub fn plan_browser_command(url: &str, env: &BrowserEnvironment) -> Option<BrowserCommand> {
     match env.platform {
-        BrowserPlatform::Macos if env.mac_google_chrome_available => Some(BrowserCommand {
-            program: OsString::from("open"),
-            args: vec![
+        BrowserPlatform::Macos
+            if env.mac_google_chrome_available && env.chrome_profile_dir.is_some() =>
+        {
+            let profile_dir = env
+                .chrome_profile_dir
+                .as_deref()
+                .expect("guarded by is_some");
+            let mut args = vec![
                 OsString::from("-na"),
                 OsString::from("Google Chrome"),
                 OsString::from("--args"),
-                OsString::from(format!("--app={url}")),
-                OsString::from("--start-fullscreen"),
-            ],
-        }),
+            ];
+            args.extend(chrome_args(url, profile_dir));
+            Some(BrowserCommand {
+                program: OsString::from("open"),
+                args,
+            })
+        }
         BrowserPlatform::Macos => Some(BrowserCommand {
             program: OsString::from("open"),
             args: vec![OsString::from(url)],
         }),
-        BrowserPlatform::Linux => linux_browser_command(url, env.linux_browser.as_deref()),
+        BrowserPlatform::Linux => linux_browser_command(
+            url,
+            env.linux_browser.as_deref(),
+            env.chrome_profile_dir.as_deref(),
+        ),
         BrowserPlatform::Other => None,
     }
 }
 
-fn linux_browser_command(url: &str, browser: Option<&std::ffi::OsStr>) -> Option<BrowserCommand> {
-    match browser {
-        Some(program) => Some(BrowserCommand {
+fn linux_browser_command(
+    url: &str,
+    browser: Option<&OsStr>,
+    profile_dir: Option<&Path>,
+) -> Option<BrowserCommand> {
+    match (browser, profile_dir) {
+        (Some(program), Some(profile_dir)) => Some(BrowserCommand {
             program: program.to_owned(),
-            args: vec![
-                OsString::from(format!("--app={url}")),
-                OsString::from("--start-fullscreen"),
-            ],
+            args: chrome_args(url, profile_dir),
         }),
-        None => Some(BrowserCommand {
+        _ => Some(BrowserCommand {
             program: OsString::from("xdg-open"),
             args: vec![OsString::from(url)],
         }),
@@ -83,16 +111,42 @@ fn find_in_path(program: &str) -> Option<OsString> {
     })
 }
 
+fn chrome_profile_dir_from_home(home: Option<OsString>) -> Option<PathBuf> {
+    home.map(PathBuf::from)
+        .map(|home| home.join(".peitho").join("chrome-profile"))
+}
+
 fn current_environment() -> BrowserEnvironment {
     BrowserEnvironment {
         platform: current_platform(),
         mac_google_chrome_available: chrome_app_exists(),
         linux_browser: find_linux_browser(),
+        chrome_profile_dir: chrome_profile_dir_from_home(std::env::var_os("HOME")),
+    }
+}
+
+fn prepare_profile_dir(profile_dir: Option<&Path>) -> bool {
+    let Some(profile_dir) = profile_dir else {
+        return false;
+    };
+    match std::fs::create_dir_all(profile_dir) {
+        Ok(()) => true,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to prepare Chrome profile at {}: {err}",
+                profile_dir.display()
+            );
+            false
+        }
     }
 }
 
 pub fn open_browser(url: &str) {
-    let env = current_environment();
+    let mut env = current_environment();
+    if !prepare_profile_dir(env.chrome_profile_dir.as_deref()) {
+        env.chrome_profile_dir = None;
+    }
+
     let Some(command) = plan_browser_command(url, &env) else {
         eprintln!("warning: browser auto-open is not supported on this platform");
         return;
@@ -108,14 +162,15 @@ pub fn open_browser(url: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
+    use std::{ffi::OsString, path::PathBuf};
 
     #[test]
-    fn macos_uses_google_chrome_app_mode_when_available() {
+    fn macos_chrome_uses_dedicated_profile_and_fullscreen_flags() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Macos,
             mac_google_chrome_available: true,
             linux_browser: None,
+            chrome_profile_dir: Some(PathBuf::from("/Users/alice/.peitho/chrome-profile")),
         };
 
         let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
@@ -127,6 +182,9 @@ mod tests {
                 OsString::from("-na"),
                 OsString::from("Google Chrome"),
                 OsString::from("--args"),
+                OsString::from("--user-data-dir=/Users/alice/.peitho/chrome-profile"),
+                OsString::from("--no-first-run"),
+                OsString::from("--no-default-browser-check"),
                 OsString::from("--app=http://127.0.0.1:8000/present.html"),
                 OsString::from("--start-fullscreen"),
             ]
@@ -134,11 +192,12 @@ mod tests {
     }
 
     #[test]
-    fn macos_falls_back_to_open_when_google_chrome_is_absent() {
+    fn macos_chrome_without_profile_falls_back_to_plain_open() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Macos,
-            mac_google_chrome_available: false,
+            mac_google_chrome_available: true,
             linux_browser: None,
+            chrome_profile_dir: None,
         };
 
         let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
@@ -151,11 +210,30 @@ mod tests {
     }
 
     #[test]
-    fn linux_uses_google_chrome_app_mode_when_available() {
+    fn macos_falls_back_to_open_when_google_chrome_is_absent() {
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: false,
+            linux_browser: None,
+            chrome_profile_dir: None,
+        };
+
+        let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
+
+        assert_eq!(command.program, OsString::from("open"));
+        assert_eq!(
+            command.args,
+            vec![OsString::from("http://127.0.0.1:8000/present.html")]
+        );
+    }
+
+    #[test]
+    fn linux_chrome_uses_profile_and_fullscreen_flags() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Linux,
             mac_google_chrome_available: false,
             linux_browser: Some(OsString::from("google-chrome")),
+            chrome_profile_dir: Some(PathBuf::from("/home/alice/.peitho/chrome-profile")),
         };
 
         let command = plan_browser_command("http://127.0.0.1:9000/present.html", &env).unwrap();
@@ -164,6 +242,9 @@ mod tests {
         assert_eq!(
             command.args,
             vec![
+                OsString::from("--user-data-dir=/home/alice/.peitho/chrome-profile"),
+                OsString::from("--no-first-run"),
+                OsString::from("--no-default-browser-check"),
                 OsString::from("--app=http://127.0.0.1:9000/present.html"),
                 OsString::from("--start-fullscreen")
             ]
@@ -171,11 +252,12 @@ mod tests {
     }
 
     #[test]
-    fn linux_uses_chromium_app_mode_when_chromium_is_the_available_browser() {
+    fn linux_chromium_uses_profile_and_fullscreen_flags() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Linux,
             mac_google_chrome_available: false,
             linux_browser: Some(OsString::from("chromium")),
+            chrome_profile_dir: Some(PathBuf::from("/home/alice/.peitho/chrome-profile")),
         };
 
         let command = plan_browser_command("http://127.0.0.1:9000/present.html", &env).unwrap();
@@ -184,6 +266,9 @@ mod tests {
         assert_eq!(
             command.args,
             vec![
+                OsString::from("--user-data-dir=/home/alice/.peitho/chrome-profile"),
+                OsString::from("--no-first-run"),
+                OsString::from("--no-default-browser-check"),
                 OsString::from("--app=http://127.0.0.1:9000/present.html"),
                 OsString::from("--start-fullscreen")
             ]
@@ -191,11 +276,12 @@ mod tests {
     }
 
     #[test]
-    fn linux_falls_back_to_xdg_open_without_chrome_or_chromium() {
+    fn linux_chrome_without_profile_falls_back_to_xdg_open() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Linux,
             mac_google_chrome_available: false,
-            linux_browser: None,
+            linux_browser: Some(OsString::from("google-chrome")),
+            chrome_profile_dir: None,
         };
 
         let command = plan_browser_command("http://127.0.0.1:9000/present.html", &env).unwrap();
@@ -208,11 +294,76 @@ mod tests {
     }
 
     #[test]
+    fn chrome_profile_dir_uses_home_peitho_chrome_profile() {
+        assert_eq!(
+            chrome_profile_dir_from_home(Some(OsString::from("/Users/alice"))),
+            Some(PathBuf::from("/Users/alice/.peitho/chrome-profile"))
+        );
+    }
+
+    #[test]
+    fn chrome_profile_dir_is_absent_without_home() {
+        assert_eq!(chrome_profile_dir_from_home(None), None);
+    }
+
+    #[test]
+    fn prepare_profile_keeps_existing_profile_dir() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let profile = temp.path().join(".peitho").join("chrome-profile");
+
+        assert!(prepare_profile_dir(Some(&profile)));
+        assert!(profile.is_dir());
+    }
+
+    #[test]
+    fn prepare_profile_reports_failure_for_file_parent() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let file_parent = temp.path().join("not-a-dir");
+        std::fs::write(&file_parent, "file").expect("write marker");
+        let profile = file_parent.join("chrome-profile");
+
+        assert!(!prepare_profile_dir(Some(&profile)));
+    }
+
+    #[test]
+    fn prepare_profile_is_false_without_profile_path() {
+        assert!(!prepare_profile_dir(None));
+    }
+
+    #[test]
+    fn macos_command_report_matches_author_expected_command() {
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: true,
+            linux_browser: None,
+            chrome_profile_dir: Some(PathBuf::from("/Users/alice/.peitho/chrome-profile")),
+        };
+
+        let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
+        let rendered = std::iter::once(command.program.to_string_lossy().to_string())
+            .chain(
+                command
+                    .args
+                    .iter()
+                    .map(|arg| arg.to_string_lossy().to_string()),
+            )
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("{rendered}");
+
+        assert_eq!(
+            rendered,
+            "open -na Google Chrome --args --user-data-dir=/Users/alice/.peitho/chrome-profile --no-first-run --no-default-browser-check --app=http://127.0.0.1:8000/present.html --start-fullscreen"
+        );
+    }
+
+    #[test]
     fn unsupported_platform_returns_no_command() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Other,
             mac_google_chrome_available: false,
             linux_browser: None,
+            chrome_profile_dir: None,
         };
 
         assert!(plan_browser_command("http://127.0.0.1:9000/present.html", &env).is_none());

--- a/docs/plans/2026-07-03-milestone-9-display-placement-fix.md
+++ b/docs/plans/2026-07-03-milestone-9-display-placement-fix.md
@@ -1,0 +1,1101 @@
+# Peitho Milestone 9 Display Placement Fix Plan
+
+## Purpose
+
+Milestone 9 fixes the two real-device failures found after Milestone 8:
+
+- Chrome app mode opened, but fullscreen was not reliable when Chrome was already running. The fix is to launch Chrome-family browsers with a dedicated profile at `$HOME/.peitho/chrome-profile`, plus `--no-first-run` and `--no-default-browser-check`, so `--app` and `--start-fullscreen` are applied by a fresh Chrome process. The profile is under the user home directory because browser permissions and first-run state are machine-level state, not project build artifacts.
+- Window placement failed after the first Window Management API permission prompt because `requestFullscreen({ screen })` also requires transient user activation. The fix is activation-aware: open the popup synchronously, request screen details, try placement, and if fullscreen fails with `NotAllowedError`, show a visible "Click to place windows / クリックで画面を配置" overlay. The overlay click creates a new user activation and retries the same placement function.
+
+This milestone does not add CLI-side display enumeration, Firefox/Safari multi-screen support, or new command flags. Existing `--no-open`, `--no-serve`, `--port`, and `--shell` behavior remains.
+
+## File Structure Map
+
+| Path | Responsibility | Depends on |
+| --- | --- | --- |
+| `crates/peitho/src/browser.rs` | Chrome profile path planning, browser command planning, profile directory creation before spawn | `std::env`, `std::fs`, `std::process::Command` |
+| `crates/peitho/src/lib.rs` | Existing `browser` module export remains | `browser.rs` |
+| `packages/peitho-present/src/presentDisplay.ts` | Placement extraction, fullscreen retry overlay, activation-aware presenter opening | Window Management API declarations |
+| `packages/peitho-present/src/controls.ts` | Pass optional placement overlay injection to display helper | `presentDisplay.ts` |
+| `packages/peitho-present/src/index.ts` | Export placement helpers and overlay types for tests and future shell wiring | `presentDisplay.ts` |
+| `packages/peitho-present/test/presentDisplay.test.ts` | Deterministic two-screen placement and overlay retry tests | `presentDisplay.ts` |
+| `packages/peitho-present/test/controls.test.ts` | Control-bar default path can exercise overlay injection | `controls.ts` |
+| `packages/peitho-present/test/generated.test.ts` | Public export smoke for new helpers | `index.ts` |
+
+Dependency order:
+
+1. Add Chrome profile path to browser command planning.
+2. Make `open_browser` create the profile directory before app-mode launch and fall back when it cannot.
+3. Extract TS placement into `placeWindows`.
+4. Add the default DOM placement overlay.
+5. Wire retry-on-`NotAllowedError` into `openPresenterWithDisplay`.
+6. Thread overlay injection through controls and exports.
+7. Run all Rust and TS gates and report the concrete command/overlay behavior.
+
+## Implementation Tasks
+
+### Task 1 - Add Chrome Profile Path to Browser Environment
+
+Goal: make profile-dir availability part of pure browser command planning so app-mode Chrome commands always carry `--user-data-dir` when they use Chrome.
+
+Files:
+
+- `crates/peitho/src/browser.rs`
+
+Test:
+
+```rust
+// crates/peitho/src/browser.rs
+#[test]
+fn macos_chrome_uses_dedicated_profile_and_fullscreen_flags() {
+    let env = BrowserEnvironment {
+        platform: BrowserPlatform::Macos,
+        mac_google_chrome_available: true,
+        linux_browser: None,
+        chrome_profile_dir: Some(PathBuf::from("/Users/alice/.peitho/chrome-profile")),
+    };
+
+    let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
+
+    assert_eq!(command.program, OsString::from("open"));
+    assert_eq!(
+        command.args,
+        vec![
+            OsString::from("-na"),
+            OsString::from("Google Chrome"),
+            OsString::from("--args"),
+            OsString::from("--user-data-dir=/Users/alice/.peitho/chrome-profile"),
+            OsString::from("--no-first-run"),
+            OsString::from("--no-default-browser-check"),
+            OsString::from("--app=http://127.0.0.1:8000/present.html"),
+            OsString::from("--start-fullscreen"),
+        ]
+    );
+}
+
+#[test]
+fn macos_chrome_without_profile_falls_back_to_plain_open() {
+    let env = BrowserEnvironment {
+        platform: BrowserPlatform::Macos,
+        mac_google_chrome_available: true,
+        linux_browser: None,
+        chrome_profile_dir: None,
+    };
+
+    let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
+
+    assert_eq!(command.program, OsString::from("open"));
+    assert_eq!(
+        command.args,
+        vec![OsString::from("http://127.0.0.1:8000/present.html")]
+    );
+}
+```
+
+Expected Red:
+
+```text
+error[E0063]: missing field `chrome_profile_dir` in initializer of `BrowserEnvironment`
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/browser.rs
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserEnvironment {
+    pub platform: BrowserPlatform,
+    pub mac_google_chrome_available: bool,
+    pub linux_browser: Option<OsString>,
+    pub chrome_profile_dir: Option<PathBuf>,
+}
+
+fn chrome_args(url: &str, profile_dir: &Path) -> Vec<OsString> {
+    vec![
+        OsString::from(format!("--user-data-dir={}", profile_dir.display())),
+        OsString::from("--no-first-run"),
+        OsString::from("--no-default-browser-check"),
+        OsString::from(format!("--app={url}")),
+        OsString::from("--start-fullscreen"),
+    ]
+}
+
+pub fn plan_browser_command(url: &str, env: &BrowserEnvironment) -> Option<BrowserCommand> {
+    match env.platform {
+        BrowserPlatform::Macos
+            if env.mac_google_chrome_available && env.chrome_profile_dir.is_some() =>
+        {
+            let profile_dir = env.chrome_profile_dir.as_deref().expect("guarded by is_some");
+            let mut args = vec![
+                OsString::from("-na"),
+                OsString::from("Google Chrome"),
+                OsString::from("--args"),
+            ];
+            args.extend(chrome_args(url, profile_dir));
+            Some(BrowserCommand {
+                program: OsString::from("open"),
+                args,
+            })
+        }
+        BrowserPlatform::Macos => Some(BrowserCommand {
+            program: OsString::from("open"),
+            args: vec![OsString::from(url)],
+        }),
+        BrowserPlatform::Linux => linux_browser_command(
+            url,
+            env.linux_browser.as_deref(),
+            env.chrome_profile_dir.as_deref(),
+        ),
+        BrowserPlatform::Other => None,
+    }
+}
+```
+
+Verification:
+
+```sh
+cargo test -p peitho browser::tests::macos_chrome_uses_dedicated_profile_and_fullscreen_flags
+cargo test -p peitho browser::tests::macos_chrome_without_profile_falls_back_to_plain_open
+```
+
+### Task 2 - Update Linux Chrome Planning for Dedicated Profile
+
+Goal: Linux Chrome and Chromium commands include the profile and first-run suppression flags; no profile falls back to `xdg-open`.
+
+Files:
+
+- `crates/peitho/src/browser.rs`
+
+Test:
+
+```rust
+// crates/peitho/src/browser.rs
+#[test]
+fn linux_chrome_uses_profile_and_fullscreen_flags() {
+    let env = BrowserEnvironment {
+        platform: BrowserPlatform::Linux,
+        mac_google_chrome_available: false,
+        linux_browser: Some(OsString::from("google-chrome")),
+        chrome_profile_dir: Some(PathBuf::from("/home/alice/.peitho/chrome-profile")),
+    };
+
+    let command = plan_browser_command("http://127.0.0.1:9000/present.html", &env).unwrap();
+
+    assert_eq!(command.program, OsString::from("google-chrome"));
+    assert_eq!(
+        command.args,
+        vec![
+            OsString::from("--user-data-dir=/home/alice/.peitho/chrome-profile"),
+            OsString::from("--no-first-run"),
+            OsString::from("--no-default-browser-check"),
+            OsString::from("--app=http://127.0.0.1:9000/present.html"),
+            OsString::from("--start-fullscreen"),
+        ]
+    );
+}
+
+#[test]
+fn linux_chromium_uses_profile_and_fullscreen_flags() {
+    let env = BrowserEnvironment {
+        platform: BrowserPlatform::Linux,
+        mac_google_chrome_available: false,
+        linux_browser: Some(OsString::from("chromium")),
+        chrome_profile_dir: Some(PathBuf::from("/home/alice/.peitho/chrome-profile")),
+    };
+
+    let command = plan_browser_command("http://127.0.0.1:9000/present.html", &env).unwrap();
+
+    assert_eq!(command.program, OsString::from("chromium"));
+    assert_eq!(
+        command.args,
+        vec![
+            OsString::from("--user-data-dir=/home/alice/.peitho/chrome-profile"),
+            OsString::from("--no-first-run"),
+            OsString::from("--no-default-browser-check"),
+            OsString::from("--app=http://127.0.0.1:9000/present.html"),
+            OsString::from("--start-fullscreen"),
+        ]
+    );
+}
+
+#[test]
+fn linux_chrome_without_profile_falls_back_to_xdg_open() {
+    let env = BrowserEnvironment {
+        platform: BrowserPlatform::Linux,
+        mac_google_chrome_available: false,
+        linux_browser: Some(OsString::from("google-chrome")),
+        chrome_profile_dir: None,
+    };
+
+    let command = plan_browser_command("http://127.0.0.1:9000/present.html", &env).unwrap();
+
+    assert_eq!(command.program, OsString::from("xdg-open"));
+    assert_eq!(
+        command.args,
+        vec![OsString::from("http://127.0.0.1:9000/present.html")]
+    );
+}
+```
+
+Expected Red:
+
+```text
+assertion `left == right` failed
+left: ["--app=http://127.0.0.1:9000/present.html", "--start-fullscreen"]
+right: ["--user-data-dir=/home/alice/.peitho/chrome-profile", "--no-first-run", "--no-default-browser-check", "--app=http://127.0.0.1:9000/present.html", "--start-fullscreen"]
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/browser.rs
+fn linux_browser_command(
+    url: &str,
+    browser: Option<&OsStr>,
+    profile_dir: Option<&Path>,
+) -> Option<BrowserCommand> {
+    match (browser, profile_dir) {
+        (Some(program), Some(profile_dir)) => Some(BrowserCommand {
+            program: program.to_owned(),
+            args: chrome_args(url, profile_dir),
+        }),
+        _ => Some(BrowserCommand {
+            program: OsString::from("xdg-open"),
+            args: vec![OsString::from(url)],
+        }),
+    }
+}
+```
+
+Verification:
+
+```sh
+cargo test -p peitho browser::tests::linux_chrome_uses_profile_and_fullscreen_flags
+cargo test -p peitho browser::tests::linux_chromium_uses_profile_and_fullscreen_flags
+cargo test -p peitho browser::tests::linux_chrome_without_profile_falls_back_to_xdg_open
+```
+
+### Task 3 - Derive Profile Directory from HOME
+
+Goal: `current_environment` derives `$HOME/.peitho/chrome-profile`, and missing `HOME` removes the Chrome profile path so command planning falls back.
+
+Files:
+
+- `crates/peitho/src/browser.rs`
+
+Test:
+
+```rust
+// crates/peitho/src/browser.rs
+#[test]
+fn chrome_profile_dir_uses_home_peitho_chrome_profile() {
+    assert_eq!(
+        chrome_profile_dir_from_home(Some(OsString::from("/Users/alice"))),
+        Some(PathBuf::from("/Users/alice/.peitho/chrome-profile"))
+    );
+}
+
+#[test]
+fn chrome_profile_dir_is_absent_without_home() {
+    assert_eq!(chrome_profile_dir_from_home(None), None);
+}
+
+#[test]
+fn current_environment_sets_supported_platform_shape_and_profile_slot() {
+    let env = current_environment();
+    if cfg!(target_os = "macos") {
+        assert_eq!(env.platform, BrowserPlatform::Macos);
+    } else if cfg!(target_os = "linux") {
+        assert_eq!(env.platform, BrowserPlatform::Linux);
+    } else {
+        assert_eq!(env.platform, BrowserPlatform::Other);
+    }
+}
+```
+
+Expected Red:
+
+```text
+error[E0425]: cannot find function `chrome_profile_dir_from_home` in this scope
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/browser.rs
+fn chrome_profile_dir_from_home(home: Option<OsString>) -> Option<PathBuf> {
+    home.map(PathBuf::from)
+        .map(|home| home.join(".peitho").join("chrome-profile"))
+}
+
+fn current_environment() -> BrowserEnvironment {
+    BrowserEnvironment {
+        platform: current_platform(),
+        mac_google_chrome_available: chrome_app_exists(),
+        linux_browser: find_linux_browser(),
+        chrome_profile_dir: chrome_profile_dir_from_home(std::env::var_os("HOME")),
+    }
+}
+```
+
+Verification:
+
+```sh
+cargo test -p peitho browser::tests::chrome_profile_dir_uses_home_peitho_chrome_profile
+cargo test -p peitho browser::tests::chrome_profile_dir_is_absent_without_home
+cargo test -p peitho browser::tests::current_environment_sets_supported_platform_shape_and_profile_slot
+```
+
+### Task 4 - Create Profile Directory Before Spawn and Fall Back on Failure
+
+Goal: `open_browser` creates the Chrome profile directory before spawning; if creation fails, it warns and replans without the profile instead of launching Chrome without a dedicated profile.
+
+Files:
+
+- `crates/peitho/src/browser.rs`
+
+Test:
+
+```rust
+// crates/peitho/src/browser.rs
+#[test]
+fn prepare_profile_keeps_existing_profile_dir() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let profile = temp.path().join(".peitho").join("chrome-profile");
+
+    assert!(prepare_profile_dir(Some(&profile)));
+    assert!(profile.is_dir());
+}
+
+#[test]
+fn prepare_profile_reports_failure_for_file_parent() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let file_parent = temp.path().join("not-a-dir");
+    std::fs::write(&file_parent, "file").expect("write marker");
+    let profile = file_parent.join("chrome-profile");
+
+    assert!(!prepare_profile_dir(Some(&profile)));
+}
+
+#[test]
+fn prepare_profile_is_false_without_profile_path() {
+    assert!(!prepare_profile_dir(None));
+}
+```
+
+Expected Red:
+
+```text
+error[E0425]: cannot find function `prepare_profile_dir` in this scope
+```
+
+Implementation:
+
+```rust
+// crates/peitho/src/browser.rs
+fn prepare_profile_dir(profile_dir: Option<&Path>) -> bool {
+    let Some(profile_dir) = profile_dir else {
+        return false;
+    };
+    match std::fs::create_dir_all(profile_dir) {
+        Ok(()) => true,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to prepare Chrome profile at {}: {err}",
+                profile_dir.display()
+            );
+            false
+        }
+    }
+}
+
+pub fn open_browser(url: &str) {
+    let mut env = current_environment();
+    if !prepare_profile_dir(env.chrome_profile_dir.as_deref()) {
+        env.chrome_profile_dir = None;
+    }
+
+    let Some(command) = plan_browser_command(url, &env) else {
+        eprintln!("warning: browser auto-open is not supported on this platform");
+        return;
+    };
+    if let Err(err) = Command::new(&command.program).args(&command.args).spawn() {
+        eprintln!(
+            "warning: failed to open browser with {}: {err}",
+            command.program.to_string_lossy()
+        );
+    }
+}
+```
+
+Verification:
+
+```sh
+cargo test -p peitho browser::tests::prepare_profile_keeps_existing_profile_dir
+cargo test -p peitho browser::tests::prepare_profile_reports_failure_for_file_parent
+cargo test -p peitho browser::tests::prepare_profile_is_false_without_profile_path
+```
+
+### Task 5 - Extract TS Window Placement Function
+
+Goal: use one `placeWindows` function for the first placement attempt and the overlay retry.
+
+Files:
+
+- `packages/peitho-present/src/presentDisplay.ts`
+- `packages/peitho-present/test/presentDisplay.test.ts`
+
+Test:
+
+```ts
+// packages/peitho-present/test/presentDisplay.test.ts
+import { placeWindows } from "../src/presentDisplay";
+
+it("places the slide fullscreen on the other screen and popup on the current screen", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const requestFullscreen = vi.fn(async () => undefined);
+
+  await placeWindows({
+    details: { currentScreen: current, screens: [current, other] },
+    popup,
+    requestFullscreen
+  });
+
+  expect(requestFullscreen).toHaveBeenCalledWith({ screen: other });
+  expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
+  expect(popup.resizeTo).toHaveBeenCalledWith(1200, 800);
+});
+
+it("does nothing when there is no other screen", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const requestFullscreen = vi.fn();
+
+  await placeWindows({
+    details: { currentScreen: current, screens: [current] },
+    popup,
+    requestFullscreen
+  });
+
+  expect(requestFullscreen).not.toHaveBeenCalled();
+  expect(popup.moveTo).not.toHaveBeenCalled();
+  expect(popup.resizeTo).not.toHaveBeenCalled();
+});
+```
+
+Expected Red:
+
+```text
+Module '"../src/presentDisplay"' has no exported member 'placeWindows'
+```
+
+Implementation:
+
+```ts
+// packages/peitho-present/src/presentDisplay.ts
+export type RequestFullscreen = (options?: FullscreenOptions) => Promise<void> | void;
+
+export type PlaceWindowsOptions = {
+  details: ScreenDetails;
+  popup: PresenterPopup | null;
+  requestFullscreen: RequestFullscreen;
+};
+
+export async function placeWindows(options: PlaceWindowsOptions): Promise<boolean> {
+  const otherScreen = chooseOtherScreen(options.details);
+  if (!otherScreen) return false;
+
+  await options.requestFullscreen({ screen: otherScreen });
+
+  if (options.popup) {
+    options.popup.moveTo(
+      options.details.currentScreen.availLeft,
+      options.details.currentScreen.availTop
+    );
+    options.popup.resizeTo(
+      Math.min(DEFAULT_POPUP_WIDTH, options.details.currentScreen.availWidth),
+      Math.min(DEFAULT_POPUP_HEIGHT, options.details.currentScreen.availHeight)
+    );
+  }
+
+  return true;
+}
+```
+
+Verification:
+
+```sh
+cd packages/peitho-present
+npm test -- presentDisplay.test.ts
+npm run typecheck
+```
+
+### Task 6 - Add Default Placement Overlay
+
+Goal: the slide window can show a visible retry target when fullscreen placement needs a second user activation.
+
+Files:
+
+- `packages/peitho-present/src/presentDisplay.ts`
+- `packages/peitho-present/test/presentDisplay.test.ts`
+
+Test:
+
+```ts
+// packages/peitho-present/test/presentDisplay.test.ts
+import { showPlacementOverlay } from "../src/presentDisplay";
+
+it("shows a visible placement overlay and invokes the retry on click", async () => {
+  const retry = vi.fn(async () => undefined);
+  const overlay = showPlacementOverlay(document, retry);
+  const button = document.querySelector<HTMLButtonElement>("[data-peitho-place-overlay]");
+
+  expect(button).not.toBeNull();
+  expect(button?.textContent).toContain("Click to place windows");
+  expect(button?.textContent).toContain("クリックで画面を配置");
+
+  button?.click();
+  await Promise.resolve();
+
+  expect(retry).toHaveBeenCalledTimes(1);
+  overlay.remove();
+  expect(document.querySelector("[data-peitho-place-overlay]")).toBeNull();
+});
+```
+
+Expected Red:
+
+```text
+Module '"../src/presentDisplay"' has no exported member 'showPlacementOverlay'
+```
+
+Implementation:
+
+```ts
+// packages/peitho-present/src/presentDisplay.ts
+export type PlacementOverlay = {
+  remove: () => void;
+};
+
+export type ShowPlacementOverlay = (retry: () => Promise<void>) => PlacementOverlay;
+
+export function showPlacementOverlay(
+  doc: Document,
+  retry: () => Promise<void>
+): PlacementOverlay {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.dataset.peithoPlaceOverlay = "true";
+  button.textContent = "Click to place windows / クリックで画面を配置";
+  button.style.position = "fixed";
+  button.style.inset = "0";
+  button.style.zIndex = "2147483647";
+  button.style.display = "grid";
+  button.style.placeItems = "center";
+  button.style.border = "0";
+  button.style.background = "rgba(0, 0, 0, 0.82)";
+  button.style.color = "#fff";
+  button.style.font = "600 28px system-ui, sans-serif";
+  button.addEventListener("click", () => {
+    void retry();
+  });
+  doc.body.appendChild(button);
+
+  return {
+    remove: () => button.remove()
+  };
+}
+```
+
+Verification:
+
+```sh
+cd packages/peitho-present
+npm test -- presentDisplay.test.ts
+npm run typecheck
+```
+
+### Task 7 - Retry Placement from Overlay After NotAllowedError
+
+Goal: when the first `requestFullscreen({ screen })` fails after permission prompt activation loss, show the overlay and retry placement on overlay click. Permission denial from `getScreenDetails` remains a popup-only fallback.
+
+Files:
+
+- `packages/peitho-present/src/presentDisplay.ts`
+- `packages/peitho-present/test/presentDisplay.test.ts`
+
+Test:
+
+```ts
+// packages/peitho-present/test/presentDisplay.test.ts
+it("shows overlay after NotAllowedError and retries placement from the overlay click", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const requestFullscreen = vi.fn(async (_options?: FullscreenOptions) => undefined);
+  requestFullscreen
+    .mockRejectedValueOnce(new DOMException("activation expired", "NotAllowedError"))
+    .mockResolvedValueOnce(undefined);
+  let retry: (() => Promise<void>) | null = null;
+  const overlay = { remove: vi.fn() };
+  const showPlacementOverlay = vi.fn((nextRetry: () => Promise<void>) => {
+    retry = nextRetry;
+    return overlay;
+  });
+
+  await openPresenterWithDisplay({
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    openWindow: vi.fn(() => popup),
+    requestFullscreen,
+    showPlacementOverlay
+  });
+
+  expect(showPlacementOverlay).toHaveBeenCalledTimes(1);
+  expect(popup.moveTo).not.toHaveBeenCalled();
+  expect(retry).not.toBeNull();
+
+  await retry?.();
+
+  expect(requestFullscreen).toHaveBeenNthCalledWith(2, { screen: other });
+  expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
+  expect(popup.resizeTo).toHaveBeenCalledWith(1200, 800);
+  expect(overlay.remove).toHaveBeenCalledTimes(1);
+});
+
+it("does not show overlay when the first placement succeeds", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const showPlacementOverlay = vi.fn();
+
+  await openPresenterWithDisplay({
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    openWindow: vi.fn(() => popup),
+    requestFullscreen: vi.fn(async () => undefined),
+    showPlacementOverlay
+  });
+
+  expect(showPlacementOverlay).not.toHaveBeenCalled();
+  expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
+});
+
+it("does not show overlay when popup is blocked", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const showPlacementOverlay = vi.fn();
+
+  await openPresenterWithDisplay({
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    openWindow: vi.fn(() => null),
+    requestFullscreen: vi.fn(async () => {
+      throw new DOMException("activation expired", "NotAllowedError");
+    }),
+    showPlacementOverlay
+  });
+
+  expect(showPlacementOverlay).not.toHaveBeenCalled();
+});
+```
+
+Expected Red:
+
+```text
+Object literal may only specify known properties, and 'showPlacementOverlay' does not exist
+```
+
+Implementation:
+
+```ts
+// packages/peitho-present/src/presentDisplay.ts
+export type OpenPresenterWithDisplayOptions = {
+  window?: Window;
+  document?: Document;
+  url?: string;
+  getScreenDetails?: (() => Promise<ScreenDetails>) | undefined;
+  openWindow?: (url: string, target: string, features: string) => PresenterPopup | null;
+  requestFullscreen?: RequestFullscreen;
+  showPlacementOverlay?: ShowPlacementOverlay;
+};
+
+function isNotAllowedError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}
+
+export async function openPresenterWithDisplay(
+  options: OpenPresenterWithDisplayOptions = {}
+): Promise<PresenterPopup | null> {
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const url = options.url ?? PRESENTER_URL;
+  const openWindow =
+    options.openWindow ?? ((nextUrl, target, features) => win.open(nextUrl, target, features));
+  const popup = openWindow(url, PRESENTER_TARGET, fallbackFeatures());
+  const requestFullscreen =
+    options.requestFullscreen ??
+    ((fullscreenOptions?: FullscreenOptions) =>
+      doc.documentElement.requestFullscreen?.(fullscreenOptions));
+  const getScreenDetails = options.getScreenDetails ?? win.getScreenDetails?.bind(win);
+  const showOverlay =
+    options.showPlacementOverlay ?? ((retry: () => Promise<void>) => showPlacementOverlay(doc, retry));
+
+  if (!getScreenDetails) return popup;
+
+  let details: ScreenDetails;
+  try {
+    details = await getScreenDetails();
+  } catch {
+    return popup;
+  }
+
+  try {
+    await placeWindows({ details, popup, requestFullscreen });
+  } catch (error) {
+    if (!popup || !isNotAllowedError(error)) return popup;
+    let overlay: PlacementOverlay | null = null;
+    overlay = showOverlay(async () => {
+      try {
+        await placeWindows({ details, popup, requestFullscreen });
+        overlay?.remove();
+        overlay = null;
+      } catch {
+        return;
+      }
+    });
+  }
+
+  return popup;
+}
+```
+
+Verification:
+
+```sh
+cd packages/peitho-present
+npm test -- presentDisplay.test.ts
+npm run typecheck
+```
+
+### Task 8 - Thread Overlay Injection Through Controls
+
+Goal: tests and future UI wiring can inject the placement overlay hook through `installPresentationControls`; default browser behavior still uses the DOM overlay.
+
+Files:
+
+- `packages/peitho-present/src/controls.ts`
+- `packages/peitho-present/test/controls.test.ts`
+
+Test:
+
+```ts
+// packages/peitho-present/test/controls.test.ts
+it("passes the placement overlay hook to the default presenter display helper", async () => {
+  const root = document.createElement("main");
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const showPlacementOverlay = vi.fn((retry: () => Promise<void>) => {
+    void retry;
+    return { remove: vi.fn() };
+  });
+  const cleanup = installPresentationControls({
+    root,
+    window,
+    document,
+    bus: window,
+    openPresenterWindow: vi.fn(() => popup),
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    requestFullscreen: vi.fn(async () => {
+      throw new DOMException("activation expired", "NotAllowedError");
+    }),
+    showPlacementOverlay
+  });
+  cleanups.push(cleanup);
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="presenter"]')?.click();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(showPlacementOverlay).toHaveBeenCalledTimes(1);
+});
+```
+
+Expected Red:
+
+```text
+Object literal may only specify known properties, and 'showPlacementOverlay' does not exist
+```
+
+Implementation:
+
+```ts
+// packages/peitho-present/src/controls.ts
+export type PresentationControlsOptions = {
+  root: HTMLElement;
+  window?: Window;
+  document?: Document;
+  bus?: EventTarget;
+  idleMs?: number;
+  openPresenter?: () => void | Promise<void>;
+  getScreenDetails?: OpenPresenterWithDisplayOptions["getScreenDetails"];
+  openPresenterWindow?: OpenPresenterWithDisplayOptions["openWindow"];
+  requestFullscreen?: OpenPresenterWithDisplayOptions["requestFullscreen"];
+  showPlacementOverlay?: OpenPresenterWithDisplayOptions["showPlacementOverlay"];
+};
+
+const openPresenter =
+  options.openPresenter ??
+  (() =>
+    openPresenterWithDisplay({
+      window: win,
+      document: doc,
+      getScreenDetails: options.getScreenDetails,
+      openWindow: options.openPresenterWindow,
+      requestFullscreen: options.requestFullscreen,
+      showPlacementOverlay: options.showPlacementOverlay
+    }));
+```
+
+Verification:
+
+```sh
+cd packages/peitho-present
+npm test -- controls.test.ts
+npm run typecheck
+```
+
+### Task 9 - Export New Placement Helpers
+
+Goal: public package exports include the placement helper and overlay types used by tests and future shell wiring.
+
+Files:
+
+- `packages/peitho-present/src/index.ts`
+- `packages/peitho-present/test/generated.test.ts`
+
+Test:
+
+```ts
+// packages/peitho-present/test/generated.test.ts
+import {
+  openPresenterWithDisplay,
+  placeWindows,
+  showPlacementOverlay
+} from "../src/index";
+import type {
+  PlacementOverlay,
+  PlaceWindowsOptions,
+  RequestFullscreen,
+  ShowPlacementOverlay
+} from "../src/index";
+
+it("exports display placement retry helpers", () => {
+  const overlay: PlacementOverlay = { remove: () => undefined };
+  const fullscreen: RequestFullscreen = () => undefined;
+  const show: ShowPlacementOverlay = () => overlay;
+  const options: PlaceWindowsOptions = {
+    details: {
+      currentScreen: { availLeft: 0, availTop: 0, availWidth: 1, availHeight: 1 },
+      screens: [{ availLeft: 0, availTop: 0, availWidth: 1, availHeight: 1 }]
+    },
+    popup: null,
+    requestFullscreen: fullscreen
+  };
+
+  expect(openPresenterWithDisplay).toBeTypeOf("function");
+  expect(placeWindows).toBeTypeOf("function");
+  expect(showPlacementOverlay).toBeTypeOf("function");
+  expect(show).toBeTypeOf("function");
+  expect(options.popup).toBeNull();
+});
+```
+
+Expected Red:
+
+```text
+Module '"../src/index"' has no exported member 'placeWindows'
+```
+
+Implementation:
+
+```ts
+// packages/peitho-present/src/index.ts
+export {
+  buildPresenterFeatures,
+  chooseOtherScreen,
+  fallbackFeatures,
+  openPresenterWithDisplay,
+  placeWindows,
+  PRESENTER_URL,
+  showPlacementOverlay
+} from "./presentDisplay";
+export type {
+  OpenPresenterWithDisplayOptions,
+  PlacementOverlay,
+  PlaceWindowsOptions,
+  PresenterPopup,
+  RequestFullscreen,
+  ShowPlacementOverlay
+} from "./presentDisplay";
+```
+
+Verification:
+
+```sh
+cd packages/peitho-present
+npm test -- generated.test.ts
+npm run typecheck
+```
+
+### Task 10 - Full Gate and Real-Device Regression Markers
+
+Goal: verify the implementation with the full project gates and report the two behavioral markers needed for real-device testing.
+
+Files:
+
+- `crates/peitho/src/browser.rs`
+- `packages/peitho-present/src/presentDisplay.ts`
+- `packages/peitho-present/dist/shell.js`
+
+Test:
+
+```rust
+// crates/peitho/src/browser.rs
+#[test]
+fn macos_command_report_matches_author_expected_command() {
+    let env = BrowserEnvironment {
+        platform: BrowserPlatform::Macos,
+        mac_google_chrome_available: true,
+        linux_browser: None,
+        chrome_profile_dir: Some(PathBuf::from("/Users/alice/.peitho/chrome-profile")),
+    };
+
+    let command = plan_browser_command("http://127.0.0.1:8000/present.html", &env).unwrap();
+    let rendered = std::iter::once(command.program.to_string_lossy().to_string())
+        .chain(command.args.iter().map(|arg| arg.to_string_lossy().to_string()))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert_eq!(
+        rendered,
+        "open -na Google Chrome --args --user-data-dir=/Users/alice/.peitho/chrome-profile --no-first-run --no-default-browser-check --app=http://127.0.0.1:8000/present.html --start-fullscreen"
+    );
+}
+```
+
+Implementation:
+
+- Keep the `macos_command_report_matches_author_expected_command` test in `browser.rs`.
+- Run `npm run build` after TS changes so `packages/peitho-present/dist/shell.js` contains `data-peitho-place-overlay`, `NotAllowedError`, and `placeWindows`.
+- Do not commit `dist/`; it remains a generated artifact for local verification and existing present tests.
+
+Verification:
+
+```sh
+cd packages/peitho-present
+npm run build
+npm test
+npm run typecheck
+
+cd ../..
+cargo test --workspace
+cargo test --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all --check
+git diff --exit-code bindings/
+cargo run -p peitho -- present examples/deck.md --template templates/title-body-code.html --base-css themes/base.css --overrides-css themes/overrides.css --no-serve --no-open
+rg -n "user-data-dir|no-first-run|no-default-browser-check|start-fullscreen" crates/peitho/src/browser.rs
+rg -n "data-peitho-place-overlay|NotAllowedError|placeWindows" packages/peitho-present/dist/shell.js
+```
+
+Report these concrete values:
+
+```text
+Mac app-mode command:
+open -na "Google Chrome" --args --user-data-dir=$HOME/.peitho/chrome-profile --no-first-run --no-default-browser-check --app=<URL> --start-fullscreen
+
+Overlay marker:
+data-peitho-place-overlay is present in shell.js and is only shown after requestFullscreen fails with NotAllowedError while a popup exists.
+```
+
+## Summary
+
+This plan has 10 TDD tasks. The Rust half first makes Chrome app-mode launch deterministic by requiring a home-scoped Peitho Chrome profile, then creating that profile before spawning and falling back if it cannot be prepared. The TypeScript half extracts window placement, adds a visible activation-retry overlay, wires it through the presenter control button, exports the helpers, and finishes with full Rust/TS gates plus the exact command and overlay markers needed for real-device verification.

--- a/packages/peitho-present/src/controls.ts
+++ b/packages/peitho-present/src/controls.ts
@@ -14,6 +14,7 @@ export type PresentationControlsOptions = {
   getScreenDetails?: OpenPresenterWithDisplayOptions["getScreenDetails"];
   openPresenterWindow?: OpenPresenterWithDisplayOptions["openWindow"];
   requestFullscreen?: OpenPresenterWithDisplayOptions["requestFullscreen"];
+  showPlacementOverlay?: OpenPresenterWithDisplayOptions["showPlacementOverlay"];
 };
 
 export type CanvasClickNavigationOptions = {
@@ -40,7 +41,8 @@ export function installPresentationControls(options: PresentationControlsOptions
         document: doc,
         getScreenDetails: options.getScreenDetails,
         openWindow: options.openPresenterWindow,
-        requestFullscreen: options.requestFullscreen
+        requestFullscreen: options.requestFullscreen,
+        showPlacementOverlay: options.showPlacementOverlay
       }));
 
   const bar = doc.createElement("nav");

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -21,9 +21,18 @@ export {
   chooseOtherScreen,
   fallbackFeatures,
   openPresenterWithDisplay,
-  PRESENTER_URL
+  placeWindows,
+  PRESENTER_URL,
+  showPlacementOverlay
 } from "./presentDisplay";
-export type { OpenPresenterWithDisplayOptions, PresenterPopup } from "./presentDisplay";
+export type {
+  OpenPresenterWithDisplayOptions,
+  PlacementOverlay,
+  PlaceWindowsOptions,
+  PresenterPopup,
+  RequestFullscreen,
+  ShowPlacementOverlay
+} from "./presentDisplay";
 export { installKeyboardNavigation } from "./keyboard";
 export { mountPresenterView } from "./presenter";
 export { mountPresentShell } from "./shell";

--- a/packages/peitho-present/src/presentDisplay.ts
+++ b/packages/peitho-present/src/presentDisplay.ts
@@ -25,6 +25,66 @@ export function chooseOtherScreen(details: ScreenDetails): ScreenDetailed | null
 }
 
 export type PresenterPopup = Pick<Window, "moveTo" | "resizeTo">;
+export type RequestFullscreen = (options?: FullscreenOptions) => Promise<void> | void;
+
+export type PlaceWindowsOptions = {
+  details: ScreenDetails;
+  popup: PresenterPopup | null;
+  requestFullscreen: RequestFullscreen;
+};
+
+export type PlacementOverlay = {
+  remove: () => void;
+};
+
+export type ShowPlacementOverlay = (retry: () => Promise<void>) => PlacementOverlay;
+
+export async function placeWindows(options: PlaceWindowsOptions): Promise<boolean> {
+  const otherScreen = chooseOtherScreen(options.details);
+  if (!otherScreen) return false;
+
+  await options.requestFullscreen({ screen: otherScreen });
+
+  if (options.popup) {
+    options.popup.moveTo(
+      options.details.currentScreen.availLeft,
+      options.details.currentScreen.availTop
+    );
+    options.popup.resizeTo(
+      Math.min(DEFAULT_POPUP_WIDTH, options.details.currentScreen.availWidth),
+      Math.min(DEFAULT_POPUP_HEIGHT, options.details.currentScreen.availHeight)
+    );
+  }
+
+  return true;
+}
+
+export function showPlacementOverlay(
+  doc: Document,
+  retry: () => Promise<void>
+): PlacementOverlay {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.dataset.peithoPlaceOverlay = "true";
+  button.textContent = "Click to place windows / クリックで画面を配置";
+  button.style.position = "fixed";
+  button.style.inset = "0";
+  button.style.zIndex = "2147483647";
+  button.style.display = "grid";
+  button.style.placeItems = "center";
+  button.style.border = "0";
+  button.style.background = "rgba(0, 0, 0, 0.82)";
+  button.style.color = "#fff";
+  button.style.font = "600 28px system-ui, sans-serif";
+  button.addEventListener("click", () => {
+    void retry();
+  });
+  doc.body.appendChild(button);
+
+  return {
+    remove: () => button.remove()
+  };
+}
 
 export type OpenPresenterWithDisplayOptions = {
   window?: Window;
@@ -32,8 +92,13 @@ export type OpenPresenterWithDisplayOptions = {
   url?: string;
   getScreenDetails?: (() => Promise<ScreenDetails>) | undefined;
   openWindow?: (url: string, target: string, features: string) => PresenterPopup | null;
-  requestFullscreen?: (options?: FullscreenOptions) => Promise<void> | void;
+  requestFullscreen?: RequestFullscreen;
+  showPlacementOverlay?: ShowPlacementOverlay;
 };
+
+function isNotAllowedError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "NotAllowedError";
+}
 
 export async function openPresenterWithDisplay(
   options: OpenPresenterWithDisplayOptions = {}
@@ -49,24 +114,33 @@ export async function openPresenterWithDisplay(
     ((fullscreenOptions?: FullscreenOptions) =>
       doc.documentElement.requestFullscreen?.(fullscreenOptions));
   const getScreenDetails = options.getScreenDetails ?? win.getScreenDetails?.bind(win);
+  const showOverlay =
+    options.showPlacementOverlay ??
+    ((retry: () => Promise<void>) => showPlacementOverlay(doc, retry));
 
   if (!getScreenDetails) return popup;
 
+  let details: ScreenDetails;
   try {
-    const details = await getScreenDetails();
-    const otherScreen = chooseOtherScreen(details);
-    if (otherScreen) {
-      await requestFullscreen({ screen: otherScreen });
-      if (popup) {
-        popup.moveTo(details.currentScreen.availLeft, details.currentScreen.availTop);
-        popup.resizeTo(
-          Math.min(DEFAULT_POPUP_WIDTH, details.currentScreen.availWidth),
-          Math.min(DEFAULT_POPUP_HEIGHT, details.currentScreen.availHeight)
-        );
-      }
-    }
+    details = await getScreenDetails();
   } catch {
     return popup;
+  }
+
+  try {
+    await placeWindows({ details, popup, requestFullscreen });
+  } catch (error) {
+    if (!popup || !isNotAllowedError(error)) return popup;
+    let overlay: PlacementOverlay | null = null;
+    overlay = showOverlay(async () => {
+      try {
+        await placeWindows({ details, popup, requestFullscreen });
+        overlay?.remove();
+        overlay = null;
+      } catch {
+        return;
+      }
+    });
   }
 
   return popup;

--- a/packages/peitho-present/test/controls.test.ts
+++ b/packages/peitho-present/test/controls.test.ts
@@ -109,6 +109,50 @@ it("opens presenter popup with default display management", async () => {
   );
 });
 
+it("passes the placement overlay hook to the default presenter display helper", async () => {
+  const root = document.createElement("main");
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const showPlacementOverlay = vi.fn((retry: () => Promise<void>) => {
+    void retry;
+    return { remove: vi.fn() };
+  });
+  const cleanup = installPresentationControls({
+    root,
+    window,
+    document,
+    bus: window,
+    openPresenterWindow: vi.fn(() => popup),
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    requestFullscreen: vi.fn(async () => {
+      throw new DOMException("activation expired", "NotAllowedError");
+    }),
+    showPlacementOverlay
+  });
+  cleanups.push(cleanup);
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="presenter"]')?.click();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(showPlacementOverlay).toHaveBeenCalledTimes(1);
+});
+
 it("keeps the explicit openPresenter injection as the highest priority", () => {
   const root = document.createElement("main");
   const openPresenter = vi.fn();

--- a/packages/peitho-present/test/generated.test.ts
+++ b/packages/peitho-present/test/generated.test.ts
@@ -12,13 +12,19 @@ import {
   installPresentationControls,
   mountPresenterView,
   mountPresentShell,
-  openPresenterWithDisplay
+  openPresenterWithDisplay,
+  placeWindows,
+  showPlacementOverlay
 } from "../src/index";
 import type {
+  PlacementOverlay,
+  PlaceWindowsOptions,
   PresentationEndDetail,
   PresentationStartDetail,
   PresenterOptions,
+  RequestFullscreen,
   ShellOptions,
+  ShowPlacementOverlay,
   TimerControlDetail
 } from "../src/index";
 
@@ -75,5 +81,24 @@ describe("generated manifest contract", () => {
     expect(typeof buildPresenterFeatures).toBe("function");
     expect(typeof chooseOtherScreen).toBe("function");
     expect(typeof openPresenterWithDisplay).toBe("function");
+  });
+
+  it("exports display placement retry helpers", () => {
+    const overlay: PlacementOverlay = { remove: () => undefined };
+    const fullscreen: RequestFullscreen = () => undefined;
+    const show: ShowPlacementOverlay = () => overlay;
+    const options: PlaceWindowsOptions = {
+      details: {
+        currentScreen: { availLeft: 0, availTop: 0, availWidth: 1, availHeight: 1 },
+        screens: [{ availLeft: 0, availTop: 0, availWidth: 1, availHeight: 1 }]
+      },
+      popup: null,
+      requestFullscreen: fullscreen
+    };
+
+    expect(typeof placeWindows).toBe("function");
+    expect(typeof showPlacementOverlay).toBe("function");
+    expect(show).toBeTypeOf("function");
+    expect(options.popup).toBeNull();
   });
 });

--- a/packages/peitho-present/test/presentDisplay.test.ts
+++ b/packages/peitho-present/test/presentDisplay.test.ts
@@ -1,9 +1,16 @@
-import { expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import {
   buildPresenterFeatures,
   chooseOtherScreen,
-  openPresenterWithDisplay
+  openPresenterWithDisplay,
+  placeWindows,
+  showPlacementOverlay
 } from "../src/presentDisplay";
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
 
 it("compiles the minimal window management types", () => {
   const screen: ScreenDetailed = {
@@ -61,6 +68,77 @@ it("chooses a non-current screen when one exists", () => {
   expect(chooseOtherScreen({ currentScreen: current, screens: [current, other] })).toBe(other);
 });
 
+it("places the slide fullscreen on the other screen and popup on the current screen", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const requestFullscreen = vi.fn(async () => undefined);
+
+  await placeWindows({
+    details: { currentScreen: current, screens: [current, other] },
+    popup,
+    requestFullscreen
+  });
+
+  expect(requestFullscreen).toHaveBeenCalledWith({ screen: other });
+  expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
+  expect(popup.resizeTo).toHaveBeenCalledWith(1200, 800);
+});
+
+it("does nothing when there is no other screen", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const requestFullscreen = vi.fn();
+
+  await placeWindows({
+    details: { currentScreen: current, screens: [current] },
+    popup,
+    requestFullscreen
+  });
+
+  expect(requestFullscreen).not.toHaveBeenCalled();
+  expect(popup.moveTo).not.toHaveBeenCalled();
+  expect(popup.resizeTo).not.toHaveBeenCalled();
+});
+
+it("shows a visible placement overlay and invokes the retry on click", async () => {
+  const retry = vi.fn(async () => undefined);
+  const overlay = showPlacementOverlay(document, retry);
+  const button = document.querySelector<HTMLButtonElement>("[data-peitho-place-overlay]");
+
+  expect(button).not.toBeNull();
+  expect(button?.textContent).toContain("Click to place windows");
+  expect(button?.textContent).toContain("クリックで画面を配置");
+
+  button?.click();
+  await Promise.resolve();
+
+  expect(retry).toHaveBeenCalledTimes(1);
+  overlay.remove();
+  expect(document.querySelector("[data-peitho-place-overlay]")).toBeNull();
+});
+
 it("opens the popup before awaiting screen details, then places windows on two screens", async () => {
   const current: ScreenDetailed = {
     availLeft: 0,
@@ -104,6 +182,112 @@ it("opens the popup before awaiting screen details, then places windows on two s
   expect(requestFullscreen).toHaveBeenCalledWith({ screen: other });
   expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
   expect(popup.resizeTo).toHaveBeenCalledWith(1200, 800);
+});
+
+it("shows overlay after NotAllowedError and retries placement from the overlay click", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const requestFullscreen = vi.fn(async (_options?: FullscreenOptions) => undefined);
+  requestFullscreen
+    .mockRejectedValueOnce(new DOMException("activation expired", "NotAllowedError"))
+    .mockResolvedValueOnce(undefined);
+  const captured: { retry?: () => Promise<void> } = {};
+  const overlay = { remove: vi.fn() };
+  const showPlacementOverlay = vi.fn((nextRetry: () => Promise<void>) => {
+    captured.retry = nextRetry;
+    return overlay;
+  });
+
+  await openPresenterWithDisplay({
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    openWindow: vi.fn(() => popup),
+    requestFullscreen,
+    showPlacementOverlay
+  });
+
+  expect(showPlacementOverlay).toHaveBeenCalledTimes(1);
+  expect(popup.moveTo).not.toHaveBeenCalled();
+  const retry = captured.retry;
+  expect(retry).not.toBeNull();
+  if (!retry) throw new Error("retry was not captured");
+
+  await retry();
+
+  expect(requestFullscreen).toHaveBeenNthCalledWith(2, { screen: other });
+  expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
+  expect(popup.resizeTo).toHaveBeenCalledWith(1200, 800);
+  expect(overlay.remove).toHaveBeenCalledTimes(1);
+});
+
+it("does not show overlay when the first placement succeeds", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const popup = {
+    moveTo: vi.fn(),
+    resizeTo: vi.fn()
+  };
+  const showPlacementOverlay = vi.fn();
+
+  await openPresenterWithDisplay({
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    openWindow: vi.fn(() => popup),
+    requestFullscreen: vi.fn(async () => undefined),
+    showPlacementOverlay
+  });
+
+  expect(showPlacementOverlay).not.toHaveBeenCalled();
+  expect(popup.moveTo).toHaveBeenCalledWith(0, 0);
+});
+
+it("does not show overlay when popup is blocked", async () => {
+  const current: ScreenDetailed = {
+    availLeft: 0,
+    availTop: 0,
+    availWidth: 1440,
+    availHeight: 900
+  };
+  const other: ScreenDetailed = {
+    availLeft: 1440,
+    availTop: 0,
+    availWidth: 1920,
+    availHeight: 1080
+  };
+  const showPlacementOverlay = vi.fn();
+
+  await openPresenterWithDisplay({
+    getScreenDetails: async () => ({ currentScreen: current, screens: [current, other] }),
+    openWindow: vi.fn(() => null),
+    requestFullscreen: vi.fn(async () => {
+      throw new DOMException("activation expired", "NotAllowedError");
+    }),
+    showPlacementOverlay
+  });
+
+  expect(showPlacementOverlay).not.toHaveBeenCalled();
 });
 
 it("falls back to popup only when the api is absent", async () => {


### PR DESCRIPTION
## Summary

Root-cause fixes for the author's real-hardware feedback on a two-display setup ("doesn't go fullscreen, the presenter view appears on the same display").

**1. `--start-fullscreen` had no effect**
Because on Chrome flag-handoff to an already-running instance, only `--app` takes effect. Attach a **dedicated profile** (`--user-data-dir=$HOME/.peitho/chrome-profile` + `--no-first-run --no-default-browser-check`) to Chrome-family launches so a fresh process is always spawned, letting `--app` + `--start-fullscreen` take effect reliably. Side effect: **the screen-management permission persists on the profile**, so subsequent presentations skip the permission prompt for a one-click placement. If creating the profile directory fails, warn and fall back to a no-profile launch (browser profiles are machine-level state, so they live under $HOME, not the cwd's `.peitho/`)

**2. Slides not moving to the external display**
`requestFullscreen` is also subject to transient user activation, and the click's validity was expiring while waiting for the initial permission dialog — silently failing with `NotAllowedError`. Instead of swallowing the failure, we show a full-screen **"Click to place windows / クリックで画面を配置"** overlay and re-run placement on that fresh click (external fullscreen + presenter moveTo/resizeTo locally). The overlay is only removed on success. On popup block / permission denial, fall back as before

## Expected UX

- First time only: click Presenter → approve the permission dialog → one click on "Click to place windows"
- Subsequently: Presenter click alone gives "slides = external fullscreen, presenter = local"

## Verification

- All gates green (Rust 3 runs / TS 63 tests / clippy / fmt / bindings drift)
- Real browser: verified the overlay's display, that a click re-triggers, and that it's removed after success (a single-display environment; the two-display placement success path is pinned by mock-injected tests)
- **Please re-verify on two-display real hardware** (this run is the first launch on the dedicated profile, so the first time will still include a permission dialog + placement click)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
