### PR TITLE
feat: add --presenter-windowed debug mode to present

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ UX変更は必ず実ブラウザ/実ディスプレイでE2E確認する（jsdom
 
 - **tiny_httpでSSEは不成立**: data_length Noneだと閾値以下のbodyをEOFまでバッファ、chunkエンコーダも小チャンクをflushしない。だから/syncはロングポーリング（`GET /sync?seq=N`、クエリ無しGETは現在seq即答=参加ハンドシェイク、`POST /sync`で`{index}|{close:true}`）
 - **Chrome既起動インスタンスへのフラグhandoffは`--app`しか効かない**: `--start-fullscreen`/`--window-position`/`--window-size`は無視される。確実に効かせるには別`--user-data-dir`で新規プロセス起動（だからslides/presenterは`~/.peitho/chrome-profile-{slides,presenter}`の2インスタンス）
+- **macOSのChromeは全ウィンドウを閉じてもプロセスが残る**: 前回presentのインスタンスがpeithoプロファイルを掴んだままだと次回起動がhandoffになり配置フラグが全滅する。だからpresent起動時に残存プロセスを`pkill -f -- "--user-data-dir=<profile>"`でkillしてから開く（pkillはパターンが`--`始まりだと`--`セパレータ必須）
 - **別プロファイル間はBroadcastChannelが届かない**: だから同期はサーバ経由（§15からの意図的拡張。層分け=DOMイベント⇔トランスポート橋渡しは不変）
 - **CLI起動のappウィンドウは`window.close()`で閉じられる**（履歴1エントリのため）。Escは`peitho:closerequest`→`{close:true}`全窓配信→各自close→サーバも猶予後にunblockして終了
 - **requestFullscreen/window.openはtransient user activation必須**: permission promptのawaitを挟むと失効する。ブラウザ内でのウィンドウ配置はこれで2敗した末にCLI主導へ転換した経緯（M8/M9/M10）

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ peitho build deck.md --watch
 # 発表（揮発キャッシュ生成 + ローカルサーバ + ブラウザ起動。2画面なら自動配置）
 peitho present deck.md
 
