### PR TITLE
build: add serde_norway workspace dependency for deck frontmatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,7 @@ dependencies = [
  "pulldown-cmark",
  "serde",
  "serde_json",
+ "serde_norway",
  "syntect",
  "ts-rs",
 ]
@@ -980,6 +981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1061,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -1309,6 +1329,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "utf8-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ notify-debouncer-mini = "0.7.0"
 predicates = "3"
 pulldown-cmark = "0.10"
 serde = { version = "1", features = ["derive"] }
+serde_norway = "0.9"
 serde_json = "1"
 tempfile = "3"
 tiny_http = "0.12.0"

--- a/crates/peitho-core/Cargo.toml
+++ b/crates/peitho-core/Cargo.toml
@@ -12,6 +12,7 @@ html-escape.workspace = true
 lol_html.workspace = true
 pulldown-cmark.workspace = true
 serde.workspace = true
+serde_norway.workspace = true
 serde_json.workspace = true
 syntect.workspace = true
 ts-rs = { workspace = true, optional = true }

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -515,6 +515,18 @@ mod tests {
     use crate::{domain::FragmentKind, error::ErrorKind, phase::KeySource};
 
     #[test]
+    fn deck_frontmatter_yaml_dependency_is_available() {
+        #[derive(Debug, serde::Deserialize)]
+        struct Probe {
+            time: String,
+        }
+
+        let parsed: Probe = serde_norway::from_str("time: 15m\n").unwrap();
+
+        assert_eq!(parsed.time, "15m");
+    }
+
+    #[test]
     fn preserves_inline_markdown_and_generates_list_fragments() {
         let markdown = r#"<!-- {"key":"arch-1"} -->
 # **Architecture** `Phase`


### PR DESCRIPTION
Closes #45

## Summary

Task 1 of the time-tracking plan (`docs/plans/2026-07-03-time-tracking.md`). Adds `serde_norway` 0.9 (the actively maintained fork of serde_yaml) as a workspace dependency for reading YAML frontmatter via serde, and pins its availability from peitho-core with a probe test.

- `Cargo.toml`: `serde_norway = "0.9"` added under `[workspace.dependencies]`
- `crates/peitho-core/Cargo.toml`: `serde_norway.workspace = true`
- `crates/peitho-core/src/parser.rs`: probe test `deck_frontmatter_yaml_dependency_is_available` (TDD: confirmed to fail with E0433 before adding the dep)
- Production use lands in Tasks 2–3 (frontmatter parsing proper)

## Verification

- `cargo test --workspace` ×3 in a row pass
- `cargo clippy --workspace --all-targets -- -D warnings` pass
- `cargo fmt --all --check` pass
- `git diff --exit-code bindings/` pass
- `npm run build && npm test` (57 passed) `&& npm run typecheck` pass
- `git diff --exit-code packages/peitho-present/dist/shell.js` pass
- code-review (high, multi-agent): 0 correctness findings. The single "production dep but currently test-only use" note matches the plan's phased composition and requires no change
- Five rounds of self-review (overall / correctness / scope / tests / supply chain), all CLEAN

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
