### PR TITLE
feat: let Chrome restore the windowed presenter where it was left

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,10 @@ UX変更は必ず実ブラウザ/実ディスプレイでE2E確認する（jsdom
 
 - **tiny_httpでSSEは不成立**: data_length Noneだと閾値以下のbodyをEOFまでバッファ、chunkエンコーダも小チャンクをflushしない。だから/syncはロングポーリング（`GET /sync?seq=N`、クエリ無しGETは現在seq即答=参加ハンドシェイク、`POST /sync`で`{index}|{close:true}`）
 - **Chrome既起動インスタンスへのフラグhandoffは`--app`しか効かない**: `--start-fullscreen`/`--window-position`/`--window-size`は無視される。確実に効かせるには別`--user-data-dir`で新規プロセス起動（だからslides/presenterは`~/.peitho/chrome-profile-{slides,presenter}`の2インスタンス）
-- **macOSのChromeは全ウィンドウを閉じてもプロセスが残る**: 前回presentのインスタンスがpeithoプロファイルを掴んだままだと次回起動がhandoffになり配置フラグが全滅する。だからpresent起動時に残存プロセスを`pkill -f -- "--user-data-dir=<profile>"`でkillしてから開く（pkillはパターンが`--`始まりだと`--`セパレータ必須）
+- **macOSのChromeは全ウィンドウを閉じてもプロセスが残る**: 前回presentのインスタンスがpeithoプロファイルを掴んだままだと次回起動がhandoffになり配置フラグが全滅する。だからpresent起動時に残存プロセスを終了してから開く
+- **Chromeの残存プロセスはSIGTERM killではなく正規終了させる**: SIGTERMはChrome的にクラッシュ（`exit_type: Crashed`）で、次回起動でクラッシュ復元が走り古いセッションの窓・boundsが復活する。`NSRunningApplication.terminate`（JXAではブリッジの都合で**括弧なし**アクセスで発火・実測）で終了させるとNormal。なお`exit_type`は起動中は常にCrashed表示（起動時に先書き→正常終了でNormalに戻す仕様）なので稼働中の読み取りは無意味。対象pidは`ps`からChromeメインプロセス（`--type=`なし）だけに絞る（`pgrep -f`はパターンを含むシェル自身まで拾う）
+- **Chromeの`--app`ウィンドウ位置復元はapp名にドットがあると壊れる**: 位置は`browser.app_window_placement`にURL由来のapp名（host+path）で保存されるが、名前中のドット（`127.0.0.1`や`.html`）が書き込み時にprefパスとして展開され、読み出しと不一致になり復元されない（Chromiumの実挙動、実測）。だからpresenterは`http://localhost:<port>/presenter`（拡張子なしルート）で開く。app名にポートは含まれないのでポートが毎回変わっても復元は効く
+- **配置フラグ無しの`--app`初回起動はウィンドウがどのディスプレイに出るか不定**: slides側ディスプレイに出るとフルスクリーンSpaceの裏に完全に隠れる（CGWindowListのOnScreenOnlyにも出ない）。だからwindowedモードは、保存placementが無い/不可視位置のときだけ`--window-position`+`--window-size`でプライマリ中央にシードし、可視な保存placementがあるときだけフラグ無しでChrome復元に任せる（判定はpeithoがプロファイルのPreferencesを読む）。Chromeは部分的に画面外の保存boundsを起動時にクランプする
 - **別プロファイル間はBroadcastChannelが届かない**: だから同期はサーバ経由（§15からの意図的拡張。層分け=DOMイベント⇔トランスポート橋渡しは不変）
 - **CLI起動のappウィンドウは`window.close()`で閉じられる**（履歴1エントリのため）。Escは`peitho:closerequest`→`{close:true}`全窓配信→各自close→サーバも猶予後にunblockして終了
 - **requestFullscreen/window.openはtransient user activation必須**: permission promptのawaitを挟むと失効する。ブラウザ内でのウィンドウ配置はこれで2敗した末にCLI主導へ転換した経緯（M8/M9/M10）

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ peitho build deck.md --watch
 # 発表（揮発キャッシュ生成 + ローカルサーバ + ブラウザ起動。2画面なら自動配置）
 peitho present deck.md
 
-# デバッグ用: 発表者画面をフルスクリーンにせず1200x800の窓で開く
+# デバッグ用: 発表者画面をフルスクリーンにせず通常ウィンドウで開く（位置・サイズは前回の状態をChromeが復元）
 peitho present deck.md --presenter-windowed
 
 # 公開（検査してから既存のデプロイコマンドに委譲。デプロイは再発明しない）

--- a/crates/peitho/src/browser.rs
+++ b/crates/peitho/src/browser.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command,
 };
 
-use crate::displays::{PresentationLayout, WindowPlacement};
+use crate::displays::{PresentationLayout, SavedWindowBounds, WindowPlacement};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BrowserPlatform {
@@ -41,8 +41,16 @@ pub struct BrowserOpenRequest<'a> {
     pub no_presenter: bool,
 }
 
