### PR TITLE
fix: phrase-aware wrapping for the demo landing page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -38,6 +38,9 @@
       font-size: 17px;
       line-height: 2;
       color: #4c463d;
+      line-break: strict;
+      word-break: auto-phrase;
+      text-wrap: balance;
     }
     ul { list-style: none; }
     li + li { margin-top: 16px; }
@@ -60,6 +63,8 @@
       font-size: 14.5px;
       line-height: 1.8;
       color: #4c463d;
+      line-break: strict;
+      word-break: auto-phrase;
     }
     footer {
       margin-top: 48px;


### PR DESCRIPTION
Fix a demo-site issue where the centered lead paragraph broke mid-word and left a "です。" orphan line. Apply the same `line-break: strict` + `word-break: auto-phrase` as the keynote theme, and add `text-wrap: balance` to the lead. Verified in a real browser and on the production deployment.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
