### PR TITLE
docs: add README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# peitho
+
+Markdownをsource of truthとするHTMLネイティブなプレゼンツール。設計の正は `docs/PEITHO_KICKOFF.md`（キックオフ仕様書）。設計判断に迷ったら仕様書§18「未決定事項」を見て、載っていない新規判断は著者に確認する。
+
+## 三本柱（壊してはいけない不変条件）
+
+1. **コンテンツとデザインの分離**: コンテンツはMarkdown、デザインはテンプレートHTML+CSS。混ぜない
+2. **git管理可能なHTML/CSSテンプレート**: テンプレート自身がスキーマ（`<slot name accepts arity>`）。契約を別ファイルに分けない
+3. **型検査されるスロット契約とキー付きoverride**: スロット過不足・型不整合・参照切れ・未割当コンテンツは全て行番号+help付きビルドエラー。**サイレントドロップ絶対禁止**（パーサに`_ => {}`で未知構造を飲ませない）
+
+その他の不変条件:
+- typestate `Parsed→Mapped→Checked→Rendered`。相の構築子はcrate内私有。未検査デッキはレンダラに渡せない（compile_failドクテストで固定）
+- 契約の単一source: ドメイン型はpeitho-core(Rust)が正。TS型は`bindings/*.ts`にts-rsで生成しコミット。CIでdrift検査
+- §16イベント契約: 遷移の実行主体はシェルのみ。UI部品は`peitho:navigate`/`peitho:timercontrol`等の要求イベント発行のみ。スライド本体はシェルの存在を知らない
+- 配布物(dist/)に発表シェル・ノートを混ぜない（publishが非混入検査で門番）
+
+## 構成
+
+```
+crates/peitho-core/   契約・パイプライン(parser/template/mapping/check/render/theme/manifest/notes)
+crates/peitho/        CLI(build/present/publish)、server.rs(配信+/syncロングポール)、browser.rs、displays.rs
+packages/peitho-present/  TS発表シェル(canvas/shell/controls/keyboard/sync/presenter)
+bindings/             ts-rs生成TS型（コミット対象）
+templates/ themes/ examples/  共有レイアウト・baseテーマ・サンプル
+docs/plans/           各マイルストーンの実装計画（履歴）
+```
+
+## ゲート（全部通ってからコミット）
+
+```
+cargo test --workspace          # 3回連続（過去にテストレース事故あり）
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all --check
+git diff --exit-code bindings/  # 契約drift
+cd packages/peitho-present && npm run build && npm test && npm run typecheck
+```
+
+UX変更は必ず実ブラウザ/実ディスプレイでE2E確認する（jsdomはレイアウト・フラッシュ・ウィンドウ挙動を検出できない。過去に真っ黒画面・SSE不達・無限再ビルドをE2Eでのみ検出）。presentの確認は `--port`固定+`curl POST /sync`+`screencapture -x -D <n>` が便利。
+
+## ハマりどころ（実測で確定済みの事実。再調査不要）
+
+- **tiny_httpでSSEは不成立**: data_length Noneだと閾値以下のbodyをEOFまでバッファ、chunkエンコーダも小チャンクをflushしない。だから/syncはロングポーリング（`GET /sync?seq=N`、クエリ無しGETは現在seq即答=参加ハンドシェイク、`POST /sync`で`{index}|{close:true}`）
+- **Chrome既起動インスタンスへのフラグhandoffは`--app`しか効かない**: `--start-fullscreen`/`--window-position`/`--window-size`は無視される。確実に効かせるには別`--user-data-dir`で新規プロセス起動（だからslides/presenterは`~/.peitho/chrome-profile-{slides,presenter}`の2インスタンス）
+- **別プロファイル間はBroadcastChannelが届かない**: だから同期はサーバ経由（§15からの意図的拡張。層分け=DOMイベント⇔トランスポート橋渡しは不変）
+- **CLI起動のappウィンドウは`window.close()`で閉じられる**（履歴1エントリのため）。Escは`peitho:closerequest`→`{close:true}`全窓配信→各自close→サーバも猶予後にunblockして終了
+- **requestFullscreen/window.openはtransient user activation必須**: permission promptのawaitを挟むと失効する。ブラウザ内でのウィンドウ配置はこれで2敗した末にCLI主導へ転換した経緯（M8/M9/M10）
+- NSScreenはbottom-left原点。Chromeの`--window-position`はtop-left。変換は`displays.rs`（純関数+実測値テスト）
+- vitestテストではシェル/リスナーを必ずdestroy/cleanup（共有windowのリスナー汚染で多重発火する）
+- `.peitho/present-cache/`は毎回作り直し（§18キャッシュ方針の採用値）。`dist/slides/`もビルド毎にクリア（stale断片の公開漏れ防止）
+
+## 未決定・著者判断待ち（勝手に決めない）
+
+- スピーカーノートのMarkdown記法（notes.jsonスキーマ・TS型・presenter表示配線は実装済み、常に空）
+- fenced div明示スロット記法 `::: {slot=...}`（§18）
+- 型駆動レイアウトディスパッチ（§18）
+- シンタックスハイライタ選定
+- デッキ別リポジトリ運用の設定ファイル（peitho.toml等）とpeitho.gosu.keデプロイ
+
+残タスクはGitHub Issuesに登録済み。着手時は`docs/plans/`に計画を書いてから実装する。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# peitho
+
+Markdownをsource of truthとする、HTMLネイティブなプレゼンテーションツール。
+
+Peitho（ペイトー）は、力ではなく言葉で人の心を動かす力を司るギリシャ神話の女神。プレゼンテーションの本質に対応する。
+
+## 特徴
+
+- **コンテンツとデザインの分離** — コンテンツはMarkdown、デザインはHTMLテンプレートとCSS。両者を混ぜない
+- **git管理可能なテンプレート** — デザイン成果物はただのHTML/CSS。diffが取れ、レビューできる
+- **型検査されるスロット契約** — テンプレート自身がスキーマ。スロットの過不足・型不整合・参照切れ・余ったコンテンツは、黙って捨てられる代わりに行番号とヒント付きのビルドエラーになる
+
+```
+error: slide 2 ('code-slide'), line 7: slot 'code' got 2 item(s), but layout 'title-body-code' allows 0..1
+  = help: use a layout with more code capacity or remove one code block
+```
+
+- **安定キー起点のper-slide調整** — `<!-- {"key":"arch-1"} -->` で固定したキーをCSSから狙う。タイトルを直してもCSSは剥がれず、存在しないキーを狙えばビルドが止まる
+
+```css
+[data-slide-key="arch-1"] .slot-code {
+  grid-column: 2 / 3;
+  width: 60%;
+}
+```
+
+- **Keynote風の発表体験** — `peitho present` で、外部ディスプレイにスライドをフルスクリーン、手元に発表者ビュー（現在/次スライド・ノート・タイマー）を自動配置。Escで全終了
+
+## 使い方
+
+```sh
+# 配布物の生成（dist/ に slides/断片 + manifest.json + index.html + peitho.css）
+peitho build deck.md
+
+# 保存のたびに再ビルド
+peitho build deck.md --watch
+
+# 発表（揮発キャッシュ生成 + ローカルサーバ + ブラウザ起動。2画面なら自動配置）
+peitho present deck.md
+
+# 公開（検査してから既存のデプロイコマンドに委譲。デプロイは再発明しない）
+peitho publish -- aws s3 sync dist/ s3://your-bucket/
+```
+
+`peitho present` はTS製の発表シェルを使うため、初回のみバンドルのビルドが必要:
+
+```sh
+cd packages/peitho-present && npm ci && npm run build
+```
+
+## デッキの書き方
+
+規約マッピングにより、素のMarkdownがそのままスライドになる。スライド区切りは `---`、最も浅い見出しがタイトル、コードブロックはcodeスロット、残りはbodyへ。
+
+```markdown
+<!-- {"key":"intro"} -->
+# タイトル
+
+本文の段落。
+
+- リストも
+- 使える
+
+---
+
+# 次のスライド
+
+```rust
+enum Phase { Parsed, Mapped, Checked, Rendered }
+```
+```
+
+## アーキテクチャ
+
+```
+Markdown ─→ peitho build（解析・マッピング・4段検査。決定論的・純粋関数）
+              ├─ emit distribute → dist/（配布物のみ。シェル・ノート非混入）
+              └─ emit present    → .peitho/present-cache/（発表シェル・揮発）
+```
+
+- ビルドコアはRust（typestate: `Parsed→Mapped→Checked→Rendered`。未検査スライドはレンダラに渡せない）
+- 発表シェルはTypeScript。契約（manifest等のドメイン型）はRustが唯一のsourceで、`bindings/` にTS型を生成してdriftをCIで検査
+- 詳細な設計は `docs/PEITHO_KICKOFF.md` を参照
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- **README.md**: project intro (the name origin is phrased around the goddess Peitho's role), features (type-checked slot contracts, stable-key overrides, Keynote-style presenting), usage (build/watch/present/publish), how to write a deck, architecture overview
- **CLAUDE.md**: project guide for future sessions — the three pillars and invariants, the structure, pre-commit gates, **empirically confirmed pitfalls** (SSE not working over tiny_http → long polling, Chrome flag-handoff constraints → two-profile launches, BroadcastChannel's profile boundary, the two failed attempts at in-browser placement due to activation constraints — facts that need no re-investigation), items awaiting the author's judgment

Remaining tasks are registered as Issues #15–#23.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
