### PR TITLE
feat: write present.json from the browser launch plan

### DIFF
--- a/crates/peitho/src/browser.rs
+++ b/crates/peitho/src/browser.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command,
 };
 
-use crate::displays::{PresentationLayout, SavedWindowBounds, WindowPlacement};
+use crate::displays::{self, PresentationLayout, SavedWindowBounds, WindowPlacement};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BrowserPlatform {
@@ -30,8 +30,21 @@ pub struct BrowserEnvironment {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrowserCommand {
+    pub role: WindowRole,
     pub program: OsString,
     pub args: Vec<OsString>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowRole {
+    Slides,
+    Presenter,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserPlan {
+    pub commands: Vec<BrowserCommand>,
+    pub opens_presenter: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -112,7 +125,7 @@ fn chrome_presenter_args(
     args
 }
 
-fn macos_chrome_command(args: Vec<OsString>) -> BrowserCommand {
+fn macos_chrome_command(role: WindowRole, args: Vec<OsString>) -> BrowserCommand {
     let mut full_args = vec![
         OsString::from("-na"),
         OsString::from("Google Chrome"),
@@ -120,6 +133,7 @@ fn macos_chrome_command(args: Vec<OsString>) -> BrowserCommand {
     ];
     full_args.extend(args);
     BrowserCommand {
+        role,
         program: OsString::from("open"),
         args: full_args,
     }
@@ -133,31 +147,38 @@ pub fn plan_browser_commands(
         BrowserPlatform::Macos if env.mac_google_chrome_available => {
             let Some(profiles) = env.chrome_profiles.as_ref() else {
                 return vec![BrowserCommand {
+                    role: WindowRole::Slides,
                     program: OsString::from("open"),
                     args: vec![OsString::from(request.slides_url)],
                 }];
             };
             if let Some(layout) = env.layout.filter(|_| !request.no_presenter) {
                 return vec![
-                    macos_chrome_command(chrome_slides_args(
-                        &profiles.slides,
-                        request.slides_url,
-                        Some(layout.slides),
-                    )),
-                    macos_chrome_command(chrome_presenter_args(
-                        &profiles.presenter,
-                        request.presenter_url,
-                        layout.presenter,
-                    )),
+                    macos_chrome_command(
+                        WindowRole::Slides,
+                        chrome_slides_args(
+                            &profiles.slides,
+                            request.slides_url,
+                            Some(layout.slides),
+                        ),
+                    ),
+                    macos_chrome_command(
+                        WindowRole::Presenter,
+                        chrome_presenter_args(
+                            &profiles.presenter,
+                            request.presenter_url,
+                            layout.presenter,
+                        ),
+                    ),
                 ];
             }
-            vec![macos_chrome_command(chrome_slides_args(
-                &profiles.slides,
-                request.slides_url,
-                None,
-            ))]
+            vec![macos_chrome_command(
+                WindowRole::Slides,
+                chrome_slides_args(&profiles.slides, request.slides_url, None),
+            )]
         }
         BrowserPlatform::Macos => vec![BrowserCommand {
+            role: WindowRole::Slides,
             program: OsString::from("open"),
             args: vec![OsString::from(request.slides_url)],
         }],
@@ -172,12 +193,14 @@ fn linux_browser_commands(
 ) -> Vec<BrowserCommand> {
     let Some(program) = env.linux_browser.as_deref() else {
         return vec![BrowserCommand {
+            role: WindowRole::Slides,
             program: OsString::from("xdg-open"),
             args: vec![OsString::from(request.slides_url)],
         }];
     };
     let Some(profiles) = env.chrome_profiles.as_ref() else {
         return vec![BrowserCommand {
+            role: WindowRole::Slides,
             program: OsString::from("xdg-open"),
             args: vec![OsString::from(request.slides_url)],
         }];
@@ -186,10 +209,12 @@ fn linux_browser_commands(
     if let Some(layout) = env.layout.filter(|_| !request.no_presenter) {
         return vec![
             BrowserCommand {
+                role: WindowRole::Slides,
                 program: program.to_owned(),
                 args: chrome_slides_args(&profiles.slides, request.slides_url, Some(layout.slides)),
             },
             BrowserCommand {
+                role: WindowRole::Presenter,
                 program: program.to_owned(),
                 args: chrome_presenter_args(
                     &profiles.presenter,
@@ -201,9 +226,26 @@ fn linux_browser_commands(
     }
 
     vec![BrowserCommand {
+        role: WindowRole::Slides,
         program: program.to_owned(),
         args: chrome_slides_args(&profiles.slides, request.slides_url, None),
     }]
+}
+
+pub fn plan_browser(request: &BrowserOpenRequest<'_>, env: &BrowserEnvironment) -> BrowserPlan {
+    BrowserPlan::from_commands(plan_browser_commands(request, env))
+}
+
+impl BrowserPlan {
+    fn from_commands(commands: Vec<BrowserCommand>) -> Self {
+        let opens_presenter = commands
+            .iter()
+            .any(|command| command.role == WindowRole::Presenter);
+        Self {
+            commands,
+            opens_presenter,
+        }
+    }
 }
 
 fn chrome_app_exists() -> bool {
@@ -389,12 +431,28 @@ fn prepare_profile_dirs(profiles: Option<&ChromeProfiles>) -> bool {
     true
 }
 
-pub fn open_browser_with_request(
+fn presenter_mode(
+    presenter_windowed: bool,
+    profiles: Option<&ChromeProfiles>,
+) -> displays::PresenterMode {
+    if presenter_windowed {
+        displays::PresenterMode::Windowed {
+            saved: profiles.and_then(saved_presenter_bounds),
+        }
+    } else {
+        displays::PresenterMode::Fullscreen
+    }
+}
+
+pub fn plan_browser_with_request(
     request: BrowserOpenRequest<'_>,
-    layout: Option<PresentationLayout>,
-) {
+    presenter_windowed: bool,
+) -> BrowserPlan {
     let mut env = current_environment();
-    env.layout = layout;
+    env.layout = displays::detect_presentation_layout(presenter_mode(
+        presenter_windowed,
+        env.chrome_profiles.as_ref(),
+    ));
     if !prepare_profile_dirs(env.chrome_profiles.as_ref()) {
         env.chrome_profiles = None;
     }
@@ -402,12 +460,15 @@ pub fn open_browser_with_request(
         terminate_stale_profile_instances(profiles);
     }
 
-    let commands = plan_browser_commands(&request, &env);
-    if commands.is_empty() {
+    plan_browser(&request, &env)
+}
+
+pub fn open_browser_plan(plan: BrowserPlan) {
+    if plan.commands.is_empty() {
         eprintln!("warning: browser auto-open is not supported on this platform");
         return;
     }
-    for command in commands {
+    for command in plan.commands {
         if let Err(err) = Command::new(&command.program).args(&command.args).spawn() {
             eprintln!(
                 "warning: failed to open browser with {}: {err}",
@@ -501,6 +562,8 @@ mod tests {
         let commands = plan_browser_commands(&test_request(false), &env);
 
         assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].role, WindowRole::Slides);
+        assert_eq!(commands[1].role, WindowRole::Presenter);
         assert_eq!(
             commands[0].args,
             vec![
@@ -649,6 +712,7 @@ mod tests {
         let commands = plan_browser_commands(&test_request(true), &env);
 
         assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].role, WindowRole::Slides);
         assert!(commands[0]
             .args
             .contains(&OsString::from("--start-fullscreen")));
@@ -656,6 +720,57 @@ mod tests {
             .args
             .iter()
             .any(|arg| arg == "--window-size=1200,800"));
+    }
+
+    #[test]
+    fn browser_plan_reports_presenter_open_for_two_display_chrome_plan() {
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: true,
+            linux_browser: None,
+            chrome_profiles: Some(test_profiles()),
+            layout: Some(test_layout()),
+        };
+
+        let plan = plan_browser(&test_request(false), &env);
+
+        assert!(plan.opens_presenter);
+        assert_eq!(plan.commands.len(), 2);
+        assert_eq!(plan.commands[1].role, WindowRole::Presenter);
+    }
+
+    #[test]
+    fn browser_plan_reports_no_presenter_when_chrome_is_unavailable() {
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: false,
+            linux_browser: None,
+            chrome_profiles: Some(test_profiles()),
+            layout: Some(test_layout()),
+        };
+
+        let plan = plan_browser(&test_request(false), &env);
+
+        assert!(!plan.opens_presenter);
+        assert_eq!(plan.commands.len(), 1);
+        assert_eq!(plan.commands[0].role, WindowRole::Slides);
+    }
+
+    #[test]
+    fn browser_plan_reports_no_presenter_when_disabled_by_flag() {
+        let env = BrowserEnvironment {
+            platform: BrowserPlatform::Macos,
+            mac_google_chrome_available: true,
+            linux_browser: None,
+            chrome_profiles: Some(test_profiles()),
+            layout: Some(test_layout()),
+        };
+
+        let plan = plan_browser(&test_request(true), &env);
+
+        assert!(!plan.opens_presenter);
+        assert_eq!(plan.commands.len(), 1);
+        assert_eq!(plan.commands[0].role, WindowRole::Slides);
     }
 
     #[test]

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -12,7 +12,7 @@ use miette::IntoDiagnostic;
 use notify::{PollWatcher, RecursiveMode};
 use notify_debouncer_mini::{new_debouncer_opt, Config as DebounceConfig, DebounceEventResult};
 
-use peitho::{browser, displays, server};
+use peitho::{browser, server};
 
 struct BuildArtifacts {
     slide_count: usize,
@@ -648,35 +648,35 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         effective_asset_path(&options.layouts, &options.input, "layouts").as_deref(),
         effective_asset_path(&options.css, &options.input, "css").as_deref(),
     )?;
-    emit_present_cache(&cache, &artifacts, options.shell.as_deref())?;
     if options.no_serve {
+        emit_present_cache(&cache, &artifacts, options.shell.as_deref(), false)?;
         println!("generated present cache at {}", cache.display());
         return Ok(());
     }
 
-    let server = server::PresentServer::bind(cache, options.port)?;
+    let server = server::PresentServer::bind(cache.clone(), options.port)?;
     let url = server.url();
     let presenter_url = browser::presenter_url(&url);
-    println!("serving presentation at {url}");
-    std::io::stdout().flush().into_diagnostic()?;
-    if !options.no_open {
-        let presenter_mode = if options.presenter_windowed {
-            displays::PresenterMode::Windowed {
-                saved: browser::chrome_profiles_from_home(std::env::var_os("HOME"))
-                    .as_ref()
-                    .and_then(browser::saved_presenter_bounds),
-            }
-        } else {
-            displays::PresenterMode::Fullscreen
-        };
-        browser::open_browser_with_request(
+    let browser_plan = if options.no_open {
+        None
+    } else {
+        Some(browser::plan_browser_with_request(
             browser::BrowserOpenRequest {
                 slides_url: &url,
                 presenter_url: &presenter_url,
                 no_presenter: options.no_presenter,
             },
-            displays::detect_presentation_layout(presenter_mode),
-        );
+            options.presenter_windowed,
+        ))
+    };
+    let presenter_open = browser_plan
+        .as_ref()
+        .is_some_and(|plan| plan.opens_presenter);
+    emit_present_cache(&cache, &artifacts, options.shell.as_deref(), presenter_open)?;
+    println!("serving presentation at {url}");
+    std::io::stdout().flush().into_diagnostic()?;
+    if let Some(plan) = browser_plan {
+        browser::open_browser_plan(plan);
     }
     let result = server.serve_forever();
     if !options.no_open {
@@ -689,6 +689,7 @@ fn emit_present_cache(
     cache: &Path,
     artifacts: &BuildArtifacts,
     shell: Option<&Path>,
+    presenter_open: bool,
 ) -> miette::Result<()> {
     if let Some(shell) = shell {
         ensure_shell_bundle(shell)?;
@@ -699,6 +700,13 @@ fn emit_present_cache(
     fs::write(
         cache.join("notes.json"),
         core(peitho_core::notes_json(&peitho_core::Notes::empty()))?,
+    )
+    .into_diagnostic()?;
+    fs::write(
+        cache.join("present.json"),
+        core(peitho_core::present_config_json(
+            &peitho_core::PresentConfig::new(presenter_open),
+        ))?,
     )
     .into_diagnostic()?;
     fs::write(
@@ -1060,6 +1068,23 @@ mod tests {
                 panic!("expected present command");
             }
         }
+    }
+
+    #[test]
+    fn emit_present_cache_writes_present_json() {
+        let fixture = WatchFixture::new("# Intro\n");
+        let artifacts = build_artifacts(
+            &fixture.options.input,
+            fixture.options.effective_layouts().as_deref(),
+            fixture.options.effective_css().as_deref(),
+        )
+        .unwrap();
+
+        fs::create_dir_all(&fixture.options.out).unwrap();
+        emit_present_cache(&fixture.options.out, &artifacts, None, true).unwrap();
+
+        let json = fs::read_to_string(fixture.options.out.join("present.json")).unwrap();
+        assert!(json.contains(r#""presenterOpen": true"#));
     }
 
     #[test]

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -53,10 +53,14 @@ fn present_no_serve_writes_clean_present_cache() {
     assert!(cache.join("peitho.css").exists());
     assert!(cache.join("manifest.json").exists());
     assert!(cache.join("notes.json").exists());
+    assert!(cache.join("present.json").exists());
     assert!(cache.join("slides/000-arch-1.html").exists());
     assert!(fs::read_to_string(cache.join("notes.json"))
         .unwrap()
         .contains(r#""notes": {}"#));
+    assert!(fs::read_to_string(cache.join("present.json"))
+        .unwrap()
+        .contains(r#""presenterOpen": false"#));
     assert!(fs::read_to_string(cache.join("present.html"))
         .unwrap()
         .contains("installSyncBridge(window, serverSyncChannelFactory())"));

--- a/docs/specs/2026-07-03-time-tracking-design.md
+++ b/docs/specs/2026-07-03-time-tracking-design.md
@@ -88,13 +88,13 @@ Rejected alternatives:
 
 ### D4: The display destination decision is finalized by the CLI at launch time (`presenter_open`)
 
-`presenter_open = !no_open && !no_presenter && display layout detection is Some`
+`presenter_open` = the launch plan (`BrowserPlan`) contains a command that opens the presenter window. **Refined during Task 9 implementation (2026-07-04)**: the original formula `!no_open && !no_presenter && detection is Some` re-derived the decision from fewer inputs than the code that actually opens windows (`browser.rs` also falls back to slides-only when Chrome is unavailable or profile preparation fails), so present.json could claim a presenter that never opens. The single source of truth is the browser launch plan itself; `opens_presenter` is derived structurally from the planned commands, not re-computed from flags.
 
-- 2 displays (presenter window present) → `true` → tracker shows **only on the presenter screen**
+- 2 displays (presenter window planned) → `true` → tracker shows **only on the presenter screen**
 - 1 display + default Fullscreen (no presenter window) → `false` → tracker shows **on the presentation screen**
 - `--presenter-windowed` (1-screen debugging, both windows) → `true` → presenter screen only
-- `--no-presenter` → `false` → presentation screen
-- Implementation-wise, the layout detection inside `present()` runs once, before `emit_present_cache`, so both the config write-out and the browser launch use the same detection result
+- `--no-presenter`, Chrome unavailable, or profile preparation failure → `false` → presentation screen
+- Ordering inside `present()`: build → (`--no-serve`: emit with `false` and return) → server bind → detect+plan once → emit present.json from the plan → announce URL → execute the plan → serve. Binding first keeps early `/sync` clients in the listener backlog instead of connection-refused during the JXA detection window, and a bind failure never leaves a cache claiming a presenter that was not opened
 
 Frontend display rules:
 - presenter.html: show the tracker if `manifest.plannedDurationMs != null`


### PR DESCRIPTION
Closes #53

## Summary

Task 9 of the time-tracking plan: the CLI finalizes `presenterOpen` at launch and writes `present.json` into the present cache.

- **Single source of truth**: the review found the planned `presenter_open = !no_open && !no_presenter && detection.is_some()` formula re-derives the decision from fewer inputs than `browser.rs` (which falls back to slides-only when Chrome is missing or profile preparation fails), so present.json could lie. Instead, browser planning now returns role-tagged commands (`WindowRole::Slides/Presenter`) and `BrowserPlan.opens_presenter` is derived structurally from the plan — the same plan that is then executed
- **Ordering**: `present()` now binds the server before the JXA display detection, so early `/sync` clients wait in the listener backlog instead of connection-refused, and a bind failure cannot leave a stale cache claiming an open presenter. `--no-serve`/`--no-open` skip detection and record `false`
- Design doc D4 updated to record the refinement

## Verification

- `cargo test --workspace` ×3 pass / clippy `-D warnings` / fmt / bindings & shell.js drift all pass
- 5-round self-review incl. a runtime round driving the real CLI: `--no-serve` cache contents, `GET /present.json` over the long-poll server, close handshake, and dist/ non-contamination (`build` output has no present.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
