### PR TITLE
chore: add Makefile targets to present each example deck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# 動作確認用: 各サンプルデッキをcargo runでpresentする。
+# 追加フラグは PRESENT_FLAGS で渡す。例:
+#   make keynote PRESENT_FLAGS="--presenter-windowed"
+
+PRESENT_FLAGS ?=
+PRESENT = cargo run -q -p peitho -- present
+
+.PHONY: help minimal lightning-talk code-walkthrough keynote shell
+
+help:
+	@echo "サンプルの動作確認ターゲット:"
+	@echo "  make minimal           最小デッキ（内蔵デフォルトテーマ）"
+	@echo "  make lightning-talk    日本語LT（ダーク+大型タイポ）"
+	@echo "  make code-walkthrough  typestate解説（ターミナル風2カラム）"
+	@echo "  make keynote           キーノート（セリフ体中央寄せ）"
+	@echo ""
+	@echo "追加フラグ: make keynote PRESENT_FLAGS=\"--presenter-windowed\""
+
+shell:
+	cd packages/peitho-present && npm run build
+
+minimal: shell
+	$(PRESENT) examples/deck.md $(PRESENT_FLAGS)
+
+lightning-talk: shell
+	$(PRESENT) examples/lightning-talk/deck.md \
+		--template examples/lightning-talk/template.html \
+		--base-css examples/lightning-talk/base.css \
+		--overrides-css examples/lightning-talk/overrides.css \
+		$(PRESENT_FLAGS)
+
+code-walkthrough: shell
+	$(PRESENT) examples/code-walkthrough/deck.md \
+		--template examples/code-walkthrough/template.html \
+		--base-css examples/code-walkthrough/base.css \
+		--overrides-css examples/code-walkthrough/overrides.css \
+		$(PRESENT_FLAGS)
+
+keynote: shell
+	$(PRESENT) examples/keynote/deck.md \
+		--template examples/keynote/template.html \
+		--base-css examples/keynote/base.css \
+		--overrides-css examples/keynote/overrides.css \
+		$(PRESENT_FLAGS)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ peitho present examples/keynote/deck.md \
   --overrides-css examples/keynote/overrides.css
 ```
 
+動作確認にはMakefileのターゲットが便利（`make help`で一覧。`make keynote`、`make lightning-talk`等。シェルバンドルのビルド込みで`cargo run`する）。
+
 ## アーキテクチャ
 
 ```


### PR DESCRIPTION
## Summary

Add Makefile targets for smoke-checking sample decks.

- `make minimal` / `make lightning-talk` / `make code-walkthrough` / `make keynote` — launch each sample via `cargo run -q -p peitho -- present`
- Each target depends on building the presentation shell (`npm run build`), so it just works even if the shell hasn't been built yet
- Extra flags go through `PRESENT_FLAGS` (e.g. `make keynote PRESENT_FLAGS="--presenter-windowed"`)
- `make` with no argument prints the target list

Adds a brief note to the samples section of the README.

## Verification

- All gates pass (cargo test 3 runs / clippy / fmt / bindings drift / full npm cycle)
- Real-hardware E2E: `make lightning-talk PRESENT_FLAGS="--port 8970"` launches → server returns 200 → `{close:true}` cleanly terminates → Chrome process count returns to 0. Also confirmed command assembly via `make help` and `make -n`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