+/// Chrome keys per-app window placement by an app name derived from the URL
+/// (host + path). Dots in that name ("127.0.0.1", ".html") get expanded as
+/// nested pref paths on write and never match on read, so placement is
+/// silently never restored. A dot-free URL — localhost host, extensionless
+/// /presenter route — keeps the key flat and lets Chrome restore the
+/// presenter window where it was last closed.
 pub fn presenter_url(slides_url: &str) -> String {
-    slides_url.replace("/present.html", "/presenter.html")
+    slides_url
+        .replace("127.0.0.1", "localhost")
+        .replace("/present.html", "/presenter")
 }
 
 pub fn chrome_profiles_from_home(home: Option<OsString>) -> Option<ChromeProfiles> {
@@ -63,17 +71,21 @@ fn chrome_base_args(profile_dir: &Path, url: &str) -> Vec<OsString> {
 }
 
 fn push_placement_args(args: &mut Vec<OsString>, placement: WindowPlacement) {
-    args.push(OsString::from(format!(
-        "--window-position={},{}",
-        placement.x, placement.y
-    )));
-    if placement.fullscreen {
-        args.push(OsString::from("--start-fullscreen"));
-    } else {
-        args.push(OsString::from(format!(
-            "--window-size={},{}",
-            placement.width, placement.height
-        )));
+    match placement {
+        WindowPlacement::Fullscreen { x, y } => {
+            args.push(OsString::from(format!("--window-position={x},{y}")));
+            args.push(OsString::from("--start-fullscreen"));
+        }
+        WindowPlacement::Windowed {
+            x,
+            y,
+            width,
+            height,
+        } => {
+            args.push(OsString::from(format!("--window-position={x},{y}")));
+            args.push(OsString::from(format!("--window-size={width},{height}")));
+        }
+        WindowPlacement::Restored => {}
     }
 }
 
@@ -230,6 +242,33 @@ fn current_environment() -> BrowserEnvironment {
     }
 }
 
+/// The Chrome app name for the presenter URL; placement is stored under this
+/// key in the profile's Preferences. Must stay dot-free (see presenter_url).
+const PRESENTER_APP_PLACEMENT_KEY: &str = "localhost_/presenter";
+
+/// Read the presenter window bounds Chrome saved in the peitho presenter
+/// profile, if any. Used to decide between letting Chrome restore the window
+/// (bounds exist and are visible) and seeding an explicit first-run position.
+pub fn saved_presenter_bounds(profiles: &ChromeProfiles) -> Option<SavedWindowBounds> {
+    let path = profiles.presenter.join("Default/Preferences");
+    let json = std::fs::read_to_string(path).ok()?;
+    let prefs: serde_json::Value = serde_json::from_str(&json).ok()?;
+    let placement = prefs
+        .get("browser")?
+        .get("app_window_placement")?
+        .get(PRESENTER_APP_PLACEMENT_KEY)?;
+    let left = placement.get("left")?.as_i64()? as i32;
+    let top = placement.get("top")?.as_i64()? as i32;
+    let right = placement.get("right")?.as_i64()? as i32;
+    let bottom = placement.get("bottom")?.as_i64()? as i32;
+    Some(SavedWindowBounds {
+        x: left,
+        y: top,
+        width: u32::try_from(right.checked_sub(left)?).ok()?,
+        height: u32::try_from(bottom.checked_sub(top)?).ok()?,
+    })
+}
+
 fn stale_profile_patterns(profiles: &ChromeProfiles) -> [String; 2] {
     [
         format!("--user-data-dir={}", profiles.slides.display()),
@@ -237,32 +276,85 @@ fn stale_profile_patterns(profiles: &ChromeProfiles) -> [String; 2] {
     ]
 }
 
+/// Extract the pids of browser main processes whose command line holds one
+/// of the peitho profile dirs. Child processes (`--type=renderer` etc.) are
+/// excluded: quitting the main process takes them down with it. Matching on
+/// the full `ps` command line instead of `pgrep -f` keeps shells that merely
+/// mention the profile path out of the result; a non-GUI false positive is
+/// additionally ignored by `NSRunningApplication` returning nil.
+fn stale_main_pids(ps_output: &str, patterns: &[String]) -> Vec<String> {
+    ps_output
+        .lines()
+        .filter_map(|line| {
+            let (pid, command) = line.trim_start().split_once(' ')?;
+            let is_main = patterns.iter().any(|pattern| command.contains(pattern))
+                && !command.contains("--type=");
+            is_main.then(|| pid.to_owned())
+        })
+        .collect()
+}
+
+fn profile_main_pids(patterns: &[String]) -> Vec<String> {
+    Command::new("ps")
+        .args(["-axo", "pid=,command="])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| stale_main_pids(&String::from_utf8_lossy(&output.stdout), patterns))
+        .unwrap_or_default()
+}
+
+/// JXA quirk: the ObjC bridge invokes the zero-arg `terminate` method on
+/// property access and returns its BOOL, so the call is written without
+/// parentheses. If a macOS version bridges it as a plain function instead,
+/// the access is a no-op and the pkill escalation below still cleans up.
+fn graceful_quit_jxa(pid: &str) -> String {
+    format!(
+        "ObjC.import('AppKit'); \
+         const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier({pid}); \
+         if (!app.isNil()) app.terminate;"
+    )
+}
+
+/// Ask the instance to quit the way the user would (Quit Apple Event on
+/// macOS, SIGTERM elsewhere). A raw kill is recorded by Chrome as a crash
+/// (`exit_type: Crashed`) and the next launch runs crash restore, which
+/// resurrects stale session windows and bounds over the saved placement.
+fn request_graceful_quit(pid: &str) {
+    if cfg!(target_os = "macos") {
+        let _ = Command::new("osascript")
+            .args(["-l", "JavaScript", "-e", &graceful_quit_jxa(pid)])
+            .status();
+    } else {
+        let _ = Command::new("kill").args(["--", pid]).status();
+    }
+}
+
 /// Chrome on macOS keeps running after its last window closes, so a previous
 /// `present` session leaves processes holding the peitho profiles. Launching
 /// into such a process hands off the URL and drops every flag except `--app`
-/// (window position, size, and fullscreen are silently ignored). Kill the
-/// stale processes so each session starts fresh ones that honor the flags.
+/// (window position, size, and fullscreen are silently ignored). Quit the
+/// stale processes so each session starts fresh ones that honor the flags
+/// and restore saved window placement from a cleanly exited profile.
 fn terminate_stale_profile_instances(profiles: &ChromeProfiles) {
     let patterns = stale_profile_patterns(profiles);
-    let mut killed_any = false;
-    for pattern in &patterns {
-        if let Ok(status) = Command::new("pkill").args(["-f", "--", pattern]).status() {
-            killed_any |= status.success();
-        }
-    }
-    if !killed_any {
+    let pids = profile_main_pids(&patterns);
+    if pids.is_empty() {
         return;
     }
-    for _ in 0..20 {
-        let any_alive = patterns.iter().any(|pattern| {
-            Command::new("pgrep")
-                .args(["-f", "--", pattern])
-                .output()
-                .map(|output| output.status.success())
-                .unwrap_or(false)
-        });
-        if !any_alive {
+    for pid in &pids {
+        request_graceful_quit(pid);
+    }
+    // A clean Chrome shutdown can take a few seconds; escalating too early
+    // turns it back into the crash-exit this function exists to avoid.
+    for attempt in 0..100 {
+        if profile_main_pids(&patterns).is_empty() {
             return;
+        }
+        if attempt == 60 {
+            for pattern in &patterns {
+                let _ = Command::new("pkill").args(["-f", "--", pattern]).status();
+            }
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
@@ -327,26 +419,14 @@ mod tests {
 
     fn test_layout() -> PresentationLayout {
         PresentationLayout {
-            slides: WindowPlacement {
-                x: -1055,
-                y: 0,
-                width: 1055,
-                height: 666,
-                fullscreen: true,
-            },
-            presenter: WindowPlacement {
-                x: 156,
-                y: 91,
-                width: 1200,
-                height: 800,
-                fullscreen: true,
-            },
+            slides: WindowPlacement::Fullscreen { x: -1055, y: 0 },
+            presenter: WindowPlacement::Fullscreen { x: 156, y: 91 },
         }
     }
 
     fn windowed_presenter_layout() -> PresentationLayout {
         let mut layout = test_layout();
-        layout.presenter.fullscreen = false;
+        layout.presenter = WindowPlacement::Restored;
         layout
     }
 
@@ -439,7 +519,82 @@ mod tests {
     }
 
     #[test]
-    fn windowed_presenter_placement_opens_sized_window_instead_of_fullscreen() {
+    fn windowed_presenter_placement_passes_position_and_size() {
+        let mut layout = test_layout();
+        layout.presenter = WindowPlacement::Windowed {
+            x: 156,
+            y: 91,
+            width: 1200,
+            height: 800,
+        };
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: true,
+            linux_browser: None,
+            chrome_profiles: Some(test_profiles()),
+            layout: Some(layout),
+        };
+
+        let commands = plan_browser_commands(&test_request(false), &env);
+
+        assert!(commands[1]
+            .args
+            .contains(&OsString::from("--window-position=156,91")));
+        assert!(commands[1]
+            .args
+            .contains(&OsString::from("--window-size=1200,800")));
+        assert!(!commands[1]
+            .args
+            .contains(&OsString::from("--start-fullscreen")));
+    }
+
+    #[test]
+    fn saved_presenter_bounds_read_flat_localhost_key() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let profiles = ChromeProfiles {
+            slides: temp.path().join("slides"),
+            presenter: temp.path().join("presenter"),
+        };
+        std::fs::create_dir_all(profiles.presenter.join("Default")).unwrap();
+        std::fs::write(
+            profiles.presenter.join("Default/Preferences"),
+            r#"{"browser":{"app_window_placement":{"localhost_/presenter":{"left":300,"top":60,"right":1500,"bottom":960}}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            saved_presenter_bounds(&profiles),
+            Some(SavedWindowBounds {
+                x: 300,
+                y: 60,
+                width: 1200,
+                height: 900,
+            })
+        );
+    }
+
+    #[test]
+    fn saved_presenter_bounds_none_without_preferences_or_key() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let profiles = ChromeProfiles {
+            slides: temp.path().join("slides"),
+            presenter: temp.path().join("presenter"),
+        };
+
+        assert_eq!(saved_presenter_bounds(&profiles), None);
+
+        std::fs::create_dir_all(profiles.presenter.join("Default")).unwrap();
+        std::fs::write(
+            profiles.presenter.join("Default/Preferences"),
+            r#"{"browser":{"app_window_placement":{}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(saved_presenter_bounds(&profiles), None);
+    }
+
+    #[test]
+    fn restored_presenter_placement_passes_no_placement_flags() {
         let env = BrowserEnvironment {
             platform: BrowserPlatform::Macos,
             mac_google_chrome_available: true,
@@ -454,15 +609,18 @@ mod tests {
         assert!(commands[0]
             .args
             .contains(&OsString::from("--start-fullscreen")));
-        assert!(commands[1]
-            .args
-            .contains(&OsString::from("--window-position=156,91")));
-        assert!(commands[1]
-            .args
-            .contains(&OsString::from("--window-size=1200,800")));
-        assert!(!commands[1]
-            .args
-            .contains(&OsString::from("--start-fullscreen")));
+        assert_eq!(
+            commands[1].args,
+            vec![
+                OsString::from("-na"),
+                OsString::from("Google Chrome"),
+                OsString::from("--args"),
+                OsString::from("--user-data-dir=/Users/alice/.peitho/chrome-profile-presenter"),
+                OsString::from("--no-first-run"),
+                OsString::from("--no-default-browser-check"),
+                OsString::from("--app=http://127.0.0.1:8000/presenter.html"),
+            ]
+        );
     }
 
     #[test]
@@ -507,11 +665,33 @@ mod tests {
     }
 
     #[test]
-    fn presenter_url_uses_same_origin_as_present_url() {
+    fn presenter_url_uses_dotless_localhost_app_name() {
         assert_eq!(
             presenter_url("http://127.0.0.1:49152/present.html"),
-            "http://127.0.0.1:49152/presenter.html"
+            "http://localhost:49152/presenter"
         );
+    }
+
+    #[test]
+    fn graceful_quit_script_targets_pid_via_nsrunningapplication() {
+        let script = graceful_quit_jxa("12345");
+        assert!(script.contains("NSRunningApplication"));
+        assert!(script.contains("runningApplicationWithProcessIdentifier(12345)"));
+        assert!(script.contains("app.terminate;"));
+    }
+
+    #[test]
+    fn stale_main_pids_keep_browser_main_and_drop_children_and_shells() {
+        let patterns = stale_profile_patterns(&test_profiles());
+        let ps_output = "\
+  101 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/Users/alice/.peitho/chrome-profile-slides --app=http://x/present.html
+  102 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --type=renderer --user-data-dir=/Users/alice/.peitho/chrome-profile-slides
+  103 bash -c pgrep -f -- --user-data-dir=/Users/alice/.peitho/other-profile
+  104 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/Users/alice/.peitho/chrome-profile-presenter --app=http://x/presenter.html
+  105 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --user-data-dir=/Users/alice/.config/chrome-other
+";
+
+        assert_eq!(stale_main_pids(ps_output, &patterns), vec!["101", "104"]);
     }
 
     #[test]

--- a/crates/peitho/src/browser.rs
+++ b/crates/peitho/src/browser.rs
@@ -321,12 +321,15 @@ fn graceful_quit_jxa(pid: &str) -> String {
 /// (`exit_type: Crashed`) and the next launch runs crash restore, which
 /// resurrects stale session windows and bounds over the saved placement.
 fn request_graceful_quit(pid: &str) {
+    // output() rather than status(): osascript echoes the value of the last
+    // JXA expression (`true` from terminate) to stdout, which would leak
+    // into the present command's own output.
     if cfg!(target_os = "macos") {
         let _ = Command::new("osascript")
             .args(["-l", "JavaScript", "-e", &graceful_quit_jxa(pid)])
-            .status();
+            .output();
     } else {
-        let _ = Command::new("kill").args(["--", pid]).status();
+        let _ = Command::new("kill").args(["--", pid]).output();
     }
 }
 

--- a/crates/peitho/src/displays.rs
+++ b/crates/peitho/src/displays.rs
@@ -26,13 +26,43 @@ pub struct ChromeDisplay {
     pub primary: bool,
 }
 
+/// How a browser window should be opened. `Fullscreen` positions the window
+/// on a display and fullscreens it there; `Windowed` positions and sizes a
+/// normal window explicitly; `Restored` passes no placement flags so Chrome
+/// restores the bounds saved in the profile from the last session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WindowPlacement {
+pub enum WindowPlacement {
+    Fullscreen {
+        x: i32,
+        y: i32,
+    },
+    Windowed {
+        x: i32,
+        y: i32,
+        width: u32,
+        height: u32,
+    },
+    Restored,
+}
+
+/// Presenter window bounds recorded by Chrome in the profile
+/// (`browser.app_window_placement`), in Chrome's top-left screen coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SavedWindowBounds {
     pub x: i32,
     pub y: i32,
     pub width: u32,
     pub height: u32,
-    pub fullscreen: bool,
+}
+
+/// How the presenter window should be planned. In `Windowed` mode Chrome is
+/// left to restore the saved bounds, but only when they would be visible:
+/// without placement flags Chrome may drop a first-run window onto the
+/// slides display, where the fullscreen slides Space hides it entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresenterMode {
+    Fullscreen,
+    Windowed { saved: Option<SavedWindowBounds> },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,9 +106,31 @@ fn convert_nsscreen_frames(frames: &[NsscreenFrame]) -> Vec<ChromeDisplay> {
         .collect()
 }
 
+fn contains_point(display: &ChromeDisplay, x: i32, y: i32) -> bool {
+    x >= display.x
+        && x < display.x + display.width as i32
+        && y >= display.y
+        && y < display.y + display.height as i32
+}
+
+/// Saved bounds are only worth restoring when their center sits on a display
+/// other than the slides display; anywhere else the restored window would be
+/// hidden behind the fullscreen slides Space or off screen entirely.
+fn saved_bounds_visible(
+    saved: &SavedWindowBounds,
+    displays: &[ChromeDisplay],
+    slides: &ChromeDisplay,
+) -> bool {
+    let center_x = saved.x + (saved.width / 2) as i32;
+    let center_y = saved.y + (saved.height / 2) as i32;
+    displays
+        .iter()
+        .any(|display| display != slides && contains_point(display, center_x, center_y))
+}
+
 pub fn plan_presentation_layout(
     displays: &[ChromeDisplay],
-    presenter_windowed: bool,
+    presenter_mode: PresenterMode,
 ) -> Option<PresentationLayout> {
     let primary = displays.iter().find(|display| display.primary)?;
     let slides = displays.iter().find(|display| !display.primary)?;
@@ -88,33 +140,42 @@ pub fn plan_presentation_layout(
     let presenter_x = primary.x + ((primary.width - presenter_width) / 2) as i32;
     let presenter_y = primary.y + ((primary.height - presenter_height) / 2) as i32;
 
-    Some(PresentationLayout {
-        slides: WindowPlacement {
-            x: slides.x,
-            y: slides.y,
-            width: slides.width,
-            height: slides.height,
-            fullscreen: true,
+    let presenter = match presenter_mode {
+        PresenterMode::Fullscreen => WindowPlacement::Fullscreen {
+            x: presenter_x,
+            y: presenter_y,
         },
-        presenter: WindowPlacement {
+        PresenterMode::Windowed { saved: Some(saved) }
+            if saved_bounds_visible(&saved, displays, slides) =>
+        {
+            WindowPlacement::Restored
+        }
+        PresenterMode::Windowed { .. } => WindowPlacement::Windowed {
             x: presenter_x,
             y: presenter_y,
             width: presenter_width,
             height: presenter_height,
-            fullscreen: !presenter_windowed,
         },
+    };
+
+    Some(PresentationLayout {
+        slides: WindowPlacement::Fullscreen {
+            x: slides.x,
+            y: slides.y,
+        },
+        presenter,
     })
 }
 
 pub fn layout_from_jxa_output(
     stdout: &str,
-    presenter_windowed: bool,
+    presenter_mode: PresenterMode,
 ) -> Option<PresentationLayout> {
     let displays = parse_nsscreen_json(stdout).ok()?;
-    plan_presentation_layout(&displays, presenter_windowed)
+    plan_presentation_layout(&displays, presenter_mode)
 }
 
-pub fn detect_presentation_layout(presenter_windowed: bool) -> Option<PresentationLayout> {
+pub fn detect_presentation_layout(presenter_mode: PresenterMode) -> Option<PresentationLayout> {
     if !cfg!(target_os = "macos") {
         return None;
     }
@@ -126,7 +187,7 @@ pub fn detect_presentation_layout(presenter_windowed: bool) -> Option<Presentati
         return None;
     }
     let stdout = String::from_utf8(output.stdout).ok()?;
-    layout_from_jxa_output(&stdout, presenter_windowed)
+    layout_from_jxa_output(&stdout, presenter_mode)
 }
 
 #[cfg(test)]
@@ -163,9 +224,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn plans_slides_on_external_and_presenter_fullscreen_on_primary() {
-        let displays = vec![
+    fn two_displays() -> Vec<ChromeDisplay> {
+        vec![
             ChromeDisplay {
                 x: 0,
                 y: 0,
@@ -180,68 +240,116 @@ mod tests {
                 height: 666,
                 primary: false,
             },
-        ];
+        ]
+    }
 
-        let layout = plan_presentation_layout(&displays, false).unwrap();
+    #[test]
+    fn plans_slides_on_external_and_presenter_fullscreen_on_primary() {
+        let layout = plan_presentation_layout(&two_displays(), PresenterMode::Fullscreen).unwrap();
 
         assert_eq!(
             layout.slides,
-            WindowPlacement {
-                x: -1055,
-                y: 0,
-                width: 1055,
-                height: 666,
-                fullscreen: true,
-            }
+            WindowPlacement::Fullscreen { x: -1055, y: 0 }
         );
         assert_eq!(
             layout.presenter,
-            WindowPlacement {
+            WindowPlacement::Fullscreen { x: 156, y: 91 }
+        );
+    }
+
+    #[test]
+    fn windowed_first_run_seeds_centered_window_on_primary() {
+        let layout =
+            plan_presentation_layout(&two_displays(), PresenterMode::Windowed { saved: None })
+                .unwrap();
+
+        assert_eq!(
+            layout.presenter,
+            WindowPlacement::Windowed {
                 x: 156,
                 y: 91,
                 width: 1200,
                 height: 800,
-                fullscreen: true,
+            }
+        );
+        assert_eq!(
+            layout.slides,
+            WindowPlacement::Fullscreen { x: -1055, y: 0 }
+        );
+    }
+
+    #[test]
+    fn windowed_mode_restores_saved_bounds_on_primary() {
+        let layout = plan_presentation_layout(
+            &two_displays(),
+            PresenterMode::Windowed {
+                saved: Some(SavedWindowBounds {
+                    x: 300,
+                    y: 60,
+                    width: 1200,
+                    height: 900,
+                }),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(layout.presenter, WindowPlacement::Restored);
+    }
+
+    #[test]
+    fn windowed_mode_reseeds_when_saved_bounds_sit_on_slides_display() {
+        let layout = plan_presentation_layout(
+            &two_displays(),
+            PresenterMode::Windowed {
+                saved: Some(SavedWindowBounds {
+                    x: -1000,
+                    y: 47,
+                    width: 900,
+                    height: 600,
+                }),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            layout.presenter,
+            WindowPlacement::Windowed {
+                x: 156,
+                y: 91,
+                width: 1200,
+                height: 800,
             }
         );
     }
 
     #[test]
-    fn windowed_mode_plans_presenter_without_fullscreen() {
-        let displays = vec![
-            ChromeDisplay {
-                x: 0,
-                y: 0,
-                width: 1512,
-                height: 982,
-                primary: true,
+    fn windowed_mode_reseeds_when_saved_bounds_are_off_screen() {
+        let layout = plan_presentation_layout(
+            &two_displays(),
+            PresenterMode::Windowed {
+                saved: Some(SavedWindowBounds {
+                    x: 9000,
+                    y: 9000,
+                    width: 1200,
+                    height: 800,
+                }),
             },
-            ChromeDisplay {
-                x: -1055,
-                y: 0,
-                width: 1055,
-                height: 666,
-                primary: false,
-            },
-        ];
-
-        let layout = plan_presentation_layout(&displays, true).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             layout.presenter,
-            WindowPlacement {
+            WindowPlacement::Windowed {
                 x: 156,
                 y: 91,
                 width: 1200,
                 height: 800,
-                fullscreen: false,
             }
         );
-        assert!(layout.slides.fullscreen);
     }
 
     #[test]
-    fn clamps_windowed_presenter_to_small_primary_display() {
+    fn centers_fullscreen_presenter_position_within_small_primary_display() {
         let displays = vec![
             ChromeDisplay {
                 x: 0,
@@ -259,18 +367,9 @@ mod tests {
             },
         ];
 
-        let layout = plan_presentation_layout(&displays, true).unwrap();
+        let layout = plan_presentation_layout(&displays, PresenterMode::Fullscreen).unwrap();
 
-        assert_eq!(
-            layout.presenter,
-            WindowPlacement {
-                x: 0,
-                y: 0,
-                width: 900,
-                height: 700,
-                fullscreen: false,
-            }
-        );
+        assert_eq!(layout.presenter, WindowPlacement::Fullscreen { x: 0, y: 0 });
     }
 
     #[test]
@@ -283,7 +382,10 @@ mod tests {
             primary: true,
         }];
 
-        assert_eq!(plan_presentation_layout(&displays, false), None);
+        assert_eq!(
+            plan_presentation_layout(&displays, PresenterMode::Fullscreen),
+            None
+        );
     }
 
     #[test]
@@ -295,7 +397,10 @@ mod tests {
 
     #[test]
     fn layout_from_jxa_output_returns_none_for_invalid_json() {
-        assert_eq!(layout_from_jxa_output("not json", false), None);
+        assert_eq!(
+            layout_from_jxa_output("not json", PresenterMode::Fullscreen),
+            None
+        );
     }
 
     #[test]
@@ -303,26 +408,28 @@ mod tests {
         let json = r#"[{"x":0,"y":0,"width":1512,"height":982},{"x":-1055,"y":316,"width":1055,"height":666}]"#;
 
         assert_eq!(
-            layout_from_jxa_output(json, false).unwrap().slides,
-            WindowPlacement {
-                x: -1055,
-                y: 0,
-                width: 1055,
-                height: 666,
-                fullscreen: true,
-            }
+            layout_from_jxa_output(json, PresenterMode::Fullscreen)
+                .unwrap()
+                .slides,
+            WindowPlacement::Fullscreen { x: -1055, y: 0 }
         );
     }
 
     #[test]
-    fn layout_from_jxa_output_passes_windowed_mode_through() {
+    fn layout_from_jxa_output_passes_presenter_mode_through() {
         let json = r#"[{"x":0,"y":0,"width":1512,"height":982},{"x":-1055,"y":316,"width":1055,"height":666}]"#;
+        let saved = SavedWindowBounds {
+            x: 200,
+            y: 100,
+            width: 1200,
+            height: 800,
+        };
 
-        assert!(
-            !layout_from_jxa_output(json, true)
+        assert_eq!(
+            layout_from_jxa_output(json, PresenterMode::Windowed { saved: Some(saved) })
                 .unwrap()
-                .presenter
-                .fullscreen
+                .presenter,
+            WindowPlacement::Restored
         );
     }
 }

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -546,13 +546,22 @@ fn present(options: PresentOptions) -> miette::Result<()> {
     println!("serving presentation at {url}");
     std::io::stdout().flush().into_diagnostic()?;
     if !options.no_open {
+        let presenter_mode = if options.presenter_windowed {
+            displays::PresenterMode::Windowed {
+                saved: browser::chrome_profiles_from_home(std::env::var_os("HOME"))
+                    .as_ref()
+                    .and_then(browser::saved_presenter_bounds),
+            }
+        } else {
+            displays::PresenterMode::Fullscreen
+        };
         browser::open_browser_with_request(
             browser::BrowserOpenRequest {
                 slides_url: &url,
                 presenter_url: &presenter_url,
                 no_presenter: options.no_presenter,
             },
-            displays::detect_presentation_layout(options.presenter_windowed),
+            displays::detect_presentation_layout(presenter_mode),
         );
     }
     server.serve_forever()

--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -69,6 +69,11 @@ pub(crate) fn resolve_request_path(root: &Path, url: &str) -> Option<PathBuf> {
     if trimmed.is_empty() {
         return Some(root.join("present.html"));
     }
+    // Extensionless alias keeping the Chrome app name dot-free so app window
+    // placement is saved and restored (see browser::presenter_url).
+    if trimmed == "presenter" {
+        return Some(root.join("presenter.html"));
+    }
 
     let mut out = root.to_path_buf();
     for component in Path::new(trimmed).components() {
@@ -340,6 +345,18 @@ mod tests {
         assert_eq!(
             resolve_request_path(Path::new("/cache"), "/").unwrap(),
             Path::new("/cache").join("present.html")
+        );
+    }
+
+    #[test]
+    fn resolves_extensionless_presenter_route() {
+        assert_eq!(
+            resolve_request_path(Path::new("/cache"), "/presenter").unwrap(),
+            Path::new("/cache").join("presenter.html")
+        );
+        assert_eq!(
+            resolve_request_path(Path::new("/cache"), "/presenter?seq=1").unwrap(),
+            Path::new("/cache").join("presenter.html")
         );
     }
 

--- a/docs/plans/2026-07-03-presenter-windowed-mode.md
+++ b/docs/plans/2026-07-03-presenter-windowed-mode.md
@@ -43,3 +43,24 @@
 初回E2Eで`--window-size`が無視され、presenterがほぼ全画面で開いた。原因は前回presentセッションのChromeプロセス: macOSのChromeは全ウィンドウを閉じてもプロセスが残り、peithoプロファイルを掴んだままになる。そこへ`open -na`すると既起動インスタンスへのhandoffになり、`--app`以外の配置フラグが全滅する（既存の`--window-position`/`--start-fullscreen`も2回目以降のpresentでは同様に効いていなかった）。
 
 対処: `open_browser_with_request`で起動前に`pkill -f -- "--user-data-dir=<profile>"`で残存プロセスをkillし、pgrepで消滅を確認してからspawnする（`terminate_stale_profile_instances`）。pkillはパターンが`--`始まりだと`--`セパレータが必須（無いとexit 2で何もkillされない、実測）。
+
+## 追記: windowedは位置指定をやめChrome復元に任せる（著者指示）
+
+当初は`--window-position`+`--window-size=1200,800`を明示していたが、デバッグ中に手で動かした位置・サイズを次回も使いたいという著者要望で、windowedモードでは配置フラグを一切渡さない形に変更。Chromeはプロファイルの`Preferences`（`browser.window_placement`）に最後のウィンドウ位置を保存し、フラグが無ければそれを復元する（実測確認済み）。
+
+これに伴い`WindowPlacement`をstruct（x/y/width/height/fullscreen）からenum `Fullscreen { x, y } | Restored`に再構成。structのままだとwindowed時にwidth/heightが再び死にフィールドになるため。サイズのクランプ計算はフルスクリーン時の中央座標算出のローカル計算に残る。初回起動（プロファイルに保存値が無い場合）はChromeのデフォルト位置で開く（許容済みトレードオフ）。
+
+## 追記2: 復元を成立させるために潰した2つのroot cause
+
+E2Eで「動かした位置に復元されない」が再現し、調査で以下2点が確定した（詳細はCLAUDE.mdハマりどころ）。
+
+1. **SIGTERM killはクラッシュ扱い**: 前PRの`pkill`による残存プロセスkillは`exit_type: Crashed`を残し、次回起動のクラッシュ復元が古いセッションの窓・boundsを復活させ、保存placementを上書きしていた。対処として残存プロセスは`NSRunningApplication.terminate`（osascript JXA、括弧なしアクセスで発火）で正規終了させ、タイムアウト時のみpkillへエスカレーション。対象pidは`ps`でChromeメイン（`--type=`なし、パターン含有）に絞る。
+2. **app名のドットでplacement prefが壊れる**: `--app`窓の位置は`browser.app_window_placement`にURL由来のapp名で保存されるが、`127.0.0.1_/presenter.html`のドットが書き込み時にネスト展開され読み出しと不一致→復元が一度も効いていなかった。presenterのURLを`http://localhost:<port>/presenter`（server.rsに拡張子なしルート追加）に変え、app名`localhost_/presenter`をドットフリーに。app名にポートは含まれないため、presentのポートが毎回変わっても復元は維持される（スクラッチ環境のChrome実機で移動→正規終了→再起動→移動先復元を確認）。
+
+さらにE2Eで、配置フラグ無しの初回起動はChromeがウィンドウをslides側ディスプレイに置くことがあり、フルスクリーンSpaceの裏に完全に隠れると判明。最終形:
+
+- `PresenterMode::Windowed { saved: Option<SavedWindowBounds> }`: peithoがpresenterプロファイルのPreferencesから`localhost_/presenter`の保存boundsを読む
+- 保存boundsの中心がslides以外のディスプレイ上にある → `WindowPlacement::Restored`（フラグ無し、Chrome復元）
+- 保存が無い/不可視位置 → `WindowPlacement::Windowed`（`--window-position`+`--window-size`でプライマリ中央1200x800にシード。この位置がChromeに保存され次回以降の復元の種になる）
+
+実機E2E: 初回シード表示→移動→close→再起動で移動先(300,150)に正確に復元、不可視保存bounds（外部1534,47）からのreseedフォールバック、部分画面外boundsのChromeクランプ、をそれぞれ確認。


### PR DESCRIPTION
## Summary

Make `--presenter-windowed` restore the presenter window's manually-moved position and size on next launch (instead of resetting to 1200x800 centered every time).

To make this work, three Chrome behaviors had to be neutralized (all measured on real hardware; recorded in CLAUDE.md pitfalls):

1. **SIGTERM kill counts as a crash**: pkill'ing a lingering profile instance leaves `exit_type: Crashed`, which triggers next-launch crash recovery and restores the old session's windows and bounds. Lingering instances now shut down cleanly via `NSRunningApplication.terminate` (equivalent to Quit AppleEvent; JXA uses parenthesis-less access due to the bridge). pkill is demoted to a timeout-only escalation. Target pids also switch away from `pgrep -f` (which picks up shells containing the pattern) to `ps`-filtered Chrome main processes (no `--type=`)
2. **Dots in the app name break placement prefs**: `--app` window position is saved in `browser.app_window_placement` keyed by a URL-derived app name, but the dots in `127.0.0.1_/presenter.html` get expanded as nested pref paths on write, mismatching on read. Restoration never worked once. Open the presenter at `http://localhost:<port>/presenter` (extensionless route added in server.rs) so the key stays flat. Since the app name doesn't include the port, restoration works even with present's random port
3. **First launch with no flags puts the window on an undetermined display**: if it lands on the slides side, it can end up completely hidden behind the fullscreen Space (actually reproduced). Now read saved bounds from the presenter profile's Preferences: if visible (center on a non-slides display), let Chrome restore with no flags; if no saved bounds or the saved bounds are invisible, seed 1200x800 centered on the primary

The types add `Windowed { x, y, width, height }` to `WindowPlacement` and `PresenterMode::Windowed { saved: Option<SavedWindowBounds> }` so the layout planner decides restore vs. seed (decision logic is a pure function under test).

## Verification

- cargo test --workspace ×3 in a row / clippy -D warnings / fmt --check / no bindings drift / npm build+test+typecheck all pass
- Real-display E2E (primary + a BetterDisplay virtual display, two displays):
  - First launch: seeded at (156,91) 1200x800 on the primary
  - Move to (300,150) → close → relaunch: **accurately restored to (300,150)** (verified via ps that Chrome launched with no flags)
  - Invisible saved bounds (external display 1534,47) → re-seeded on the primary
  - Partially off-screen saved bounds → Chrome clamps into a visible position at launch
  - No stray "new tab" window, no crash-recovery recurrence

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