+# デバッグ用: 発表者画面をフルスクリーンにせず1200x800の窓で開く
+peitho present deck.md --presenter-windowed
+
 # 公開（検査してから既存のデプロイコマンドに委譲。デプロイは再発明しない）
 peitho publish -- aws s3 sync dist/ s3://your-bucket/
 ```

--- a/crates/peitho/src/browser.rs
+++ b/crates/peitho/src/browser.rs
@@ -62,11 +62,19 @@ fn chrome_base_args(profile_dir: &Path, url: &str) -> Vec<OsString> {
     ]
 }
 
-fn push_window_position(args: &mut Vec<OsString>, placement: WindowPlacement) {
+fn push_placement_args(args: &mut Vec<OsString>, placement: WindowPlacement) {
     args.push(OsString::from(format!(
         "--window-position={},{}",
         placement.x, placement.y
     )));
+    if placement.fullscreen {
+        args.push(OsString::from("--start-fullscreen"));
+    } else {
+        args.push(OsString::from(format!(
+            "--window-size={},{}",
+            placement.width, placement.height
+        )));
+    }
 }
 
 fn chrome_slides_args(
@@ -75,10 +83,10 @@ fn chrome_slides_args(
     placement: Option<WindowPlacement>,
 ) -> Vec<OsString> {
     let mut args = chrome_base_args(profile_dir, url);
-    if let Some(placement) = placement {
-        push_window_position(&mut args, placement);
+    match placement {
+        Some(placement) => push_placement_args(&mut args, placement),
+        None => args.push(OsString::from("--start-fullscreen")),
     }
-    args.push(OsString::from("--start-fullscreen"));
     args
 }
 
@@ -88,8 +96,7 @@ fn chrome_presenter_args(
     placement: WindowPlacement,
 ) -> Vec<OsString> {
     let mut args = chrome_base_args(profile_dir, url);
-    push_window_position(&mut args, placement);
-    args.push(OsString::from("--start-fullscreen"));
+    push_placement_args(&mut args, placement);
     args
 }
 
@@ -223,6 +230,44 @@ fn current_environment() -> BrowserEnvironment {
     }
 }
 
+fn stale_profile_patterns(profiles: &ChromeProfiles) -> [String; 2] {
+    [
+        format!("--user-data-dir={}", profiles.slides.display()),
+        format!("--user-data-dir={}", profiles.presenter.display()),
+    ]
+}
+
+/// Chrome on macOS keeps running after its last window closes, so a previous
+/// `present` session leaves processes holding the peitho profiles. Launching
+/// into such a process hands off the URL and drops every flag except `--app`
+/// (window position, size, and fullscreen are silently ignored). Kill the
+/// stale processes so each session starts fresh ones that honor the flags.
+fn terminate_stale_profile_instances(profiles: &ChromeProfiles) {
+    let patterns = stale_profile_patterns(profiles);
+    let mut killed_any = false;
+    for pattern in &patterns {
+        if let Ok(status) = Command::new("pkill").args(["-f", "--", pattern]).status() {
+            killed_any |= status.success();
+        }
+    }
+    if !killed_any {
+        return;
+    }
+    for _ in 0..20 {
+        let any_alive = patterns.iter().any(|pattern| {
+            Command::new("pgrep")
+                .args(["-f", "--", pattern])
+                .output()
+                .map(|output| output.status.success())
+                .unwrap_or(false)
+        });
+        if !any_alive {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
 fn prepare_profile_dirs(profiles: Option<&ChromeProfiles>) -> bool {
     let Some(profiles) = profiles else {
         return false;
@@ -247,6 +292,9 @@ pub fn open_browser_with_request(
     env.layout = layout;
     if !prepare_profile_dirs(env.chrome_profiles.as_ref()) {
         env.chrome_profiles = None;
+    }
+    if let Some(profiles) = env.chrome_profiles.as_ref() {
+        terminate_stale_profile_instances(profiles);
     }
 
     let commands = plan_browser_commands(&request, &env);
@@ -291,9 +339,15 @@ mod tests {
                 y: 91,
                 width: 1200,
                 height: 800,
-                fullscreen: false,
+                fullscreen: true,
             },
         }
+    }
+
+    fn windowed_presenter_layout() -> PresentationLayout {
+        let mut layout = test_layout();
+        layout.presenter.fullscreen = false;
+        layout
     }
 
     fn test_request(no_presenter: bool) -> BrowserOpenRequest<'static> {
@@ -385,6 +439,33 @@ mod tests {
     }
 
     #[test]
+    fn windowed_presenter_placement_opens_sized_window_instead_of_fullscreen() {
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: true,
+            linux_browser: None,
+            chrome_profiles: Some(test_profiles()),
+            layout: Some(windowed_presenter_layout()),
+        };
+
+        let commands = plan_browser_commands(&test_request(false), &env);
+
+        assert_eq!(commands.len(), 2);
+        assert!(commands[0]
+            .args
+            .contains(&OsString::from("--start-fullscreen")));
+        assert!(commands[1]
+            .args
+            .contains(&OsString::from("--window-position=156,91")));
+        assert!(commands[1]
+            .args
+            .contains(&OsString::from("--window-size=1200,800")));
+        assert!(!commands[1]
+            .args
+            .contains(&OsString::from("--start-fullscreen")));
+    }
+
+    #[test]
     fn no_presenter_forces_single_slides_window() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Macos,
@@ -430,6 +511,17 @@ mod tests {
         assert_eq!(
             presenter_url("http://127.0.0.1:49152/present.html"),
             "http://127.0.0.1:49152/presenter.html"
+        );
+    }
+
+    #[test]
+    fn stale_profile_patterns_target_only_peitho_profile_dirs() {
+        assert_eq!(
+            stale_profile_patterns(&test_profiles()),
+            [
+                String::from("--user-data-dir=/Users/alice/.peitho/chrome-profile-slides"),
+                String::from("--user-data-dir=/Users/alice/.peitho/chrome-profile-presenter"),
+            ]
         );
     }
 

--- a/crates/peitho/src/displays.rs
+++ b/crates/peitho/src/displays.rs
@@ -76,7 +76,10 @@ fn convert_nsscreen_frames(frames: &[NsscreenFrame]) -> Vec<ChromeDisplay> {
         .collect()
 }
 
-pub fn plan_presentation_layout(displays: &[ChromeDisplay]) -> Option<PresentationLayout> {
+pub fn plan_presentation_layout(
+    displays: &[ChromeDisplay],
+    presenter_windowed: bool,
+) -> Option<PresentationLayout> {
     let primary = displays.iter().find(|display| display.primary)?;
     let slides = displays.iter().find(|display| !display.primary)?;
 
@@ -98,17 +101,20 @@ pub fn plan_presentation_layout(displays: &[ChromeDisplay]) -> Option<Presentati
             y: presenter_y,
             width: presenter_width,
             height: presenter_height,
-            fullscreen: false,
+            fullscreen: !presenter_windowed,
         },
     })
 }
 
-pub fn layout_from_jxa_output(stdout: &str) -> Option<PresentationLayout> {
+pub fn layout_from_jxa_output(
+    stdout: &str,
+    presenter_windowed: bool,
+) -> Option<PresentationLayout> {
     let displays = parse_nsscreen_json(stdout).ok()?;
-    plan_presentation_layout(&displays)
+    plan_presentation_layout(&displays, presenter_windowed)
 }
 
-pub fn detect_presentation_layout() -> Option<PresentationLayout> {
+pub fn detect_presentation_layout(presenter_windowed: bool) -> Option<PresentationLayout> {
     if !cfg!(target_os = "macos") {
         return None;
     }
@@ -120,7 +126,7 @@ pub fn detect_presentation_layout() -> Option<PresentationLayout> {
         return None;
     }
     let stdout = String::from_utf8(output.stdout).ok()?;
-    layout_from_jxa_output(&stdout)
+    layout_from_jxa_output(&stdout, presenter_windowed)
 }
 
 #[cfg(test)]
@@ -158,7 +164,7 @@ mod tests {
     }
 
     #[test]
-    fn plans_slides_on_external_and_presenter_on_primary() {
+    fn plans_slides_on_external_and_presenter_fullscreen_on_primary() {
         let displays = vec![
             ChromeDisplay {
                 x: 0,
@@ -176,7 +182,7 @@ mod tests {
             },
         ];
 
-        let layout = plan_presentation_layout(&displays).unwrap();
+        let layout = plan_presentation_layout(&displays, false).unwrap();
 
         assert_eq!(
             layout.slides,
@@ -195,13 +201,47 @@ mod tests {
                 y: 91,
                 width: 1200,
                 height: 800,
-                fullscreen: false,
+                fullscreen: true,
             }
         );
     }
 
     #[test]
-    fn clamps_presenter_to_small_primary_display() {
+    fn windowed_mode_plans_presenter_without_fullscreen() {
+        let displays = vec![
+            ChromeDisplay {
+                x: 0,
+                y: 0,
+                width: 1512,
+                height: 982,
+                primary: true,
+            },
+            ChromeDisplay {
+                x: -1055,
+                y: 0,
+                width: 1055,
+                height: 666,
+                primary: false,
+            },
+        ];
+
+        let layout = plan_presentation_layout(&displays, true).unwrap();
+
+        assert_eq!(
+            layout.presenter,
+            WindowPlacement {
+                x: 156,
+                y: 91,
+                width: 1200,
+                height: 800,
+                fullscreen: false,
+            }
+        );
+        assert!(layout.slides.fullscreen);
+    }
+
+    #[test]
+    fn clamps_windowed_presenter_to_small_primary_display() {
         let displays = vec![
             ChromeDisplay {
                 x: 0,
@@ -219,7 +259,7 @@ mod tests {
             },
         ];
 
-        let layout = plan_presentation_layout(&displays).unwrap();
+        let layout = plan_presentation_layout(&displays, true).unwrap();
 
         assert_eq!(
             layout.presenter,
@@ -243,7 +283,7 @@ mod tests {
             primary: true,
         }];
 
-        assert_eq!(plan_presentation_layout(&displays), None);
+        assert_eq!(plan_presentation_layout(&displays, false), None);
     }
 
     #[test]
@@ -255,7 +295,7 @@ mod tests {
 
     #[test]
     fn layout_from_jxa_output_returns_none_for_invalid_json() {
-        assert_eq!(layout_from_jxa_output("not json"), None);
+        assert_eq!(layout_from_jxa_output("not json", false), None);
     }
 
     #[test]
@@ -263,7 +303,7 @@ mod tests {
         let json = r#"[{"x":0,"y":0,"width":1512,"height":982},{"x":-1055,"y":316,"width":1055,"height":666}]"#;
 
         assert_eq!(
-            layout_from_jxa_output(json).unwrap().slides,
+            layout_from_jxa_output(json, false).unwrap().slides,
             WindowPlacement {
                 x: -1055,
                 y: 0,
@@ -271,6 +311,18 @@ mod tests {
                 height: 666,
                 fullscreen: true,
             }
+        );
+    }
+
+    #[test]
+    fn layout_from_jxa_output_passes_windowed_mode_through() {
+        let json = r#"[{"x":0,"y":0,"width":1512,"height":982},{"x":-1055,"y":316,"width":1055,"height":666}]"#;
+
+        assert!(
+            !layout_from_jxa_output(json, true)
+                .unwrap()
+                .presenter
+                .fullscreen
         );
     }
 }

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -62,6 +62,7 @@ struct PresentOptions {
     no_open: bool,
     no_serve: bool,
     no_presenter: bool,
+    presenter_windowed: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -105,6 +106,8 @@ enum Command {
         no_serve: bool,
         #[arg(long)]
         no_presenter: bool,
+        #[arg(long)]
+        presenter_windowed: bool,
     },
     Publish {
         #[arg(long, default_value = "dist")]
@@ -152,6 +155,7 @@ fn main() -> miette::Result<()> {
             no_open,
             no_serve,
             no_presenter,
+            presenter_windowed,
         } => present(PresentOptions {
             input,
             template,
@@ -162,6 +166,7 @@ fn main() -> miette::Result<()> {
             no_open,
             no_serve,
             no_presenter,
+            presenter_windowed,
         }),
         Command::Publish { dist, command } => {
             let code = publish(&dist, &command)?;
@@ -547,7 +552,7 @@ fn present(options: PresentOptions) -> miette::Result<()> {
                 presenter_url: &presenter_url,
                 no_presenter: options.no_presenter,
             },
-            displays::detect_presentation_layout(),
+            displays::detect_presentation_layout(options.presenter_windowed),
         );
     }
     server.serve_forever()
@@ -804,6 +809,25 @@ mod tests {
     #[test]
     fn watch_build_function_is_available_for_cli_dispatch() {
         let _watch: fn(BuildOptions) -> miette::Result<()> = watch_build;
+    }
+
+    #[test]
+    fn present_command_accepts_presenter_windowed_flag() {
+        let cli = Cli::parse_from(["peitho", "present", "deck.md", "--presenter-windowed"]);
+
+        match cli.command {
+            Command::Present {
+                input,
+                presenter_windowed,
+                ..
+            } => {
+                assert_eq!(input, PathBuf::from("deck.md"));
+                assert!(presenter_windowed);
+            }
+            Command::Build { .. } | Command::Publish { .. } => {
+                panic!("expected present command");
+            }
+        }
     }
 
     #[test]

--- a/docs/plans/2026-07-03-presenter-windowed-mode.md
+++ b/docs/plans/2026-07-03-presenter-windowed-mode.md
@@ -1,0 +1,45 @@
+# presenter windowed mode（デバッグ用）
+
+## 目的
+
+`peitho present`にpresenterウィンドウをフルスクリーンにしないデバッグモードを追加する。BetterDisplayの仮想ディスプレイと組み合わせた動作確認で、presenterが常時フルスクリーンだと検証しづらいため。
+
+## 現状の問題（root cause）
+
+`displays.rs`の`plan_presentation_layout`はpresenterに`WindowPlacement { fullscreen: false, width: 1200, height: 800, .. }`を計画するが、`browser.rs`の`chrome_presenter_args`はこれを無視して常に`--start-fullscreen`を付ける。つまり`WindowPlacement.fullscreen`とサイズは死にフィールドで、「計画」と「実行」が乖離している。
+
+単にフラグ分岐を`chrome_presenter_args`に足すのは症状パッチ。正しくは**WindowPlacementを唯一の真実にする**:
+
+- `plan_presentation_layout`が意図（presenterはデフォルトでフルスクリーン、windowedモードなら1200x800中央）を`WindowPlacement`に完全に書き込む
+- `browser.rs`は`placement.fullscreen`に従い、`--start-fullscreen`か`--window-size={w},{h}`のどちらかを機械的に出す。判断はしない
+
+これで将来の呼び出し元も`WindowPlacement`を作れば正しいコマンドが出る（フラグを覚えておく必要がない）。
+
+## 変更
+
+1. `displays.rs`
+   - `plan_presentation_layout(displays, presenter_windowed: bool)`に引数追加
+   - デフォルト（false）: presenter placementは`fullscreen: true`（現行の実挙動を型に反映）
+   - windowed（true）: `fullscreen: false`、1200x800（プライマリにクランプ）中央配置
+   - `layout_from_jxa_output` / `detect_presentation_layout`にも同引数を貫通
+2. `browser.rs`
+   - `chrome_presenter_args`: `placement.fullscreen`がtrueなら`--start-fullscreen`、falseなら`--window-size={width},{height}`
+   - slides側は常に`fullscreen: true`の計画なので挙動不変
+3. `main.rs`
+   - `present`に`--presenter-windowed`フラグ追加、`PresentOptions`経由で`detect_presentation_layout`へ
+
+## テスト（TDD順）
+
+- displays: windowedモードでpresenter placementが`fullscreen: false` + クランプ済みサイズになる / デフォルトは`fullscreen: true`
+- browser: presenter placementが`fullscreen: false`のとき`--window-size=1200,800`が出て`--start-fullscreen`が出ない / デフォルトは従来どおり`--start-fullscreen`
+- main: `peitho present deck.md --presenter-windowed`がparseできる
+
+## E2E
+
+2ディスプレイ環境でのみpresenterが開くため、実ディスプレイ構成に依存する。ディスプレイ数をJXAで確認し、2枚あれば`--port`固定+`--presenter-windowed`で起動→screencaptureで窓モードを確認→`curl POST /sync`の`{close:true}`で全窓クローズ。1枚しかなければ単体テストとコマンド生成の実出力確認まで（報告に明記）。
+
+## E2Eで発覚した追加root cause（実装済み）
+
+初回E2Eで`--window-size`が無視され、presenterがほぼ全画面で開いた。原因は前回presentセッションのChromeプロセス: macOSのChromeは全ウィンドウを閉じてもプロセスが残り、peithoプロファイルを掴んだままになる。そこへ`open -na`すると既起動インスタンスへのhandoffになり、`--app`以外の配置フラグが全滅する（既存の`--window-position`/`--start-fullscreen`も2回目以降のpresentでは同様に効いていなかった）。
+
+対処: `open_browser_with_request`で起動前に`pkill -f -- "--user-data-dir=<profile>"`で残存プロセスをkillし、pgrepで消滅を確認してからspawnする（`terminate_stale_profile_instances`）。pkillはパターンが`--`始まりだと`--`セパレータが必須（無いとexit 2で何もkillされない、実測）。


### PR DESCRIPTION
## Summary

Add a debug flag `--presenter-windowed` to `peitho present`. Intended for verification with BetterDisplay's virtual display: opens the presenter not as fullscreen but as a 1200x800 windowed instance (clamped to and centered on the primary).

## Two root-cause fixes

1. **Kill dead fields in `WindowPlacement`**: `plan_presentation_layout` had been planning `fullscreen: false` + size for the presenter, but `browser.rs` was ignoring it and always attaching `--start-fullscreen`. Now the plan (displays.rs) writes intent fully into `WindowPlacement`, and execution (browser.rs) mechanically derives `--start-fullscreen`/`--window-size` from `placement.fullscreen`. Future callers get the right command just by producing a placement
2. **Lingering Chrome processes swallowed the flags (surfaced via E2E)**: because macOS Chrome doesn't quit when all windows close, an instance from the previous present session was still holding the peitho profile, so the next launch became a handoff and all flags except `--app` were ignored (existing `--window-position` / `--start-fullscreen` also weren't taking effect from the second launch onward). Fix: at present startup, `pkill -f -- "--user-data-dir=<profile>"` kills lingering processes, then launch fresh. Also added to CLAUDE.md pitfalls

## Verification

- cargo test --workspace ×3 in a row / clippy -D warnings / fmt --check / no bindings drift / npm build+test+typecheck all pass
- Real-display E2E (2-display: primary 1512x982 + BetterDisplay virtual 2560x1440):
  - `--presenter-windowed`: presenter launches as a normal titlebar window (`--window-position=156,91 --window-size=1200,800`); slides launches fullscreen on the virtual display
  - A 27-minute-old lingering Chrome process (the handoff culprit) is killed at startup; the new process's ps shows the flags are applied
  - `curl POST /sync` with `{close:true}` closes both windows

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
