### PR TITLE
style: drop two-column layout and demo override from base theme

### DIFF
--- a/themes/base.css
+++ b/themes/base.css
@@ -1,11 +1,9 @@
 .peitho-slide {
   width: 1280px;
   height: 720px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 470px;
-  grid-template-rows: auto minmax(0, 1fr);
-  column-gap: 56px;
-  row-gap: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
   padding: 64px 72px;
   box-sizing: border-box;
   overflow: hidden;
@@ -15,7 +13,6 @@
 }
 
 .peitho-slide h1 {
-  grid-column: 1 / -1;
   margin: 0;
   font-size: 56px;
   line-height: 1.05;
@@ -48,14 +45,12 @@
 .code {
   min-width: 0;
   margin: 0;
+  overflow: hidden;
 }
 
 .slot-code {
   display: block;
   margin: 0;
-  max-height: 100%;
-  box-sizing: border-box;
-  overflow: hidden;
   font-size: 22px;
   line-height: 1.35;
 }

--- a/themes/overrides.css
+++ b/themes/overrides.css
@@ -1,1 +1,0 @@
-[data-slide-key="arch-1"] .slot-code { outline: 3px solid #f40; }


### PR DESCRIPTION
## Summary

Remove two early design decisions still present in the base theme.

- **Retire the two-column layout**: drop the grid definition that pinned code to a 470px right column. title/body/code now flow top-to-bottom in a single column (flex column)
- **Empty `themes/overrides.css`**: the orange outline on arch-1 was a demo of keyed overrides, but the syntax is documented in the README and kickoff spec, so there's no need to keep a live example in the repo's theme file

## Verification

- cargo test --workspace ×3 in a row / clippy -D warnings / fmt --check / no bindings drift / npm build+test+typecheck all pass
- Real-browser E2E: build examples/deck.md and view all three slides in Chrome. The red outline is gone; code blocks sit left-aligned below the body

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
