### PR TITLE
style: strip decorative styling from base theme code slot

### DIFF
--- a/themes/base.css
+++ b/themes/base.css
@@ -53,12 +53,9 @@
 .slot-code {
   display: block;
   margin: 0;
-  padding: 24px;
   max-height: 100%;
   box-sizing: border-box;
   overflow: hidden;
-  background: #111;
-  color: #f7f7f7;
   font-size: 22px;
   line-height: 1.35;
 }


### PR DESCRIPTION
## Summary

Drop the base-theme decoration (black background, white text, padding) attached to the rust code block in `examples/deck.md`. The base theme is intended to be overridden by the deck, so only the structural properties needed to maintain the fixed canvas layout (`overflow`, sizing, `margin`) are kept.

The orange outline in `themes/overrides.css` is a demo of the keyed-override feature and is retained.

## Verification

- cargo test --workspace ×3 in a row / clippy -D warnings / fmt --check / no bindings drift / npm build+test+typecheck all pass
- Real-browser E2E: build examples/deck.md and view in Chrome. The code block renders as plain monospace text; the keyed override (arch-1 outline) still applies

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
