### PR TITLE
feat: embed the present shell bundle into the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,6 @@ jobs:
           cache-dependency-path: packages/peitho-present/package-lock.json
       - run: npm ci
       - run: npm run build
+      - run: git diff --exit-code dist/shell.js
       - run: npm test
       - run: npm run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .peitho/
 node_modules/
 packages/peitho-present/node_modules/
-packages/peitho-present/dist/
+packages/peitho-present/dist/*
+!packages/peitho-present/dist/shell.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ crates/peitho-core/   契約・パイプライン(parser/template/mapping/check/
 crates/peitho/        CLI(build/present/publish)、server.rs(配信+/syncロングポール)、browser.rs、displays.rs
 packages/peitho-present/  TS発表シェル(canvas/shell/controls/keyboard/sync/presenter)
 bindings/             ts-rs生成TS型（コミット対象）
-templates/ themes/ examples/  共有レイアウト・baseテーマ・サンプル（デフォルトのテンプレート/base.cssはinclude_str!でバイナリに内蔵。CLIフラグ未指定時はそれが使われる）
+templates/ themes/ examples/  共有レイアウト・baseテーマ・サンプル（デフォルトのテンプレート/base.css/発表シェルdist/shell.jsはinclude_str!でバイナリに内蔵。CLIフラグ未指定時はそれが使われる。shell.jsは生成物だがbindings/と同じくコミット+CI drift検査）
 docs/plans/           各マイルストーンの実装計画（履歴）
 ```
 
@@ -33,6 +33,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all --check
 git diff --exit-code bindings/  # 契約drift
 cd packages/peitho-present && npm run build && npm test && npm run typecheck
+git diff --exit-code packages/peitho-present/dist/shell.js  # 内蔵シェルdrift（npm run build後に）
 ```
 
 UX変更は必ず実ブラウザ/実ディスプレイでE2E確認する（jsdomはレイアウト・フラッシュ・ウィンドウ挙動を検出できない。過去に真っ黒画面・SSE不達・無限再ビルドをE2Eでのみ検出）。presentの確認は `--port`固定+`curl POST /sync`+`screencapture -x -D <n>` が便利。

--- a/README.md
+++ b/README.md
@@ -45,13 +45,9 @@ peitho present deck.md --presenter-windowed
 peitho publish -- aws s3 sync dist/ s3://your-bucket/
 ```
 
-テンプレートとテーマはバイナリに内蔵されたデフォルト（`templates/title-body-code.html`・`themes/base.css`と同内容）が使われるため、デッキファイルだけあればどのディレクトリでも動く。差し替えるときだけ`--template`/`--base-css`/`--overrides-css`を渡す。
+テンプレート・テーマ・発表シェルはバイナリに内蔵されたデフォルトが使われるため、デッキファイルだけあればどのディレクトリでも動く。差し替えるときだけ`--template`/`--base-css`/`--overrides-css`/`--shell`を渡す。
 
-`peitho present` はTS製の発表シェルを使うため、初回のみバンドルのビルドが必要:
-
-```sh
-cd packages/peitho-present && npm ci && npm run build
-```
+発表シェル（TS）を開発するときは`cd packages/peitho-present && npm ci && npm run build`で`dist/shell.js`を再生成する（コミット対象。CIがdriftを検査する）。
 
 ## デッキの書き方
 

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -57,7 +57,7 @@ struct PresentOptions {
     template: Option<PathBuf>,
     base_css: Option<PathBuf>,
     overrides_css: Option<PathBuf>,
-    shell: PathBuf,
+    shell: Option<PathBuf>,
     port: u16,
     no_open: bool,
     no_serve: bool,
@@ -96,8 +96,8 @@ enum Command {
         base_css: Option<PathBuf>,
         #[arg(long, help = "overrides CSS path (default: no overrides)")]
         overrides_css: Option<PathBuf>,
-        #[arg(long, default_value = "packages/peitho-present/dist/shell.js")]
-        shell: PathBuf,
+        #[arg(long, help = "shell bundle path (default: built-in present shell)")]
+        shell: Option<PathBuf>,
         #[arg(long, default_value_t = 0)]
         port: u16,
         #[arg(long)]
@@ -124,6 +124,9 @@ enum Command {
 const BUILTIN_TEMPLATE_NAME: &str = "title-body-code";
 const BUILTIN_TEMPLATE_HTML: &str = include_str!("../../../templates/title-body-code.html");
 const BUILTIN_BASE_CSS: &str = include_str!("../../../themes/base.css");
+/// The committed esbuild bundle; CI rebuilds it and fails on drift, the same
+/// discipline as the generated TS types in bindings/.
+const BUILTIN_SHELL_JS: &str = include_str!("../../../packages/peitho-present/dist/shell.js");
 
 const PRESENT_CACHE: &str = ".peitho/present-cache";
 const PRESENTATION_ONLY_DIST_FILES: &[&str] =
@@ -555,7 +558,7 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         options.base_css.as_deref(),
         options.overrides_css.as_deref(),
     )?;
-    emit_present_cache(&cache, &artifacts, &options.shell)?;
+    emit_present_cache(&cache, &artifacts, options.shell.as_deref())?;
     if options.no_serve {
         println!("generated present cache at {}", cache.display());
         return Ok(());
@@ -595,9 +598,11 @@ fn present(options: PresentOptions) -> miette::Result<()> {
 fn emit_present_cache(
     cache: &Path,
     artifacts: &BuildArtifacts,
-    shell: &Path,
+    shell: Option<&Path>,
 ) -> miette::Result<()> {
-    ensure_shell_bundle(shell)?;
+    if let Some(shell) = shell {
+        ensure_shell_bundle(shell)?;
+    }
     fs::write(cache.join("peitho.css"), &artifacts.css).into_diagnostic()?;
     write_slide_fragments(cache, &artifacts.rendered)?;
     fs::write(cache.join("manifest.json"), &artifacts.manifest_json).into_diagnostic()?;
@@ -616,7 +621,14 @@ fn emit_present_cache(
         peitho_core::render_presenter_index(),
     )
     .into_diagnostic()?;
-    fs::copy(shell, cache.join("shell.js")).into_diagnostic()?;
+    match shell {
+        Some(shell) => {
+            fs::copy(shell, cache.join("shell.js")).into_diagnostic()?;
+        }
+        None => {
+            fs::write(cache.join("shell.js"), BUILTIN_SHELL_JS).into_diagnostic()?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -97,6 +97,26 @@ fn present_no_serve_writes_presenter_html() {
 }
 
 #[test]
+fn present_without_shell_flag_writes_builtin_shell() {
+    let dir = tempdir().unwrap();
+    let fixture = Fixture::write(dir.path());
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(fixture.present_args_builtin_shell())
+        .args(["--no-serve", "--no-open"])
+        .assert()
+        .success();
+
+    let written = fs::read_to_string(dir.path().join(".peitho/present-cache/shell.js")).unwrap();
+    let committed =
+        fs::read_to_string(workspace_root().join("packages/peitho-present/dist/shell.js")).unwrap();
+    assert_eq!(written, committed);
+    assert!(written.contains("mountPresentShell"));
+}
+
+#[test]
 fn present_fails_with_help_when_shell_bundle_is_missing() {
     let dir = tempdir().unwrap();
     let fixture = Fixture::write(dir.path());
@@ -475,6 +495,13 @@ impl Fixture {
     }
 
     fn present_args(&self, shell: &std::path::Path) -> Vec<OsString> {
+        let mut args = self.present_args_builtin_shell();
+        args.push(OsString::from("--shell"));
+        args.push(shell.as_os_str().to_owned());
+        args
+    }
+
+    fn present_args_builtin_shell(&self) -> Vec<OsString> {
         vec![
             OsString::from("present"),
             self.deck.as_os_str().to_owned(),
@@ -484,8 +511,6 @@ impl Fixture {
             self.base.as_os_str().to_owned(),
             OsString::from("--overrides-css"),
             self.overrides.as_os_str().to_owned(),
-            OsString::from("--shell"),
-            shell.as_os_str().to_owned(),
         ]
     }
 }

--- a/docs/plans/2026-07-03-embed-present-shell.md
+++ b/docs/plans/2026-07-03-embed-present-shell.md
@@ -1,0 +1,18 @@
+# 発表シェル(shell.js)のバイナリ内蔵
+
+## 目的
+
+テンプレート・テーマ内蔵後も、`present`だけは`packages/peitho-present/dist/shell.js`というリポジトリ相対パスに依存しており、インストールしたバイナリでリポジトリ外から`peitho present`できなかった。シェルも内蔵して3コマンド全てをスタンドアロンにする。
+
+## 方針: bindings/と同じ「生成物をコミット+CI drift検査」
+
+- build.rsでnpmを叩く案は不採用: `cargo build`にnode/npm依存を持ち込み、純Rustビルドを壊す
+- 採用: `dist/shell.js`をコミットし、`include_str!`で内蔵。CIのnodeジョブが`npm run build`後に`git diff --exit-code dist/shell.js`でdriftを検査（bindings/のTS型と同じ規律。esbuildはpackage-lockで固定されるため出力は決定的）
+- `.gitignore`は`dist/`→`dist/*`+`!dist/shell.js`に変更（親ディレクトリ除外だと再includeが効かないgitの仕様のため）。sourcemapはignoreのまま
+- `--shell`は`Option<PathBuf>`化。未指定=内蔵シェルをpresent-cacheへ書き出し、指定=従来どおりファイルコピー（"shell bundle not found"エラーは明示パス時のみ）
+- 開発フロー: TSを直したら`npm run build`→`include_str!`の依存追跡でcargoが再コンパイルし内蔵も更新される。Makefileの`shell`依存は従来どおり
+
+## 検証
+
+- 単体/統合: `--shell`未指定でpresent-cacheのshell.jsが内蔵内容で生成されること、明示パスの従来動作、missing時のエラーが明示パス限定になること
+- E2E: リポジトリ外の一時ディレクトリで`peitho present deck.md --no-open --port固定`が起動し、/shell.jsが配信されることを確認

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -1,0 +1,719 @@
+// src/canvas.ts
+var CANVAS_WIDTH = 1280;
+var CANVAS_HEIGHT = 720;
+function calculateCanvasFit(viewport, canvasWidth = CANVAS_WIDTH, canvasHeight = CANVAS_HEIGHT) {
+  const scale = Math.min(viewport.width / canvasWidth, viewport.height / canvasHeight);
+  const width = canvasWidth * scale;
+  const height = canvasHeight * scale;
+  return {
+    scale,
+    width,
+    height,
+    left: (viewport.width - width) / 2,
+    top: (viewport.height - height) / 2
+  };
+}
+function installCanvasScaler(options) {
+  const win = options.window ?? window;
+  const canvasWidth = options.canvasWidth ?? CANVAS_WIDTH;
+  const canvasHeight = options.canvasHeight ?? CANVAS_HEIGHT;
+  const viewport = options.viewport ?? (() => ({
+    width: win.innerWidth,
+    height: win.innerHeight
+  }));
+  function apply() {
+    const fit = calculateCanvasFit(viewport(), canvasWidth, canvasHeight);
+    options.target.style.width = `${canvasWidth}px`;
+    options.target.style.height = `${canvasHeight}px`;
+    options.target.style.transformOrigin = "top left";
+    options.target.style.transform = `translate(${fit.left}px, ${fit.top}px) scale(${fit.scale})`;
+  }
+  apply();
+  win.addEventListener("resize", apply);
+  return () => win.removeEventListener("resize", apply);
+}
+
+// src/presentDisplay.ts
+var PRESENTER_URL = "presenter.html";
+var PRESENTER_TARGET = "peitho-presenter";
+function fallbackFeatures() {
+  return "popup=yes,width=1200,height=800,left=80,top=80";
+}
+function openPresenterPopup(options = {}) {
+  const win = options.window ?? window;
+  const url = options.url ?? PRESENTER_URL;
+  const features = options.features ?? fallbackFeatures();
+  const openWindow = options.openWindow ?? ((nextUrl, target, nextFeatures) => win.open(nextUrl, target, nextFeatures));
+  return openWindow(url, PRESENTER_TARGET, features);
+}
+
+// src/controls.ts
+function installPresentationControls(options) {
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const bus = options.bus ?? win;
+  const idleMs = options.idleMs ?? 3e3;
+  const openPresenter = options.openPresenter ?? (() => openPresenterPopup({
+    window: win,
+    openWindow: options.openPresenterWindow
+  }));
+  const closeWindow = options.closeWindow ?? (() => win.close());
+  const bar = doc.createElement("nav");
+  bar.dataset.peithoControlBar = "true";
+  bar.className = "peitho-control-bar";
+  bar.hidden = true;
+  bar.innerHTML = [
+    '<button type="button" data-peitho-action="prev" aria-label="Previous slide">\u25C0</button>',
+    '<button type="button" data-peitho-action="next" aria-label="Next slide">\u25B6</button>',
+    '<output data-peitho-control="counter">\u2013 / \u2013</output>',
+    '<button type="button" data-peitho-action="fullscreen" aria-label="Toggle fullscreen">\u26F6</button>',
+    '<button type="button" data-peitho-action="presenter">Presenter</button>',
+    '<button type="button" data-peitho-action="close" aria-label="Close presentation">\u2715</button>'
+  ].join("");
+  options.root.appendChild(bar);
+  let hideTimer = null;
+  const clearHideTimer = () => {
+    if (hideTimer !== null) win.clearTimeout(hideTimer);
+    hideTimer = null;
+  };
+  const show = () => {
+    bar.hidden = false;
+    clearHideTimer();
+    hideTimer = win.setTimeout(() => {
+      bar.hidden = true;
+      hideTimer = null;
+    }, idleMs);
+  };
+  const dispatchNavigate = (to) => {
+    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+  };
+  const onClick = (event) => {
+    event.stopPropagation();
+    const action = event.target.closest("[data-peitho-action]")?.dataset.peithoAction;
+    if (action === "prev" || action === "next") dispatchNavigate(action);
+    if (action === "presenter") void openPresenter();
+    if (action === "fullscreen") toggleFullscreen(doc);
+    if (action === "close") closeWindow();
+  };
+  const onSlideChange = (event) => {
+    const detail = event.detail;
+    const counter = bar.querySelector('[data-peitho-control="counter"]');
+    if (counter) counter.textContent = `${detail.index + 1} / ${detail.total}`;
+  };
+  win.addEventListener("mousemove", show);
+  bar.addEventListener("click", onClick);
+  bus.addEventListener("peitho:slidechange", onSlideChange);
+  return () => {
+    clearHideTimer();
+    win.removeEventListener("mousemove", show);
+    bar.removeEventListener("click", onClick);
+    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    bar.remove();
+  };
+}
+function installCanvasClickNavigation(options) {
+  const win = options.window ?? window;
+  const bus = options.bus ?? win;
+  const onClick = (event) => {
+    if (event.target.closest('[data-peitho-control-bar="true"]')) return;
+    const to = event.clientX < win.innerWidth / 4 ? "prev" : "next";
+    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+  };
+  options.root.addEventListener("click", onClick);
+  return () => options.root.removeEventListener("click", onClick);
+}
+function installFullscreenShortcut(options = {}) {
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const onKeyDown = (event) => {
+    if (event.key !== "f") return;
+    event.preventDefault();
+    toggleFullscreen(doc);
+  };
+  win.addEventListener("keydown", onKeyDown);
+  return () => win.removeEventListener("keydown", onKeyDown);
+}
+function toggleFullscreen(doc = document) {
+  if (doc.fullscreenElement) {
+    void doc.exitFullscreen?.();
+    return;
+  }
+  void doc.documentElement.requestFullscreen?.();
+}
+
+// src/keyboard.ts
+var keyMap = /* @__PURE__ */ new Map([
+  ["ArrowRight", "next"],
+  ["PageDown", "next"],
+  [" ", "next"],
+  ["ArrowLeft", "prev"],
+  ["PageUp", "prev"],
+  ["Home", "first"],
+  ["End", "last"]
+]);
+function installKeyboardNavigation(win = window, bus = win) {
+  const onKeyDown = (event) => {
+    const to = keyMap.get(event.key);
+    if (!to) return;
+    event.preventDefault();
+    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+  };
+  win.addEventListener("keydown", onKeyDown);
+  return () => win.removeEventListener("keydown", onKeyDown);
+}
+function installCloseOnEscape(win = window, bus = win) {
+  const onKeyDown = (event) => {
+    if (event.key !== "Escape") return;
+    event.preventDefault();
+    bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
+  };
+  win.addEventListener("keydown", onKeyDown);
+  return () => win.removeEventListener("keydown", onKeyDown);
+}
+
+// src/shell.ts
+async function mountPresentShell(options) {
+  const shell = new PresentShellController(options);
+  await shell.load();
+  return shell;
+}
+var PresentShellController = class {
+  manifest = null;
+  currentIndex = -1;
+  slides = [];
+  root;
+  fetcher;
+  win;
+  doc;
+  log;
+  bus;
+  now;
+  viewport;
+  canvasCleanups = [];
+  startedAtValue = null;
+  pausedAtValue = null;
+  pausedTotalMs = 0;
+  ended = false;
+  onNavigate = (event) => {
+    const detail = event.detail;
+    if (!detail || !("to" in detail)) {
+      this.log.error("Invalid peitho:navigate event");
+      return;
+    }
+    this.navigate(detail.to);
+  };
+  onTimerControl = (event) => {
+    const action = event.detail?.action;
+    if (action === "start") this.startPresentation();
+    else if (action === "pause") this.pauseTimer();
+    else if (action === "resume") this.resumeTimer();
+    else if (action === "reset") this.resetTimer();
+    else this.log.error("Invalid peitho:timercontrol event");
+  };
+  onPageHide = () => this.endPresentation();
+  constructor(options) {
+    this.root = options.root;
+    this.fetcher = options.fetcher ?? fetch.bind(globalThis);
+    this.win = options.window ?? window;
+    this.doc = options.document ?? document;
+    this.log = options.console ?? console;
+    this.bus = options.bus ?? this.win;
+    this.now = options.now ?? Date.now;
+    this.viewport = options.viewport;
+    this.root.classList.add("peitho-shell-viewport");
+    const rootPosition = this.win.getComputedStyle(this.root).position;
+    if (rootPosition === "static" || rootPosition === "") {
+      this.root.style.position = "relative";
+    }
+    this.root.style.overflow = "hidden";
+    this.root.style.background = "#000";
+    this.bus.addEventListener("peitho:navigate", this.onNavigate);
+    this.bus.addEventListener("peitho:timercontrol", this.onTimerControl);
+    this.win.addEventListener("pagehide", this.onPageHide);
+  }
+  async load() {
+    try {
+      const manifest = await this.fetchJson("manifest.json");
+      const css = await this.fetchText("peitho.css");
+      const pending = [];
+      for (const slide of manifest.slides) {
+        const html = await this.fetchText(slide.src);
+        const host = this.createSlideHost(slide, html, css);
+        pending.push({ meta: slide, host });
+      }
+      this.manifest = manifest;
+      for (const view of pending) {
+        this.root.appendChild(view.host);
+        this.slides.push(view);
+      }
+      this.show(0);
+    } catch (error) {
+      this.root.replaceChildren();
+      this.root.textContent = error instanceof Error ? error.message : String(error);
+    }
+  }
+  navigate(to) {
+    const index = this.resolveTarget(to);
+    if (index === null) return;
+    this.show(index);
+  }
+  elapsedMs() {
+    if (this.startedAtValue === null) return 0;
+    const current = this.now();
+    const pausedNow = this.pausedAtValue === null ? 0 : current - this.pausedAtValue;
+    return Math.max(0, current - this.startedAtValue - this.pausedTotalMs - pausedNow);
+  }
+  isPaused() {
+    return this.pausedAtValue !== null;
+  }
+  startedAt() {
+    return this.startedAtValue;
+  }
+  destroy() {
+    this.endPresentation();
+    while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
+    this.bus.removeEventListener("peitho:navigate", this.onNavigate);
+    this.bus.removeEventListener("peitho:timercontrol", this.onTimerControl);
+    this.win.removeEventListener("pagehide", this.onPageHide);
+  }
+  async fetchJson(url) {
+    const response = await this.fetchOk(url);
+    return response.json();
+  }
+  async fetchText(url) {
+    const response = await this.fetchOk(url);
+    return response.text();
+  }
+  async fetchOk(url) {
+    const response = await this.fetcher(url);
+    if (!response.ok) throw new Error(`Failed to load ${url}: ${response.status}`);
+    return response;
+  }
+  createSlideHost(slide, html, css) {
+    const host = this.doc.createElement("section");
+    host.classList.add("peitho-slide");
+    host.dataset.slideKey = slide.key;
+    host.dataset.slideIndex = String(slide.index);
+    host.dataset.peithoCanvas = "slide";
+    host.style.position = "absolute";
+    host.style.left = "0";
+    host.style.top = "0";
+    this.canvasCleanups.push(
+      installCanvasScaler({
+        window: this.win,
+        target: host,
+        viewport: this.viewport
+      })
+    );
+    const shadow = host.attachShadow({ mode: "open" });
+    const style = this.doc.createElement("style");
+    style.textContent = css;
+    shadow.appendChild(style);
+    const template = this.doc.createElement("template");
+    template.innerHTML = html;
+    shadow.appendChild(template.content.cloneNode(true));
+    return host;
+  }
+  resolveTarget(to) {
+    if (to === "first") return 0;
+    if (to === "last") return this.slides.length - 1;
+    if (to === "next") return Math.min(this.currentIndex + 1, this.slides.length - 1);
+    if (to === "prev") return Math.max(this.currentIndex - 1, 0);
+    if ("index" in to) {
+      if (to.index < 0 || to.index >= this.slides.length) {
+        this.log.error(`Unknown slide index: ${to.index}`);
+        return null;
+      }
+      return to.index;
+    }
+    const index = this.slides.findIndex((slide) => slide.meta.key === to.key);
+    if (index < 0) {
+      this.log.error(`Unknown slide key: ${to.key}`);
+      return null;
+    }
+    return index;
+  }
+  show(index) {
+    if (index < 0 || index >= this.slides.length) {
+      this.log.error(`Unknown slide target: ${index}`);
+      return;
+    }
+    if (index === this.currentIndex) return;
+    this.slides.forEach((slide2, slideIndex) => {
+      slide2.host.hidden = slideIndex !== index;
+    });
+    const previousIndex = this.currentIndex < 0 ? null : this.currentIndex;
+    this.currentIndex = index;
+    const slide = this.slides[index];
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:slidechange", {
+        detail: {
+          key: slide.meta.key,
+          index: slide.meta.index,
+          total: this.slides.length,
+          previousIndex
+        }
+      })
+    );
+  }
+  startPresentation() {
+    if (this.startedAtValue !== null) return;
+    this.startedAtValue = this.now();
+    this.pausedAtValue = null;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:presentationstart", {
+        detail: { total: this.slides.length, startedAt: this.startedAtValue }
+      })
+    );
+  }
+  endPresentation() {
+    if (this.ended || this.startedAtValue === null) return;
+    const endedAt = this.now();
+    const elapsedMs = this.elapsedMs();
+    this.ended = true;
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:presentationend", {
+        detail: { endedAt, elapsedMs }
+      })
+    );
+  }
+  pauseTimer() {
+    if (this.startedAtValue === null || this.pausedAtValue !== null) return;
+    this.pausedAtValue = this.now();
+  }
+  resumeTimer() {
+    if (this.pausedAtValue === null) return;
+    this.pausedTotalMs += this.now() - this.pausedAtValue;
+    this.pausedAtValue = null;
+  }
+  resetTimer() {
+    this.startedAtValue = null;
+    this.pausedAtValue = null;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+  }
+};
+
+// src/sync.ts
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function isCloseSyncMessage(value) {
+  return isRecord(value) && value.close === true;
+}
+function isIndexSyncMessage(value) {
+  return isRecord(value) && typeof value.index === "number";
+}
+function defaultChannelFactory(name) {
+  const channel = new BroadcastChannel(name);
+  let onmessage = null;
+  channel.onmessage = (event) => {
+    onmessage?.({ data: event.data });
+  };
+  return {
+    get onmessage() {
+      return onmessage;
+    },
+    set onmessage(next) {
+      onmessage = next;
+    },
+    postMessage(message) {
+      channel.postMessage(message);
+    },
+    close() {
+      channel.close();
+    }
+  };
+}
+function serverSyncChannelFactory(options = {}) {
+  const url = options.url ?? "/sync";
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const retryMs = options.retryMs ?? 1e3;
+  const setTimeoutFn = options.setTimeoutFn ?? window.setTimeout.bind(window);
+  const clearTimeoutFn = options.clearTimeoutFn ?? window.clearTimeout.bind(window);
+  const AbortControllerCtor = options.AbortControllerCtor ?? AbortController;
+  return () => {
+    let onmessage = null;
+    let closed = false;
+    let seq = 0;
+    let abortController = null;
+    let retryTimer = null;
+    const delay = () => new Promise((resolve) => {
+      retryTimer = setTimeoutFn(() => {
+        retryTimer = null;
+        resolve();
+      }, retryMs);
+    });
+    const handshake = async () => {
+      try {
+        const response = await fetcher(url);
+        if (closed) return false;
+        if (!response.ok) {
+          console.error(`Failed to start sync polling: ${response.status}`);
+          await delay();
+          return false;
+        }
+        const body = await response.json();
+        if (typeof body.seq !== "number") {
+          console.error("Invalid peitho sync handshake");
+          await delay();
+          return false;
+        }
+        seq = body.seq;
+        return true;
+      } catch (error) {
+        if (!closed) {
+          console.error(`Failed to start sync polling: ${String(error)}`);
+          await delay();
+        }
+        return false;
+      }
+    };
+    const poll = async () => {
+      while (!closed && !await handshake()) {
+        continue;
+      }
+      while (!closed) {
+        abortController = new AbortControllerCtor();
+        try {
+          const response = await fetcher(`${url}?seq=${seq}`, {
+            signal: abortController.signal
+          });
+          if (closed) return;
+          if (response.status === 204) continue;
+          if (!response.ok) {
+            console.error(`Failed to poll sync message: ${response.status}`);
+            await delay();
+            continue;
+          }
+          const body = await response.json();
+          if (typeof body.seq !== "number" || !("message" in body)) {
+            console.error("Invalid peitho server sync message");
+            await delay();
+            continue;
+          }
+          seq = body.seq;
+          onmessage?.({ data: body.message });
+        } catch (error) {
+          if (!closed) {
+            console.error(`Failed to poll sync message: ${String(error)}`);
+            await delay();
+          }
+        }
+      }
+    };
+    void poll();
+    return {
+      get onmessage() {
+        return onmessage;
+      },
+      set onmessage(next) {
+        onmessage = next;
+      },
+      postMessage(message) {
+        void fetcher(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(message),
+          keepalive: true
+        }).then((response) => {
+          if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
+        }).catch((error) => {
+          console.error(`Failed to post sync message: ${String(error)}`);
+        });
+      },
+      close() {
+        closed = true;
+        abortController?.abort();
+        if (retryTimer !== null) {
+          clearTimeoutFn(retryTimer);
+          retryTimer = null;
+        }
+      }
+    };
+  };
+}
+function installSyncBridge(win = window, channelFactory = defaultChannelFactory, bus = win, closeWindow = () => win.close()) {
+  const channel = channelFactory("peitho-sync");
+  const onSlideChange = (event) => {
+    const detail = event.detail;
+    if (typeof detail?.index !== "number") return;
+    channel.postMessage({ index: detail.index });
+  };
+  const onCloseRequest = () => {
+    channel.postMessage({ close: true });
+  };
+  channel.onmessage = (event) => {
+    const data = event.data;
+    if (isCloseSyncMessage(data)) {
+      closeWindow();
+      return;
+    }
+    if (isIndexSyncMessage(data)) {
+      bus.dispatchEvent(
+        new CustomEvent("peitho:navigate", { detail: { to: { index: data.index } } })
+      );
+      return;
+    }
+    console.error("Invalid peitho sync message");
+  };
+  bus.addEventListener("peitho:slidechange", onSlideChange);
+  bus.addEventListener("peitho:closerequest", onCloseRequest);
+  return () => {
+    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    bus.removeEventListener("peitho:closerequest", onCloseRequest);
+    channel.onmessage = null;
+    channel.close();
+  };
+}
+
+// src/presenter.ts
+function formatElapsed(ms) {
+  const totalSeconds = Math.floor(ms / 1e3);
+  const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, "0");
+  const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+function paneViewport(pane) {
+  return () => ({
+    width: pane.clientWidth,
+    height: pane.clientHeight
+  });
+}
+async function mountPresenterView(options) {
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const now = options.now ?? Date.now;
+  const closeWindow = options.closeWindow ?? (() => win.close());
+  const bus = win;
+  const previewBus = new EventTarget();
+  options.root.innerHTML = `
+    <section class="peitho-presenter">
+      <div class="peitho-presenter-pane" data-peitho-presenter="current"></div>
+      <aside>
+        <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
+        <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+        <section data-peitho-presenter="notes"></section>
+        <output data-peitho-presenter="timer">00:00</output>
+        <div class="peitho-presenter-controls">
+          <button type="button" data-peitho-action="prev">Prev</button>
+          <button type="button" data-peitho-action="next">Next</button>
+          <button type="button" data-peitho-action="start">Start</button>
+          <button type="button" data-peitho-action="pause">Pause</button>
+          <button type="button" data-peitho-action="resume">Resume</button>
+          <button type="button" data-peitho-action="reset">Reset</button>
+          <button type="button" data-peitho-action="close">Close</button>
+        </div>
+      </aside>
+    </section>`;
+  const currentRoot = options.root.querySelector('[data-peitho-presenter="current"]');
+  const previewRoot = options.root.querySelector('[data-peitho-presenter="preview"]');
+  const previewEnd = options.root.querySelector(
+    '[data-peitho-presenter="preview-end"]'
+  );
+  const notesRoot = options.root.querySelector('[data-peitho-presenter="notes"]');
+  const timerRoot = options.root.querySelector('[data-peitho-presenter="timer"]');
+  const mainShell = await mountPresentShell({
+    root: currentRoot,
+    fetcher,
+    window: win,
+    document: doc,
+    bus,
+    now,
+    viewport: paneViewport(currentRoot)
+  });
+  const previewShell = await mountPresentShell({
+    root: previewRoot,
+    fetcher,
+    window: win,
+    document: doc,
+    bus: previewBus,
+    now,
+    viewport: paneViewport(previewRoot)
+  });
+  const keyboardCleanup = installKeyboardNavigation(win, bus);
+  const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
+  function tick() {
+    timerRoot.textContent = formatElapsed(mainShell.elapsedMs());
+  }
+  function updateFromSlide(detail) {
+    notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide.";
+    const nextIndex = detail.index + 1;
+    if (nextIndex < detail.total) {
+      previewRoot.hidden = false;
+      previewEnd.hidden = true;
+      previewBus.dispatchEvent(
+        new CustomEvent("peitho:navigate", { detail: { to: { index: nextIndex } } })
+      );
+    } else {
+      previewRoot.hidden = true;
+      previewEnd.hidden = false;
+    }
+    tick();
+  }
+  const onSlideChange = (event) => {
+    updateFromSlide(event.detail);
+  };
+  bus.addEventListener("peitho:slidechange", onSlideChange);
+  const firstSlide = mainShell.manifest?.slides[mainShell.currentIndex];
+  if (firstSlide) {
+    updateFromSlide({
+      key: firstSlide.key,
+      index: firstSlide.index,
+      total: mainShell.manifest?.slideCount ?? 0,
+      previousIndex: null
+    });
+  }
+  options.root.querySelector('[data-peitho-action="prev"]')?.addEventListener("click", () => {
+    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
+  });
+  options.root.querySelector('[data-peitho-action="next"]')?.addEventListener("click", () => {
+    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+  });
+  for (const action of ["start", "pause", "resume", "reset"]) {
+    options.root.querySelector(`[data-peitho-action="${action}"]`)?.addEventListener("click", () => {
+      bus.dispatchEvent(new CustomEvent("peitho:timercontrol", { detail: { action } }));
+      tick();
+    });
+  }
+  options.root.querySelector('[data-peitho-action="close"]')?.addEventListener("click", () => {
+    closeWindow();
+  });
+  const interval = win.setInterval(tick, 250);
+  return {
+    mainShell,
+    previewShell,
+    tick,
+    destroy() {
+      win.clearInterval(interval);
+      bus.removeEventListener("peitho:slidechange", onSlideChange);
+      keyboardCleanup();
+      syncCleanup();
+      previewShell.destroy();
+      mainShell.destroy();
+    }
+  };
+}
+export {
+  CANVAS_HEIGHT,
+  CANVAS_WIDTH,
+  PRESENTER_URL,
+  calculateCanvasFit,
+  fallbackFeatures,
+  installCanvasClickNavigation,
+  installCanvasScaler,
+  installCloseOnEscape,
+  installFullscreenShortcut,
+  installKeyboardNavigation,
+  installPresentationControls,
+  installSyncBridge,
+  mountPresentShell,
+  mountPresenterView,
+  openPresenterPopup,
+  serverSyncChannelFactory,
+  toggleFullscreen
+};
+//# sourceMappingURL=shell.js.map


### PR DESCRIPTION
## Summary

Embed the last remaining repo-dependent asset — the presentation shell (`dist/shell.js`) — into the binary so `peitho present` also runs standalone. All three commands (build / present / publish) now work from just the deck file.

- `--shell` becomes `Option<PathBuf>`. Unset = write the embedded shell into the present cache. Explicit path = copy from that path as before ("shell bundle not found" only fires with an explicit path)
- shell.js is a build product, so it's managed with the same discipline as `bindings/`: commit `dist/shell.js` (re-included via .gitignore; the sourcemap stays ignored), and CI's node job runs `git diff --exit-code dist/shell.js` after `npm run build` to check for drift
- TS shell development flow stays natural: `npm run build` → cargo re-compiles (thanks to `include_str!`'s dependency tracking) and updates the embedded copy
- Adds shell drift check to CLAUDE.md gates, removes the "first-run npm build required" note from the README

## Verification

- All gates pass (cargo test 3 runs / clippy / fmt / bindings drift / full npm cycle / shell drift)
- Integration test added: with `--shell` unset, present-cache's shell.js matches the committed bundle byte-for-byte
- E2E: from a temp directory outside the repo (only deck.md), `peitho present deck.md --no-open` starts and /shell.js content matches the committed bundle

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
