### PR TITLE
Esc also stops the local present server

### DIFF
--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    io::Read,
+    io::{Read, Write},
     net::SocketAddr,
     path::{Component, Path, PathBuf},
     sync::{Arc, Condvar, Mutex},
@@ -97,7 +97,7 @@ pub(crate) fn content_type(path: &Path) -> &'static str {
 
 pub struct PresentServer {
     root: PathBuf,
-    server: Server,
+    server: Arc<Server>,
     sync: SyncHub,
 }
 
@@ -107,7 +107,7 @@ impl PresentServer {
             .map_err(|err| miette::miette!("failed to bind present server: {err}"))?;
         Ok(Self {
             root,
-            server,
+            server: Arc::new(server),
             sync: SyncHub::default(),
         })
     }
@@ -125,18 +125,19 @@ impl PresentServer {
 
     pub fn serve_forever(self) -> miette::Result<()> {
         for request in self.server.incoming_requests() {
-            self.respond(request);
+            self.respond(request, Some(ShutdownHandle::new(self.server.clone())));
         }
+        let _ = writeln!(std::io::stdout(), "presentation ended");
         Ok(())
     }
 
     pub fn handle_one(&self) {
         if let Some(request) = self.server.incoming_requests().next() {
-            self.respond(request);
+            self.respond(request, None);
         }
     }
 
-    fn respond(&self, request: tiny_http::Request) {
+    fn respond(&self, request: tiny_http::Request, shutdown: Option<ShutdownHandle>) {
         let path = request.url().split('?').next().unwrap_or(request.url());
         match (request.method(), path) {
             (&Method::Get, "/sync") => {
@@ -144,7 +145,7 @@ impl PresentServer {
                 return;
             }
             (&Method::Post, "/sync") => {
-                self.respond_sync_post(request);
+                self.respond_sync_post(request, shutdown);
                 return;
             }
             _ => {}
@@ -184,7 +185,7 @@ impl PresentServer {
         );
     }
 
-    fn respond_sync_post(&self, mut request: tiny_http::Request) {
+    fn respond_sync_post(&self, mut request: tiny_http::Request, shutdown: Option<ShutdownHandle>) {
         let mut body = String::new();
         if request.as_reader().read_to_string(&mut body).is_err() {
             send_response(
@@ -210,6 +211,11 @@ impl PresentServer {
         let json = serde_json::to_string(&message).expect("SyncMessage serializes");
         self.sync.broadcast(&json);
         send_response(request, Response::empty(StatusCode(204)));
+        if matches!(message, SyncMessage::Close(_)) {
+            if let Some(shutdown) = shutdown {
+                shutdown.start();
+            }
+        }
     }
 
     fn respond_static(&self, request: tiny_http::Request) {
@@ -235,6 +241,23 @@ impl PresentServer {
                 );
             }
         }
+    }
+}
+
+struct ShutdownHandle {
+    server: Arc<Server>,
+}
+
+impl ShutdownHandle {
+    fn new(server: Arc<Server>) -> Self {
+        Self { server }
+    }
+
+    fn start(self) {
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(500));
+            self.server.unblock();
+        });
     }
 }
 

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -6,7 +6,7 @@ use std::{
     path::PathBuf,
     sync::mpsc,
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use assert_cmd::Command;
@@ -199,6 +199,23 @@ fn present_server_relays_close_sync_post_to_long_poll_subscriber() {
 }
 
 #[test]
+fn present_server_shuts_down_after_close_sync_post() {
+    let dir = tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("present.html"), "<!doctype html>").unwrap();
+
+    let server = peitho::server::PresentServer::bind(cache, 0).unwrap();
+    let addr = server.addr();
+    let handle = thread::spawn(move || server.serve_forever());
+
+    let post_response = post_sync(addr, r#"{"close":true}"#);
+    assert!(post_response.contains("204 No Content"));
+
+    join_present_server(handle, Duration::from_secs(3));
+}
+
+#[test]
 fn present_server_sync_handshake_returns_current_seq_without_replaying_latest_message() {
     let dir = tempdir().unwrap();
     let cache = dir.path().join("cache");
@@ -285,11 +302,13 @@ fn present_no_open_server_prints_assigned_url() {
     let stdout = child.stdout.take().unwrap();
     let (tx, rx) = mpsc::channel();
     let reader = std::thread::spawn(move || {
+        let mut tx = Some(tx);
         for line in BufReader::new(stdout).lines() {
             let line = line.unwrap();
             if line.contains("serving presentation at") {
-                tx.send(line).unwrap();
-                break;
+                if let Some(tx) = tx.take() {
+                    tx.send(line).unwrap();
+                }
             }
         }
     });
@@ -302,6 +321,61 @@ fn present_no_open_server_prints_assigned_url() {
 
     assert!(line.contains("http://127.0.0.1:"));
     assert!(line.contains("/present.html"));
+}
+
+#[test]
+fn present_process_exits_after_close_sync_post() {
+    let dir = tempdir().unwrap();
+    let fixture = Fixture::write(dir.path());
+    let shell = dir.path().join("shell.js");
+    fs::write(
+        &shell,
+        "export function mountPresentShell() {}\nexport function installKeyboardNavigation() {}\nexport function installSyncBridge() {}\nexport function serverSyncChannelFactory() {}\n",
+    )
+    .unwrap();
+
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("peitho"))
+        .current_dir(dir.path())
+        .args(fixture.present_args(&shell))
+        .args(["--no-open", "--port", "0"])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = child.stdout.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut tx = Some(tx);
+        for line in BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            if line.contains("serving presentation at") {
+                if let Some(tx) = tx.take() {
+                    tx.send(line).unwrap();
+                }
+            }
+        }
+    });
+    let line = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("present server did not print serving URL within 5 seconds");
+    let addr = serving_addr(&line);
+
+    let post_response = post_sync(addr, r#"{"close":true}"#);
+    assert!(post_response.contains("204 No Content"));
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            assert!(status.success());
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "present process did not exit after close sync post"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    reader.join().unwrap();
 }
 
 #[test]
@@ -447,4 +521,27 @@ fn post_sync(addr: std::net::SocketAddr, body: &str) -> String {
     let mut response = String::new();
     post.read_to_string(&mut response).unwrap();
     response
+}
+
+fn join_present_server(handle: thread::JoinHandle<miette::Result<()>>, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while !handle.is_finished() {
+        assert!(
+            Instant::now() < deadline,
+            "present server did not stop within {timeout:?}"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    handle.join().unwrap().unwrap();
+}
+
+fn serving_addr(line: &str) -> std::net::SocketAddr {
+    let prefix = "serving presentation at http://";
+    let rest = line
+        .strip_prefix(prefix)
+        .unwrap_or_else(|| panic!("unexpected serving URL line: {line}"));
+    let host_port = rest
+        .strip_suffix("/present.html")
+        .unwrap_or_else(|| panic!("unexpected serving URL line: {line}"));
+    host_port.parse().unwrap()
 }


### PR DESCRIPTION
## Summary

Implements the author's request "Esc should also stop the local server". When the server receives a `{close:true}` sync message on Esc, it broadcasts to all windows → responds 204 → after a short grace (enough for the long-poll response to flush) → releases the accept loop (`Arc<Server>` + tiny_http's `unblock()`) → prints `presentation ended` and exits cleanly.

- `{index}` messages don't stop the server. Ctrl-C behaves as before
- Ending a presentation is now one keystroke: both windows close and the server process exits

## E2E verification (two real displays)

Launch (connections 15) → `POST {"close":true}` → both windows close + server process exits + `presentation ended` printed. All gates green (Rust 3 runs / clippy / fmt / TS typecheck).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
