### PR TITLE
feat: add demo site assembly and Cloudflare Pages deploy targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 packages/peitho-present/node_modules/
 packages/peitho-present/dist/*
 !packages/peitho-present/dist/shell.js
+/.demo-site

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,14 @@
 
 PRESENT_FLAGS ?=
 PRESENT = cargo run -q -p peitho -- present
+PEITHO = cargo run -q -p peitho --
+DEMO_OUT = .demo-site
+DEMO_DECKS = minimal lightning-talk code-walkthrough keynote
+WRANGLER ?= npx -y wrangler
 
 .PHONY: help minimal lightning-talk code-walkthrough keynote shell \
-	minimal-windowed lightning-talk-windowed code-walkthrough-windowed keynote-windowed
+	minimal-windowed lightning-talk-windowed code-walkthrough-windowed keynote-windowed \
+	demo-site deploy-demo
 
 help:
 	@echo "サンプルの動作確認ターゲット:"
@@ -16,6 +21,10 @@ help:
 	@echo ""
 	@echo "発表者画面を窓で開く: make keynote-windowed など <target>-windowed"
 	@echo "その他の追加フラグ:   make keynote PRESENT_FLAGS=\"--port 8000\""
+	@echo ""
+	@echo "デモサイト:"
+	@echo "  make demo-site    examplesを$(DEMO_OUT)/に組み立てて検査"
+	@echo "  make deploy-demo  Cloudflare Pagesへデプロイ（要wrangler認証）"
 
 minimal-windowed: PRESENT_FLAGS += --presenter-windowed
 minimal-windowed: minimal
@@ -43,3 +52,18 @@ code-walkthrough: shell
 
 keynote: shell
 	$(PRESENT) examples/keynote/deck.md $(PRESENT_FLAGS)
+
+demo-site:
+	rm -rf $(DEMO_OUT)
+	mkdir -p $(DEMO_OUT)
+	$(PEITHO) build examples/deck.md --out $(DEMO_OUT)/minimal
+	$(PEITHO) build examples/lightning-talk/deck.md --out $(DEMO_OUT)/lightning-talk
+	$(PEITHO) build examples/code-walkthrough/deck.md --out $(DEMO_OUT)/code-walkthrough
+	$(PEITHO) build examples/keynote/deck.md --out $(DEMO_OUT)/keynote
+	for d in $(DEMO_DECKS); do \
+		$(PEITHO) publish --dist $(DEMO_OUT)/$$d -- true || exit 1; \
+	done
+	cp demo/index.html $(DEMO_OUT)/index.html
+
+deploy-demo: demo-site
+	$(WRANGLER) pages deploy $(DEMO_OUT) --project-name peitho --branch main

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Peitho — demo</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #faf6ee;
+      color: #211f1c;
+      font-family: "Iowan Old Style", "Hiragino Mincho ProN", ui-serif, Georgia, serif;
+      min-height: 100svh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 24px;
+    }
+    main { max-width: 720px; width: 100%; }
+    h1 {
+      font-size: 56px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-align: center;
+    }
+    h1::after {
+      content: "";
+      display: block;
+      width: 72px;
+      height: 1px;
+      margin: 28px auto 0;
+      background: #9c8f76;
+    }
+    .lead {
+      margin: 28px auto 48px;
+      max-width: 34em;
+      text-align: center;
+      font-size: 17px;
+      line-height: 2;
+      color: #4c463d;
+    }
+    ul { list-style: none; }
+    li + li { margin-top: 16px; }
+    a.deck {
+      display: block;
+      padding: 20px 24px;
+      border: 1px solid #ddd3c0;
+      text-decoration: none;
+      color: inherit;
+      transition: border-color 0.15s ease;
+    }
+    a.deck:hover { border-color: #211f1c; }
+    a.deck .name {
+      font-size: 20px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    a.deck .desc {
+      margin-top: 6px;
+      font-size: 14.5px;
+      line-height: 1.8;
+      color: #4c463d;
+    }
+    footer {
+      margin-top: 48px;
+      text-align: center;
+      font-size: 14px;
+      color: #4c463d;
+    }
+    footer a { color: inherit; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Peitho</h1>
+    <p class="lead">Markdownをsource of truthにする、HTMLネイティブなプレゼンテーションツール。以下はサンプルデッキをそのまま<code>peitho build</code>して配信したデモです。</p>
+    <ul>
+      <li><a class="deck" href="./keynote/">
+        <span class="name">Keynote</span>
+        <span class="desc">セリフ体・中央寄せのキーノート。タイトルだけのスライドはcoverレイアウトへ、本文のあるスライドはstatementレイアウトへ、内容の形から自動でディスパッチされる。</span>
+      </a></li>
+      <li><a class="deck" href="./code-walkthrough/">
+        <span class="name">Code Walkthrough</span>
+        <span class="desc">ターミナル風2カラムのコード解説。毎スライドにコード必須の契約（arity="1"）、syntectによるビルド時シンタックスハイライト、キー付きCSS overrideの実例。</span>
+      </a></li>
+      <li><a class="deck" href="./lightning-talk/">
+        <span class="name">Lightning Talk</span>
+        <span class="desc">ダーク+大型タイポのLT向けデザイン。レイアウトにcodeスロットが無いので、コードを書くとビルドエラーになる。</span>
+      </a></li>
+      <li><a class="deck" href="./minimal/">
+        <span class="name">Minimal</span>
+        <span class="desc">バイナリ内蔵のデフォルトレイアウトとテーマだけで、deck.md単体からビルドした最小構成。</span>
+      </a></li>
+    </ul>
+    <footer><a href="https://github.com/mizzy/peitho">github.com/mizzy/peitho</a></footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Add assembly + deploy targets for the peitho demo site (serving the four example decks). The target is Cloudflare Pages (gosu.ke's DNS is on Cloudflare), planned host `peitho.gosu.ke`.

- `make demo-site`: builds each of the four samples into `.demo-site/<name>/` and **runs each deck through `peitho publish --dist … -- true`** (running the contamination and completeness checks through the same gatekeeper the real deploy uses) before dropping the landing page (`demo/index.html`, editorial style in the same family as the keynote example)
- `make deploy-demo`: `wrangler pages deploy .demo-site --project-name peitho` (swap the command via the `WRANGLER` variable; defaults to `npx -y wrangler`)
- `.demo-site/` is gitignored

## Verification

- `make demo-site` succeeds through build + 4-deck gatekeeper + landing placement
- Verified landing and `/keynote/` delivery in a real browser
- All gates pass (cargo test 3 runs / clippy / fmt / bindings drift / full npm cycle / shell drift)

Creating the Pages project, the initial deploy, and binding `peitho.gosu.ke` are done after wrangler authentication.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
