### PR TITLE
feat: carry deck settings through the typestate Deck

### DIFF
--- a/crates/peitho-core/src/check.rs
+++ b/crates/peitho-core/src/check.rs
@@ -8,8 +8,9 @@ use crate::{
 };
 
 pub fn check_deck(deck: Deck<Mapped>) -> Result<Deck<Checked>> {
+    let (settings, mapped_slides) = deck.into_mapped_parts();
     let mut slides = Vec::new();
-    for slide in deck.into_mapped_slides() {
+    for slide in mapped_slides {
         let slide_number = slide.index + 1;
         let slide_key = slide.key.as_str().to_owned();
         check_slide(&slide).map_err(|err| err.with_slide(slide_number, Some(&slide_key)))?;
@@ -25,7 +26,7 @@ pub fn check_deck(deck: Deck<Mapped>) -> Result<Deck<Checked>> {
             checked_slots,
         ));
     }
-    Ok(Deck::checked(slides))
+    Ok(Deck::checked(settings, slides))
 }
 
 /// Validate one mapped slide against the layout it carries. Also used by

--- a/crates/peitho-core/src/mapping.rs
+++ b/crates/peitho-core/src/mapping.rs
@@ -19,15 +19,16 @@ use crate::{
 ///    exactly one structural match is required — none or several are build
 ///    errors that name the candidates and how to disambiguate
 pub fn dispatch_by_convention(deck: Deck<Parsed>, layouts: &Layouts) -> Result<Deck<Mapped>> {
+    let (settings, parsed_slides) = deck.into_parsed_parts();
     let mut slides = Vec::new();
-    for slide in deck.into_parsed_slides() {
+    for slide in parsed_slides {
         let slide_number = slide.index + 1;
         let slide_key = slide.key.as_str().to_owned();
         let mapped = dispatch_slide(slide, layouts)
             .map_err(|err| err.with_slide(slide_number, Some(&slide_key)))?;
         slides.push(mapped);
     }
-    Ok(Deck::mapped(slides))
+    Ok(Deck::mapped(settings, slides))
 }
 
 /// Single-layout convenience.

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::{
     domain::{FragmentKind, SlideKey, SourceFragment},
     error::{BuildError, ErrorKind, Result},
-    phase::{Deck, KeySource, LayoutRequest, Parsed, ParsedSlide},
+    phase::{Deck, DeckSettings, KeySource, LayoutRequest, Parsed, ParsedSlide, PlannedTime},
 };
 
 /// Page settings comment, deck-style: `<!-- {"key":"...","layout":"..."} -->`.
@@ -24,21 +24,6 @@ struct PageComment {
 #[serde(deny_unknown_fields)]
 struct DeckFrontmatter {
     #[serde(default, deserialize_with = "deserialize_optional_planned_time")]
-    time: Option<PlannedTime>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct PlannedTime(u64);
-
-impl PlannedTime {
-    #[allow(dead_code)] // Converted at the future Deck/manifest consumption boundary.
-    fn as_millis(self) -> u64 {
-        self.0
-    }
-}
-
-#[allow(dead_code)] // Carried on Deck in Task 5.
-struct ParsedDeckSettings {
     time: Option<PlannedTime>,
 }
 
@@ -85,7 +70,7 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
         frontmatter,
         ranges,
     } = split_slide_ranges(source)?;
-    let _settings = parse_deck_frontmatter(frontmatter.as_ref())?;
+    let settings = parse_deck_frontmatter(frontmatter.as_ref())?;
     if ranges.is_empty() {
         return Err(BuildError::new(
             ErrorKind::Parse,
@@ -100,7 +85,7 @@ pub fn parse_markdown(source: &str) -> Result<Deck<Parsed>> {
         slides.push(parse_slide(source, range, index)?);
     }
     validate_unique_keys(&slides)?;
-    Ok(Deck::parsed(slides))
+    Ok(Deck::parsed(settings, slides))
 }
 
 fn split_slide_ranges(source: &str) -> Result<SplitSlides> {
@@ -202,9 +187,6 @@ fn parse_planned_time_text(input: &str) -> std::result::Result<u64, String> {
 }
 
 fn minutes_to_millis(minutes: u64) -> std::result::Result<u64, String> {
-    if minutes == 0 {
-        return Err("time must be greater than zero".to_owned());
-    }
     minutes
         .checked_mul(60_000)
         .ok_or_else(|| "time is too large".to_owned())
@@ -213,14 +195,7 @@ fn minutes_to_millis(minutes: u64) -> std::result::Result<u64, String> {
 fn seconds_to_millis(seconds: u64) -> std::result::Result<u64, String> {
     seconds
         .checked_mul(1000)
-        .filter(|millis| *millis > 0)
-        .ok_or_else(|| {
-            if seconds == 0 {
-                "time must be greater than zero".to_owned()
-            } else {
-                "time is too large".to_owned()
-            }
-        })
+        .ok_or_else(|| "time is too large".to_owned())
 }
 
 impl<'de> Deserialize<'de> for PlannedTime {
@@ -241,15 +216,17 @@ impl<'de> Deserialize<'de> for PlannedTime {
             where
                 E: serde::de::Error,
             {
-                minutes_to_millis(value).map(PlannedTime).map_err(E::custom)
+                minutes_to_millis(value)
+                    .and_then(PlannedTime::from_millis)
+                    .map_err(E::custom)
             }
 
             fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                if value <= 0 {
-                    return Err(E::custom("time must be greater than zero"));
+                if value < 0 {
+                    return Err(E::custom("time must not be negative"));
                 }
                 self.visit_u64(value as u64)
             }
@@ -259,7 +236,7 @@ impl<'de> Deserialize<'de> for PlannedTime {
                 E: serde::de::Error,
             {
                 parse_planned_time_text(value)
-                    .map(PlannedTime)
+                    .and_then(PlannedTime::from_millis)
                     .map_err(E::custom)
             }
         }
@@ -268,12 +245,12 @@ impl<'de> Deserialize<'de> for PlannedTime {
     }
 }
 
-fn parse_deck_frontmatter(raw: Option<&RawFrontmatter>) -> Result<ParsedDeckSettings> {
+fn parse_deck_frontmatter(raw: Option<&RawFrontmatter>) -> Result<DeckSettings> {
     let Some(raw) = raw else {
-        return Ok(ParsedDeckSettings { time: None });
+        return Ok(DeckSettings::default());
     };
     if raw.yaml.trim().is_empty() {
-        return Ok(ParsedDeckSettings { time: None });
+        return Ok(DeckSettings::default());
     }
     validate_frontmatter_lines(raw)?;
 
@@ -291,7 +268,7 @@ fn parse_deck_frontmatter(raw: Option<&RawFrontmatter>) -> Result<ParsedDeckSett
     let parsed: DeckFrontmatter =
         serde_norway::from_str(&raw.yaml).map_err(|err| frontmatter_yaml_error(raw, &err))?;
 
-    Ok(ParsedDeckSettings { time: parsed.time })
+    Ok(DeckSettings::new(parsed.time))
 }
 
 fn first_nonblank_yaml_line(yaml: &str) -> usize {
@@ -353,7 +330,7 @@ fn frontmatter_help(message: &str) -> &'static str {
         "use only the supported deck frontmatter key: time"
     } else if message.contains("time")
         || message.contains("duration")
-        || message.contains("greater than zero")
+        || message.contains(PlannedTime::GREATER_THAN_ZERO_MESSAGE)
         || message.contains("unit")
         || message.contains("integer")
         || message.contains("u128")
@@ -923,7 +900,10 @@ mod tests {
 
         let settings = parse_deck_frontmatter(Some(&raw)).unwrap();
 
-        assert_eq!(settings.time.map(PlannedTime::as_millis), Some(900_000));
+        assert_eq!(
+            settings.planned_time().map(PlannedTime::as_millis),
+            Some(900_000)
+        );
     }
 
     #[test]
@@ -1234,7 +1214,7 @@ After list
 
     #[test]
     fn rejects_invalid_frontmatter_time_with_line_and_help() {
-        for value in ["0", "-1", "abc", ""] {
+        for value in ["0", "0s", "-1", "abc", ""] {
             let markdown = format!("---\ntime: {value}\n---\n# Intro");
             let err = parse_markdown(&markdown).unwrap_err();
             assert_eq!(err.kind, ErrorKind::Parse);
@@ -1259,7 +1239,9 @@ After list
         }
 
         let err = serde_norway::from_str::<DeckFrontmatter>("time: 0\n").unwrap_err();
-        assert!(err.to_string().contains("time must be greater than zero"));
+        assert!(err
+            .to_string()
+            .contains(PlannedTime::GREATER_THAN_ZERO_MESSAGE));
     }
 
     #[test]
@@ -1360,7 +1342,10 @@ After list
         let settings = parse_deck_frontmatter(Some(&raw)).unwrap();
         let deck = parse_markdown("---\ntime: 15m\n\n---\n\n# A").unwrap();
 
-        assert_eq!(settings.time.map(PlannedTime::as_millis), Some(900_000));
+        assert_eq!(
+            settings.planned_time().map(PlannedTime::as_millis),
+            Some(900_000)
+        );
         assert_eq!(deck.parsed_slides().len(), 1);
         assert_eq!(deck.parsed_slides()[0].key.as_str(), "a");
     }

--- a/crates/peitho-core/src/phase.rs
+++ b/crates/peitho-core/src/phase.rs
@@ -5,8 +5,43 @@ use crate::{
     layout::Layout,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlannedTime(u64);
+
+impl PlannedTime {
+    pub(crate) const GREATER_THAN_ZERO_MESSAGE: &'static str = "time must be greater than zero";
+
+    pub(crate) fn from_millis(millis: u64) -> std::result::Result<Self, String> {
+        if millis == 0 {
+            Err(Self::GREATER_THAN_ZERO_MESSAGE.to_owned())
+        } else {
+            Ok(Self(millis))
+        }
+    }
+
+    pub fn as_millis(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DeckSettings {
+    planned_time: Option<PlannedTime>,
+}
+
+impl DeckSettings {
+    pub fn new(planned_time: Option<PlannedTime>) -> Self {
+        Self { planned_time }
+    }
+
+    pub fn planned_time(&self) -> Option<PlannedTime> {
+        self.planned_time
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Deck<P> {
+    settings: DeckSettings,
     phase: P,
 }
 
@@ -125,9 +160,16 @@ pub struct Rendered {
     css: String,
 }
 
+impl<P> Deck<P> {
+    pub fn settings(&self) -> &DeckSettings {
+        &self.settings
+    }
+}
+
 impl Deck<Parsed> {
-    pub(crate) fn parsed(slides: Vec<ParsedSlide>) -> Self {
+    pub(crate) fn parsed(settings: DeckSettings, slides: Vec<ParsedSlide>) -> Self {
         Self {
+            settings,
             phase: Parsed { slides },
         }
     }
@@ -136,14 +178,15 @@ impl Deck<Parsed> {
         &self.phase.slides
     }
 
-    pub(crate) fn into_parsed_slides(self) -> Vec<ParsedSlide> {
-        self.phase.slides
+    pub(crate) fn into_parsed_parts(self) -> (DeckSettings, Vec<ParsedSlide>) {
+        (self.settings, self.phase.slides)
     }
 }
 
 impl Deck<Mapped> {
-    pub(crate) fn mapped(slides: Vec<MappedSlide>) -> Self {
+    pub(crate) fn mapped(settings: DeckSettings, slides: Vec<MappedSlide>) -> Self {
         Self {
+            settings,
             phase: Mapped { slides },
         }
     }
@@ -152,8 +195,8 @@ impl Deck<Mapped> {
         &self.phase.slides
     }
 
-    pub(crate) fn into_mapped_slides(self) -> Vec<MappedSlide> {
-        self.phase.slides
+    pub(crate) fn into_mapped_parts(self) -> (DeckSettings, Vec<MappedSlide>) {
+        (self.settings, self.phase.slides)
     }
 }
 
@@ -198,8 +241,9 @@ impl CheckedSlide {
 }
 
 impl Deck<Checked> {
-    pub(crate) fn checked(slides: Vec<CheckedSlide>) -> Self {
+    pub(crate) fn checked(settings: DeckSettings, slides: Vec<CheckedSlide>) -> Self {
         Self {
+            settings,
             phase: Checked { slides },
         }
     }
@@ -236,14 +280,19 @@ impl Deck<Checked> {
         &self.phase.slides
     }
 
-    pub(crate) fn into_checked_slides(self) -> Vec<CheckedSlide> {
-        self.phase.slides
+    pub(crate) fn into_checked_parts(self) -> (DeckSettings, Vec<CheckedSlide>) {
+        (self.settings, self.phase.slides)
     }
 }
 
 impl Deck<Rendered> {
-    pub(crate) fn rendered(slides: Vec<RenderedSlide>, css: String) -> Self {
+    pub(crate) fn rendered(
+        settings: DeckSettings,
+        slides: Vec<RenderedSlide>,
+        css: String,
+    ) -> Self {
         Self {
+            settings,
             phase: Rendered { slides, css },
         }
     }
@@ -277,13 +326,16 @@ mod tests {
 
     #[test]
     fn parsed_deck_owns_source_fragments() {
-        let deck = Deck::parsed(vec![ParsedSlide {
-            key: SlideKey::new("arch-1").unwrap(),
-            index: 0,
-            key_source: KeySource::Explicit { line: 1 },
-            layout_request: None,
-            fragments: vec![SourceFragment::paragraph(3, "body")],
-        }]);
+        let deck = Deck::parsed(
+            DeckSettings::default(),
+            vec![ParsedSlide {
+                key: SlideKey::new("arch-1").unwrap(),
+                index: 0,
+                key_source: KeySource::Explicit { line: 1 },
+                layout_request: None,
+                fragments: vec![SourceFragment::paragraph(3, "body")],
+            }],
+        );
 
         assert_eq!(deck.parsed_slides()[0].fragments[0].line(), 3);
     }

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -14,12 +14,13 @@ use crate::{
 };
 
 pub fn render_deck(deck: Deck<Checked>) -> Result<Deck<Rendered>> {
+    let (settings, checked_slides) = deck.into_checked_parts();
     let mut slides = Vec::new();
-    for slide in deck.into_checked_slides() {
+    for slide in checked_slides {
         let html = render_slide(slide.key(), slide.slots(), slide.layout())?;
         slides.push(RenderedSlide::new(slide.index(), slide.key().clone(), html));
     }
-    Ok(Deck::rendered(slides, String::new()))
+    Ok(Deck::rendered(settings, slides, String::new()))
 }
 
 fn render_slide(
@@ -410,7 +411,8 @@ pub fn render_presenter_index() -> String {
 mod tests {
     use super::*;
     use crate::{
-        check::check_deck, layout::parse_layout, mapping::map_by_convention, parser::parse_markdown,
+        check::check_deck, layout::parse_layout, mapping::map_by_convention,
+        parser::parse_markdown, phase::PlannedTime,
     };
 
     #[test]
@@ -523,6 +525,27 @@ mod tests {
 
         assert_eq!(rendered.slides()[0].src(), "slides/000-intro.html");
         assert_eq!(rendered.slides()[1].src(), "slides/001-details.html");
+    }
+
+    #[test]
+    fn deck_settings_survive_all_typestate_transitions() {
+        let layout = parse_layout(
+            "title-only",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let parsed = parse_markdown("---\ntime: 15m\n---\n# Intro").unwrap();
+        let mapped = map_by_convention(parsed, &layout).unwrap();
+        let checked = check_deck(mapped).unwrap();
+        let rendered = render_deck(checked).unwrap();
+
+        assert_eq!(
+            rendered
+                .settings()
+                .planned_time()
+                .map(PlannedTime::as_millis),
+            Some(900_000)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #49

## Summary

Task 5 of the time-tracking plan: `Deck<P>` carries `DeckSettings` through every typestate transition (Parsed→Mapped→Checked→Rendered) with no failure path.

- Every phase constructor requires `DeckSettings`; consumers use `into_*_parts() -> (DeckSettings, Vec<_>)`, so a transition cannot silently drop the settings — the type forces the hand-off
- `settings()` accessor lives once on `impl<P> Deck<P>`
- Deviation from the plan (per the type-safety principle settled in #63): `DeckSettings` holds the validated `Option<PlannedTime>` newtype instead of erasing to `Option<u64>`; `as_millis()` is deferred to the consumption boundary (Task 6 manifest)
- Zero validation is now a single gate in `PlannedTime::from_millis` with a shared message const also used by help routing — the review found the check quadruplicated across two files with the from_millis branch dead on all paths

## Verification

- `cargo test --workspace` ×3 pass (113 core tests incl. the 4-phase survival test) / clippy `-D warnings` / fmt / bindings drift / npm build+test(57)+typecheck / shell.js drift all pass
- code-review workflow (high): 1 confirmed finding (validation duplication), fixed; 5-round self-review all CLEAN (spec, correctness, scope, tests, API surface incl. compile_fail doctest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
