### PR TITLE
Esc ends the presentation by closing both windows

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -293,6 +293,7 @@ pub fn render_present_index() -> String {
   <script type="module">
     import {
       installCanvasClickNavigation,
+      installCloseOnEscape,
       installFullscreenShortcut,
       installKeyboardNavigation,
       installPresentationControls,
@@ -316,6 +317,7 @@ pub fn render_present_index() -> String {
       const root = document.getElementById('peitho-present-root');
       try {
         window.peithoNotes = await fetchOk('notes.json').then((response) => response.json());
+        installCloseOnEscape(window);
         installKeyboardNavigation(window);
         installSyncBridge(window, serverSyncChannelFactory());
         installPresentationControls({ root, window, document });
@@ -358,7 +360,7 @@ pub fn render_presenter_index() -> String {
   <main id="peitho-presenter-root"></main>
   <!-- Runtime presenter controls include data-peitho-action="close". -->
   <script type="module">
-    import { mountPresenterView, serverSyncChannelFactory } from './shell.js';
+    import { installCloseOnEscape, mountPresenterView, serverSyncChannelFactory } from './shell.js';
 
     function showError(message) {
       const root = document.getElementById('peitho-presenter-root');
@@ -375,6 +377,7 @@ pub fn render_presenter_index() -> String {
       const root = document.getElementById('peitho-presenter-root');
       try {
         const notes = await fetchOk('notes.json').then((response) => response.json());
+        installCloseOnEscape(window);
         await mountPresenterView({
           root,
           notes,
@@ -550,6 +553,7 @@ mod tests {
         assert!(html.contains("installPresentationControls"));
         assert!(html.contains("installCanvasClickNavigation"));
         assert!(html.contains("installFullscreenShortcut"));
+        assert!(html.contains("installCloseOnEscape(window)"));
         assert!(html.contains("fetchOk('notes.json')"));
         assert!(html.contains("await mountPresentShell({ root })"));
         assert!(html.contains("installKeyboardNavigation(window)"));
@@ -571,9 +575,10 @@ mod tests {
 
         assert!(html.contains(r#"<main id="peitho-presenter-root"></main>"#));
         assert!(html.contains(
-            r#"import { mountPresenterView, serverSyncChannelFactory } from './shell.js';"#
+            r#"import { installCloseOnEscape, mountPresenterView, serverSyncChannelFactory } from './shell.js';"#
         ));
         assert!(html.contains("fetchOk('notes.json')"));
+        assert!(html.contains("installCloseOnEscape(window)"));
         assert!(html.contains("await mountPresenterView({"));
         assert!(html.contains("syncChannelFactory: serverSyncChannelFactory()"));
         assert!(html.contains(r#"data-peitho-action="close""#));

--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -53,6 +53,11 @@ impl SyncHub {
             message: state.latest.clone().expect("latest sync message"),
         })
     }
+
+    fn current_seq(&self) -> u64 {
+        let (lock, _) = &*self.state;
+        lock.lock().expect("sync hub mutex").seq
+    }
 }
 
 pub(crate) fn resolve_request_path(root: &Path, url: &str) -> Option<PathBuf> {
@@ -135,7 +140,7 @@ impl PresentServer {
         let path = request.url().split('?').next().unwrap_or(request.url());
         match (request.method(), path) {
             (&Method::Get, "/sync") => {
-                self.respond_sync_poll(request);
+                self.respond_sync_get(request);
                 return;
             }
             (&Method::Post, "/sync") => {
@@ -152,11 +157,18 @@ impl PresentServer {
         self.respond_static(request);
     }
 
-    fn respond_sync_poll(&self, request: tiny_http::Request) {
-        let Some(seq) = sync_seq(request.url()) else {
+    fn respond_sync_get(&self, request: tiny_http::Request) {
+        let Some(sync_get) = sync_get(request.url()) else {
             send_response(
                 request,
                 Response::from_string("invalid sync seq\n").with_status_code(StatusCode(400)),
+            );
+            return;
+        };
+        let SyncGet::Poll(seq) = sync_get else {
+            send_json_response(
+                request,
+                format!(r#"{{"seq":{},"message":null}}"#, self.sync.current_seq()),
             );
             return;
         };
@@ -164,14 +176,8 @@ impl PresentServer {
         thread::spawn(
             move || match sync.wait_after(seq, Duration::from_secs(30)) {
                 Some(event) => {
-                    let Ok(header) =
-                        Header::from_bytes("Content-Type", "application/json; charset=utf-8")
-                    else {
-                        eprintln!("warning: failed to build Content-Type header");
-                        return;
-                    };
                     let body = format!(r#"{{"seq":{},"message":{}}}"#, event.seq, event.message);
-                    send_response(request, Response::from_string(body).with_header(header));
+                    send_json_response(request, body);
                 }
                 None => send_response(request, Response::empty(StatusCode(204))),
             },
@@ -194,6 +200,13 @@ impl PresentServer {
             );
             return;
         };
+        if !message.is_valid() {
+            send_response(
+                request,
+                Response::from_string("invalid sync body\n").with_status_code(StatusCode(400)),
+            );
+            return;
+        }
         let json = serde_json::to_string(&message).expect("SyncMessage serializes");
         self.sync.broadcast(&json);
         send_response(request, Response::empty(StatusCode(204)));
@@ -226,27 +239,62 @@ impl PresentServer {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SyncMessage {
+    Index(SyncIndexMessage),
+    Close(SyncCloseMessage),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct SyncMessage {
+struct SyncIndexMessage {
     index: usize,
 }
 
-fn sync_seq(url: &str) -> Option<u64> {
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SyncCloseMessage {
+    close: bool,
+}
+
+impl SyncMessage {
+    fn is_valid(&self) -> bool {
+        !matches!(self, Self::Close(message) if !message.close)
+    }
+}
+
+enum SyncGet {
+    Handshake,
+    Poll(u64),
+}
+
+fn sync_get(url: &str) -> Option<SyncGet> {
     let Some((_, query)) = url.split_once('?') else {
-        return Some(0);
+        return Some(SyncGet::Handshake);
     };
     if query.is_empty() {
-        return Some(0);
+        return Some(SyncGet::Handshake);
     }
     for pair in query.split('&') {
         let Some((key, value)) = pair.split_once('=') else {
             continue;
         };
         if key == "seq" {
-            return value.parse().ok();
+            if value.is_empty() || value == "now" {
+                return Some(SyncGet::Handshake);
+            }
+            return value.parse().ok().map(SyncGet::Poll);
         }
     }
-    Some(0)
+    Some(SyncGet::Handshake)
+}
+
+fn send_json_response(request: tiny_http::Request, body: String) {
+    let Ok(header) = Header::from_bytes("Content-Type", "application/json; charset=utf-8") else {
+        eprintln!("warning: failed to build Content-Type header");
+        return;
+    };
+    send_response(request, Response::from_string(body).with_header(header));
 }
 
 fn send_response<R>(request: tiny_http::Request, response: Response<R>)
@@ -321,10 +369,18 @@ mod tests {
     }
 
     #[test]
-    fn parses_sync_seq_query() {
-        assert_eq!(sync_seq("/sync"), Some(0));
-        assert_eq!(sync_seq("/sync?seq=42"), Some(42));
-        assert_eq!(sync_seq("/sync?other=x&seq=7"), Some(7));
-        assert_eq!(sync_seq("/sync?seq=nope"), None);
+    fn parses_sync_get_query() {
+        assert!(matches!(sync_get("/sync"), Some(SyncGet::Handshake)));
+        assert!(matches!(sync_get("/sync?seq="), Some(SyncGet::Handshake)));
+        assert!(matches!(
+            sync_get("/sync?seq=now"),
+            Some(SyncGet::Handshake)
+        ));
+        assert!(matches!(sync_get("/sync?seq=42"), Some(SyncGet::Poll(42))));
+        assert!(matches!(
+            sync_get("/sync?other=x&seq=7"),
+            Some(SyncGet::Poll(7))
+        ));
+        assert!(sync_get("/sync?seq=nope").is_none());
     }
 }

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -60,6 +60,9 @@ fn present_no_serve_writes_clean_present_cache() {
     assert!(fs::read_to_string(cache.join("present.html"))
         .unwrap()
         .contains("installSyncBridge(window, serverSyncChannelFactory())"));
+    assert!(fs::read_to_string(cache.join("present.html"))
+        .unwrap()
+        .contains("installCloseOnEscape(window)"));
 }
 
 #[test]
@@ -154,13 +157,7 @@ fn present_server_relays_sync_post_to_long_poll_subscriber() {
     poll.write_all(b"GET /sync?seq=0 HTTP/1.1\r\nHost: localhost\r\n\r\n")
         .unwrap();
 
-    let mut post = TcpStream::connect(addr).unwrap();
-    post.write_all(
-        b"POST /sync HTTP/1.0\r\nHost: localhost\r\nContent-Length: 11\r\n\r\n{\"index\":1}",
-    )
-    .unwrap();
-    let mut post_response = String::new();
-    post.read_to_string(&mut post_response).unwrap();
+    let post_response = post_sync(addr, r#"{"index":1}"#);
     assert!(post_response.contains("204 No Content"));
 
     let event = read_until_contains(&mut poll, r#""message":{"index":1}"#);
@@ -170,8 +167,66 @@ fn present_server_relays_sync_post_to_long_poll_subscriber() {
     assert!(event.contains(r#""message":{"index":1}"#));
 
     drop(poll);
-    drop(post);
     drop(handle);
+}
+
+#[test]
+fn present_server_relays_close_sync_post_to_long_poll_subscriber() {
+    let dir = tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("present.html"), "<!doctype html>").unwrap();
+
+    let server = peitho::server::PresentServer::bind(cache, 0).unwrap();
+    let addr = server.addr();
+    let handle = thread::spawn(move || server.serve_forever());
+
+    let mut poll = TcpStream::connect(addr).unwrap();
+    poll.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+    poll.write_all(b"GET /sync?seq=0 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .unwrap();
+
+    let post_response = post_sync(addr, r#"{"close":true}"#);
+    assert!(post_response.contains("204 No Content"));
+
+    let event = read_until_contains(&mut poll, r#""message":{"close":true}"#);
+    assert!(event.contains("200 OK"));
+    assert!(event.contains(r#""seq":1"#));
+    assert!(event.contains(r#""message":{"close":true}"#));
+
+    drop(poll);
+    drop(handle);
+}
+
+#[test]
+fn present_server_sync_handshake_returns_current_seq_without_replaying_latest_message() {
+    let dir = tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("present.html"), "<!doctype html>").unwrap();
+
+    let server = peitho::server::PresentServer::bind(cache, 0).unwrap();
+    let addr = server.addr();
+    let handle = thread::spawn(move || {
+        server.handle_one();
+        server.handle_one();
+    });
+
+    let post_response = post_sync(addr, r#"{"close":true}"#);
+    assert!(post_response.contains("204 No Content"));
+
+    let mut stream = TcpStream::connect(addr).unwrap();
+    stream
+        .write_all(b"GET /sync HTTP/1.0\r\nHost: localhost\r\n\r\n")
+        .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    assert!(response.contains("200 OK"));
+    assert!(response.contains(r#""seq":1"#));
+    assert!(response.contains(r#""message":null"#));
+    assert!(!response.contains(r#""close":true"#));
+    handle.join().unwrap();
 }
 
 #[test]
@@ -185,13 +240,24 @@ fn present_server_rejects_invalid_sync_post_body() {
     let addr = server.addr();
     let handle = thread::spawn(move || server.handle_one());
 
-    let mut post = TcpStream::connect(addr).unwrap();
-    post.write_all(
-        b"POST /sync HTTP/1.0\r\nHost: localhost\r\nContent-Length: 11\r\n\r\n{\"key\":\"x\"}",
-    )
-    .unwrap();
-    let mut response = String::new();
-    post.read_to_string(&mut response).unwrap();
+    let response = post_sync(addr, r#"{"key":"x"}"#);
+
+    assert!(response.contains("400 Bad Request"));
+    handle.join().unwrap();
+}
+
+#[test]
+fn present_server_rejects_mixed_sync_post_body() {
+    let dir = tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("present.html"), "<!doctype html>").unwrap();
+
+    let server = peitho::server::PresentServer::bind(cache, 0).unwrap();
+    let addr = server.addr();
+    let handle = thread::spawn(move || server.handle_one());
+
+    let response = post_sync(addr, r#"{"index":1,"close":true}"#);
 
     assert!(response.contains("400 Bad Request"));
     handle.join().unwrap();
@@ -278,13 +344,16 @@ fn repository_example_present_no_serve_smoke() {
     assert!(present_html.contains("installPresentationControls"));
     assert!(present_html.contains("installCanvasClickNavigation"));
     assert!(present_html.contains("installFullscreenShortcut"));
+    assert!(present_html.contains("installCloseOnEscape(window)"));
     assert!(present_html.contains("serverSyncChannelFactory"));
     assert!(present_html.contains("data-peitho-action=\"close\""));
     assert!(!present_html.contains("peitho-presenter-link"));
     assert!(presenter_html.contains(".peitho-presenter-pane"));
+    assert!(presenter_html.contains("installCloseOnEscape(window)"));
     assert!(presenter_html.contains("serverSyncChannelFactory"));
     assert!(shell_js.contains("CANVAS_WIDTH"));
     assert!(shell_js.contains("installPresentationControls"));
+    assert!(shell_js.contains("installCloseOnEscape"));
     assert!(shell_js.contains("openPresenterPopup"));
     assert!(shell_js.contains("serverSyncChannelFactory"));
     assert!(shell_js.contains(r#"data-peitho-action="close""#));
@@ -364,4 +433,18 @@ fn read_until_contains(stream: &mut TcpStream, needle: &str) -> String {
         out.push_str(&String::from_utf8_lossy(&buf[..len]));
     }
     out
+}
+
+fn post_sync(addr: std::net::SocketAddr, body: &str) -> String {
+    let mut post = TcpStream::connect(addr).unwrap();
+    write!(
+        post,
+        "POST /sync HTTP/1.0\r\nHost: localhost\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    )
+    .unwrap();
+    let mut response = String::new();
+    post.read_to_string(&mut response).unwrap();
+    response
 }

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -22,7 +22,7 @@ export {
   PRESENTER_URL
 } from "./presentDisplay";
 export type { OpenPresenterPopupOptions } from "./presentDisplay";
-export { installKeyboardNavigation } from "./keyboard";
+export { installCloseOnEscape, installKeyboardNavigation } from "./keyboard";
 export { mountPresenterView } from "./presenter";
 export { mountPresentShell } from "./shell";
 export { installSyncBridge, serverSyncChannelFactory } from "./sync";

--- a/packages/peitho-present/src/keyboard.ts
+++ b/packages/peitho-present/src/keyboard.ts
@@ -23,3 +23,13 @@ export function installKeyboardNavigation(
   win.addEventListener("keydown", onKeyDown);
   return () => win.removeEventListener("keydown", onKeyDown);
 }
+
+export function installCloseOnEscape(win: Window = window, bus: EventTarget = win): () => void {
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
+  };
+  win.addEventListener("keydown", onKeyDown);
+  return () => win.removeEventListener("keydown", onKeyDown);
+}

--- a/packages/peitho-present/src/sync.ts
+++ b/packages/peitho-present/src/sync.ts
@@ -1,4 +1,4 @@
-export type SyncMessage = { index: number };
+export type SyncMessage = { index: number } | { close: true };
 
 export type SyncChannel = {
   onmessage: ((event: { data: unknown }) => void) | null;
@@ -21,6 +21,18 @@ type ServerSyncPollResponse = {
   seq: number;
   message: unknown;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isCloseSyncMessage(value: unknown): value is { close: true } {
+  return isRecord(value) && value.close === true;
+}
+
+function isIndexSyncMessage(value: unknown): value is { index: number } {
+  return isRecord(value) && typeof value.index === "number";
+}
 
 function defaultChannelFactory(name: string): SyncChannel {
   const channel = new BroadcastChannel(name);
@@ -67,7 +79,36 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
         }, retryMs);
       });
 
+    const handshake = async (): Promise<boolean> => {
+      try {
+        const response = await fetcher(url);
+        if (closed) return false;
+        if (!response.ok) {
+          console.error(`Failed to start sync polling: ${response.status}`);
+          await delay();
+          return false;
+        }
+        const body = (await response.json()) as Partial<ServerSyncPollResponse>;
+        if (typeof body.seq !== "number") {
+          console.error("Invalid peitho sync handshake");
+          await delay();
+          return false;
+        }
+        seq = body.seq;
+        return true;
+      } catch (error: unknown) {
+        if (!closed) {
+          console.error(`Failed to start sync polling: ${String(error)}`);
+          await delay();
+        }
+        return false;
+      }
+    };
+
     const poll = async (): Promise<void> => {
+      while (!closed && !(await handshake())) {
+        continue;
+      }
       while (!closed) {
         abortController = new AbortControllerCtor();
         try {
@@ -110,7 +151,8 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
         void fetcher(url, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(message)
+          body: JSON.stringify(message),
+          keepalive: true
         })
           .then((response) => {
             if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
@@ -134,7 +176,8 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
 export function installSyncBridge(
   win: Window = window,
   channelFactory: SyncChannelFactory = defaultChannelFactory,
-  bus: EventTarget = win
+  bus: EventTarget = win,
+  closeWindow: () => void = () => win.close()
 ): () => void {
   const channel = channelFactory("peitho-sync");
   const onSlideChange = (event: Event): void => {
@@ -142,17 +185,28 @@ export function installSyncBridge(
     if (typeof detail?.index !== "number") return;
     channel.postMessage({ index: detail.index });
   };
+  const onCloseRequest = (): void => {
+    channel.postMessage({ close: true });
+  };
   channel.onmessage = (event: { data: unknown }): void => {
-    const data = event.data as Partial<SyncMessage>;
-    if (typeof data.index !== "number") {
-      console.error("Invalid peitho sync message");
+    const data = event.data;
+    if (isCloseSyncMessage(data)) {
+      closeWindow();
       return;
     }
-    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: data.index } } }));
+    if (isIndexSyncMessage(data)) {
+      bus.dispatchEvent(
+        new CustomEvent("peitho:navigate", { detail: { to: { index: data.index } } })
+      );
+      return;
+    }
+    console.error("Invalid peitho sync message");
   };
   bus.addEventListener("peitho:slidechange", onSlideChange);
+  bus.addEventListener("peitho:closerequest", onCloseRequest);
   return () => {
     bus.removeEventListener("peitho:slidechange", onSlideChange);
+    bus.removeEventListener("peitho:closerequest", onCloseRequest);
     channel.onmessage = null;
     channel.close();
   };

--- a/packages/peitho-present/test/generated.test.ts
+++ b/packages/peitho-present/test/generated.test.ts
@@ -7,6 +7,7 @@ import {
   fallbackFeatures,
   installCanvasClickNavigation,
   installCanvasScaler,
+  installCloseOnEscape,
   installFullscreenShortcut,
   installPresentationControls,
   mountPresenterView,
@@ -68,6 +69,7 @@ describe("generated manifest contract", () => {
     expect(typeof installCanvasScaler).toBe("function");
     expect(typeof installPresentationControls).toBe("function");
     expect(typeof installCanvasClickNavigation).toBe("function");
+    expect(typeof installCloseOnEscape).toBe("function");
     expect(typeof installFullscreenShortcut).toBe("function");
     expect(typeof mountPresentShell).toBe("function");
     expect(typeof mountPresenterView).toBe("function");

--- a/packages/peitho-present/test/sync.test.ts
+++ b/packages/peitho-present/test/sync.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, expect, it, vi } from "vitest";
-import { installSyncBridge, mountPresentShell, serverSyncChannelFactory } from "../src/index";
+import {
+  installCloseOnEscape,
+  installSyncBridge,
+  mountPresentShell,
+  serverSyncChannelFactory
+} from "../src/index";
 import type { PresentShell } from "../src/index";
 import type { SyncChannel } from "../src/sync";
 
@@ -50,6 +55,7 @@ function mockChannel() {
 it("server sync channel posts local messages to /sync", async () => {
   const fetcher = vi.fn((url: string, init?: RequestInit) => {
     if (init?.method === "POST") return Promise.resolve({ ok: true, status: 204 } as Response);
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 0, message: null }));
     return new Promise<Response>(() => undefined);
   }) as typeof fetch;
   const factory = serverSyncChannelFactory({
@@ -63,7 +69,8 @@ it("server sync channel posts local messages to /sync", async () => {
   expect(fetcher).toHaveBeenCalledWith("/sync", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ index: 2 })
+    body: JSON.stringify({ index: 2 }),
+    keepalive: true
   });
   channel.close();
 });
@@ -71,8 +78,9 @@ it("server sync channel posts local messages to /sync", async () => {
 it("server sync channel polls and forwards long-poll messages", async () => {
   const fetcher = vi.fn((url: string, init?: RequestInit) => {
     if (init?.method === "POST") return Promise.resolve({ ok: true, status: 204 } as Response);
-    if (url === "/sync?seq=0") {
-      return Promise.resolve(okJson({ seq: 1, message: { index: 1 } }));
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return Promise.resolve(okJson({ seq: 6, message: { index: 1 } }));
     }
     return new Promise<Response>(() => undefined);
   }) as typeof fetch;
@@ -85,14 +93,35 @@ it("server sync channel polls and forwards long-poll messages", async () => {
 
   await vi.waitFor(() => expect(received).toEqual([{ index: 1 }]));
 
-  expect(fetcher).toHaveBeenCalledWith("/sync?seq=0", expect.objectContaining({ signal: expect.any(AbortSignal) }));
-  expect(fetcher).toHaveBeenCalledWith("/sync?seq=1", expect.objectContaining({ signal: expect.any(AbortSignal) }));
+  expect(fetcher).toHaveBeenCalledWith("/sync");
+  expect(fetcher).toHaveBeenCalledWith("/sync?seq=5", expect.objectContaining({ signal: expect.any(AbortSignal) }));
+  expect(fetcher).toHaveBeenCalledWith("/sync?seq=6", expect.objectContaining({ signal: expect.any(AbortSignal) }));
   channel.close();
 });
 
-it("server sync channel aborts the active poll on close", () => {
+it("server sync channel does not replay backlog close messages after handshake", async () => {
+  const fetcher = vi.fn((url: string) => {
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 9, message: null }));
+    if (url === "/sync?seq=9") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected poll url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() =>
+    expect(fetcher).toHaveBeenCalledWith("/sync?seq=9", expect.objectContaining({ signal: expect.any(AbortSignal) }))
+  );
+
+  expect(received).toEqual([]);
+  expect(fetcher).not.toHaveBeenCalledWith("/sync?seq=0", expect.anything());
+  channel.close();
+});
+
+it("server sync channel aborts the active poll on close", async () => {
   const captured: { signal?: AbortSignal } = {};
-  const fetcher = vi.fn((_url: string, init?: RequestInit) => {
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 0, message: null }));
     captured.signal = init?.signal as AbortSignal;
     return new Promise<Response>(() => undefined);
   }) as typeof fetch;
@@ -100,8 +129,9 @@ it("server sync channel aborts the active poll on close", () => {
     fetcher
   })("peitho-sync");
 
-  channel.close();
+  await vi.waitFor(() => expect(captured.signal).toBeInstanceOf(AbortSignal));
 
+  channel.close();
   if (!captured.signal) throw new Error("poll signal was not captured");
   expect(captured.signal.aborted).toBe(true);
 });
@@ -124,6 +154,40 @@ it("posts local slidechange index to peitho-sync", async () => {
   window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
 
   expect(channel.sent).toEqual([{ index: 1 }]);
+});
+
+it("dispatches closerequest from Escape", () => {
+  const bus = new EventTarget();
+  const requests: unknown[] = [];
+  bus.addEventListener("peitho:closerequest", (event) => requests.push((event as CustomEvent).detail));
+  const cleanup = installCloseOnEscape(window, bus);
+  cleanups.push(cleanup);
+
+  window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+  expect(requests).toEqual([null]);
+});
+
+it("posts close sync messages from closerequest", () => {
+  const channel = mockChannel();
+  const bus = new EventTarget();
+  const cleanup = installSyncBridge(window, () => channel, bus);
+  cleanups.push(cleanup);
+
+  bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
+
+  expect(channel.sent).toEqual([{ close: true }]);
+});
+
+it("closes the window when a remote close sync message arrives", () => {
+  const channel = mockChannel();
+  const closeWindow = vi.fn();
+  const cleanup = installSyncBridge(window, () => channel, window, closeWindow);
+  cleanups.push(cleanup);
+
+  channel.onmessage?.({ data: { close: true } });
+
+  expect(closeWindow).toHaveBeenCalledTimes(1);
 });
 
 it("turns remote index messages into navigate requests", () => {


### PR DESCRIPTION
## Summary

Implements the author's request "Esc closes both windows".

- Esc in either window → `peitho:closerequest` (UI parts only emit events; §16's layering preserved) → the sync bridge POSTs `{close:true}` to the server → **all windows (including the sender, via its own long poll) receive it and call `window.close()`**. A symmetric, centralized exit path
- Extends the sync protocol to `{index} | {close:true}` (a mixed body is 400). POSTs use `keepalive: true` so the send survives even during close
- Adds a **join handshake** (a `GET /sync` with no query returns the current seq immediately): while E2E-debugging, I found that a window opened after a close broadcast would receive the stale close from the backlog and immediately die. Close is an edge event and must not be replayed on join
- Not added to the distribution index.html (Esc while browsing shouldn't close)

## E2E verification (two real displays)

- Close broadcast → all window connections go from 6 to 0. Verified via screenshot that the fullscreen slide on the external display disappears
- A window opened **after** a close broadcast survives, and closes on the next broadcast
- All gates green (Rust 3 runs / TS 57 tests / clippy / fmt / bindings drift)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
