### PR TITLE
feat: add the rabbit-and-turtle time tracker component

### DIFF
--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -697,6 +697,72 @@ async function mountPresenterView(options) {
     }
   };
 }
+
+// src/timeTracker.ts
+var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
+function isValidSlideChangeDetail(detail) {
+  if (typeof detail !== "object" || detail === null) return false;
+  const candidate = detail;
+  const { index, previousIndex, total } = candidate;
+  return typeof index === "number" && Number.isFinite(index) && index >= 0 && typeof total === "number" && Number.isFinite(total) && total > 0 && (previousIndex === null || typeof previousIndex === "number" && Number.isFinite(previousIndex) && previousIndex >= 0);
+}
+function installTimeTracker(options) {
+  if (!Number.isFinite(options.plannedDurationMs) || options.plannedDurationMs <= 0) {
+    throw new Error("plannedDurationMs must be a positive finite number");
+  }
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const log = options.console ?? console;
+  const bus = options.bus ?? win;
+  const track = doc.createElement("div");
+  track.className = "peitho-time-tracker";
+  track.dataset.peithoTimeTracker = options.variant ?? "present";
+  track.innerHTML = [
+    '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
+    '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>'
+  ].join("");
+  options.root.appendChild(track);
+  const rabbit = track.querySelector('[data-peitho-marker="rabbit"]');
+  const turtle = track.querySelector('[data-peitho-marker="turtle"]');
+  let autoStarted = false;
+  const setMarker = (element, ratio) => {
+    element.style.left = `${Math.round(ratio * 1e4) / 100}%`;
+  };
+  const updateSlides = (index, total) => {
+    const ratio = total <= 1 ? 0 : index / (total - 1);
+    setMarker(rabbit, clamp01(ratio));
+  };
+  const tick = () => {
+    const ratio = options.shell.elapsedMs() / options.plannedDurationMs;
+    setMarker(turtle, clamp01(ratio));
+    track.toggleAttribute("data-peitho-overrun", ratio > 1);
+  };
+  const onSlideChange = (event) => {
+    const detail = event.detail;
+    if (!isValidSlideChangeDetail(detail)) {
+      log.error("Invalid peitho:slidechange event");
+      return;
+    }
+    updateSlides(detail.index, detail.total);
+    if (!autoStarted && detail.previousIndex !== null && detail.index > detail.previousIndex) {
+      autoStarted = true;
+      bus.dispatchEvent(
+        new CustomEvent("peitho:timercontrol", {
+          detail: { action: "start" }
+        })
+      );
+    }
+  };
+  updateSlides(options.shell.currentIndex, options.shell.manifest?.slideCount ?? 0);
+  tick();
+  bus.addEventListener("peitho:slidechange", onSlideChange);
+  const interval = win.setInterval(tick, 250);
+  return () => {
+    win.clearInterval(interval);
+    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    track.remove();
+  };
+}
 export {
   CANVAS_HEIGHT,
   CANVAS_WIDTH,
@@ -710,6 +776,7 @@ export {
   installKeyboardNavigation,
   installPresentationControls,
   installSyncBridge,
+  installTimeTracker,
   mountPresentShell,
   mountPresenterView,
   openPresenterPopup,

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -26,6 +26,7 @@ export { installCloseOnEscape, installKeyboardNavigation } from "./keyboard";
 export { mountPresenterView } from "./presenter";
 export { mountPresentShell } from "./shell";
 export { installSyncBridge, serverSyncChannelFactory } from "./sync";
+export { installTimeTracker } from "./timeTracker";
 export type { PresenterOptions, PresenterView } from "./presenter";
 export type {
   NavigateDetail,
@@ -43,3 +44,4 @@ export type {
   SyncChannelFactory,
   SyncMessage
 } from "./sync";
+export type { TimeTrackerOptions, TimeTrackerShell } from "./timeTracker";

--- a/packages/peitho-present/src/timeTracker.ts
+++ b/packages/peitho-present/src/timeTracker.ts
@@ -1,0 +1,98 @@
+import type { SlideChangeDetail, TimerControlDetail } from "./shell";
+
+export type TimeTrackerShell = {
+  manifest: { slideCount: number } | null;
+  currentIndex: number;
+  elapsedMs(): number;
+};
+
+export type TimeTrackerOptions = {
+  root: HTMLElement;
+  shell: TimeTrackerShell;
+  plannedDurationMs: number;
+  window?: Window;
+  document?: Document;
+  console?: Pick<Console, "error">;
+  bus?: EventTarget;
+  variant?: "present" | "presenter";
+};
+
+const clamp01 = (ratio: number): number => Math.min(Math.max(ratio, 0), 1);
+
+function isValidSlideChangeDetail(detail: unknown): detail is SlideChangeDetail {
+  if (typeof detail !== "object" || detail === null) return false;
+  const candidate = detail as Partial<SlideChangeDetail>;
+  const { index, previousIndex, total } = candidate;
+  return (
+    typeof index === "number" &&
+    Number.isFinite(index) &&
+    index >= 0 &&
+    typeof total === "number" &&
+    Number.isFinite(total) &&
+    total > 0 &&
+    (previousIndex === null ||
+      (typeof previousIndex === "number" && Number.isFinite(previousIndex) && previousIndex >= 0))
+  );
+}
+
+export function installTimeTracker(options: TimeTrackerOptions): () => void {
+  if (!Number.isFinite(options.plannedDurationMs) || options.plannedDurationMs <= 0) {
+    throw new Error("plannedDurationMs must be a positive finite number");
+  }
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const log = options.console ?? console;
+  const bus = options.bus ?? win;
+  const track = doc.createElement("div");
+  track.className = "peitho-time-tracker";
+  track.dataset.peithoTimeTracker = options.variant ?? "present";
+  track.innerHTML = [
+    '<span data-peitho-marker="rabbit" aria-label="slide progress">🐰</span>',
+    '<span data-peitho-marker="turtle" aria-label="time progress">🐢</span>'
+  ].join("");
+  options.root.appendChild(track);
+
+  const rabbit = track.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')!;
+  const turtle = track.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')!;
+  let autoStarted = false;
+
+  const setMarker = (element: HTMLElement, ratio: number): void => {
+    element.style.left = `${Math.round(ratio * 10_000) / 100}%`;
+  };
+  const updateSlides = (index: number, total: number): void => {
+    const ratio = total <= 1 ? 0 : index / (total - 1);
+    setMarker(rabbit, clamp01(ratio));
+  };
+  const tick = (): void => {
+    const ratio = options.shell.elapsedMs() / options.plannedDurationMs;
+    setMarker(turtle, clamp01(ratio));
+    track.toggleAttribute("data-peitho-overrun", ratio > 1);
+  };
+  const onSlideChange = (event: Event): void => {
+    const detail = (event as CustomEvent<unknown>).detail;
+    if (!isValidSlideChangeDetail(detail)) {
+      log.error("Invalid peitho:slidechange event");
+      return;
+    }
+    updateSlides(detail.index, detail.total);
+    if (!autoStarted && detail.previousIndex !== null && detail.index > detail.previousIndex) {
+      autoStarted = true;
+      bus.dispatchEvent(
+        new CustomEvent<TimerControlDetail>("peitho:timercontrol", {
+          detail: { action: "start" }
+        })
+      );
+    }
+  };
+
+  updateSlides(options.shell.currentIndex, options.shell.manifest?.slideCount ?? 0);
+  tick();
+  bus.addEventListener("peitho:slidechange", onSlideChange);
+  const interval = win.setInterval(tick, 250);
+
+  return () => {
+    win.clearInterval(interval);
+    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    track.remove();
+  };
+}

--- a/packages/peitho-present/test/timeTracker.test.ts
+++ b/packages/peitho-present/test/timeTracker.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { installTimeTracker, type TimeTrackerShell } from "../src/index";
+
+const cleanups: Array<() => void> = [];
+
+function shell(overrides: Partial<TimeTrackerShell> = {}): TimeTrackerShell {
+  return {
+    manifest: { slideCount: 3 },
+    currentIndex: 0,
+    elapsedMs: () => 0,
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+it("moves rabbit by slide progress and turtle by elapsed progress", () => {
+  let elapsed = 30_000;
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const cleanup = installTimeTracker({
+    root,
+    shell: shell({ elapsedMs: () => elapsed }),
+    plannedDurationMs: 60_000,
+    bus,
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 3, previousIndex: 0, key: "middle" }
+    })
+  );
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')?.style.left).toBe("50%");
+  expect(root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')?.style.left).toBe("50%");
+});
+
+it("rejects non-positive and non-finite planned durations", () => {
+  for (const plannedDurationMs of [0, -1, Number.NaN]) {
+    const root = document.createElement("main");
+    const bus = new EventTarget();
+    let cleanup: (() => void) | undefined;
+
+    try {
+      expect(() => {
+        cleanup = installTimeTracker({
+          root,
+          shell: shell(),
+          plannedDurationMs,
+          bus,
+          window,
+          document
+        });
+      }).toThrow("plannedDurationMs must be a positive finite number");
+    } finally {
+      cleanup?.();
+    }
+  }
+});
+
+it("dispatches timer start once on the first forward slidechange", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const starts: unknown[] = [];
+  bus.addEventListener("peitho:timercontrol", (event) => starts.push((event as CustomEvent).detail));
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ manifest: { slideCount: 2 } }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 2, previousIndex: 0, key: "two" }
+    })
+  );
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 0, total: 2, previousIndex: 1, key: "one" }
+    })
+  );
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 2, previousIndex: 0, key: "two" }
+    })
+  );
+
+  expect(starts).toEqual([{ action: "start" }]);
+});
+
+it("does not auto-start when the first slidechange has a null previous index", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const starts: unknown[] = [];
+  bus.addEventListener("peitho:timercontrol", (event) => starts.push((event as CustomEvent).detail));
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell(),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 3, previousIndex: null, key: "middle" }
+    })
+  );
+
+  expect(starts).toEqual([]);
+});
+
+it("does not auto-start on backward slidechange and does not dispatch twice", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const starts: unknown[] = [];
+  bus.addEventListener("peitho:timercontrol", (event) => starts.push((event as CustomEvent).detail));
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ currentIndex: 2 }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 3, previousIndex: 2, key: "middle" }
+    })
+  );
+  expect(starts).toEqual([]);
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 2, total: 3, previousIndex: 1, key: "last" }
+    })
+  );
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 3, previousIndex: 2, key: "middle" }
+    })
+  );
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 2, total: 3, previousIndex: 1, key: "last" }
+    })
+  );
+
+  expect(starts).toEqual([{ action: "start" }]);
+});
+
+it("logs and ignores malformed slidechange detail", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const log = { error: vi.fn() };
+  const starts: unknown[] = [];
+  bus.addEventListener("peitho:timercontrol", (event) => starts.push((event as CustomEvent).detail));
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell(),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document,
+      console: log
+    })
+  );
+
+  const rabbit = root.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')!;
+  expect(() => bus.dispatchEvent(new CustomEvent("peitho:slidechange"))).not.toThrow();
+  expect(log.error).toHaveBeenCalledWith("Invalid peitho:slidechange event");
+  expect(rabbit.style.left).toBe("0%");
+  expect(starts).toEqual([]);
+
+  log.error.mockClear();
+  expect(() =>
+    bus.dispatchEvent(
+      new CustomEvent("peitho:slidechange", {
+        detail: { index: "later", total: 3, previousIndex: 0, key: "bad" }
+      })
+    )
+  ).not.toThrow();
+
+  expect(log.error).toHaveBeenCalledWith("Invalid peitho:slidechange event");
+  expect(rabbit.style.left).toBe("0%");
+  expect(starts).toEqual([]);
+});
+
+it("logs and ignores slidechange detail with a non-positive total", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const log = { error: vi.fn() };
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ currentIndex: 1 }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document,
+      console: log
+    })
+  );
+
+  const rabbit = root.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')!;
+  expect(rabbit.style.left).toBe("50%");
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 2, total: 0, previousIndex: 1, key: "bad" }
+    })
+  );
+
+  expect(log.error).toHaveBeenCalledWith("Invalid peitho:slidechange event");
+  expect(rabbit.style.left).toBe("50%");
+});
+
+it("keeps rabbit at zero percent for a one-slide deck", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ manifest: { slideCount: 1 } }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 0, total: 1, previousIndex: null, key: "only" }
+    })
+  );
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')?.style.left).toBe("0%");
+});
+
+it("pins turtle at one hundred percent and marks overrun after planned time", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ elapsedMs: () => 60_001 }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')?.style.left).toBe(
+    "100%"
+  );
+  expect(
+    root.querySelector<HTMLElement>("[data-peitho-time-tracker]")?.hasAttribute(
+      "data-peitho-overrun"
+    )
+  ).toBe(true);
+});
+
+it("updates turtle on a 250ms interval", () => {
+  let elapsed = 0;
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ elapsedMs: () => elapsed }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  const turtle = root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')!;
+  expect(turtle.style.left).toBe("0%");
+
+  elapsed = 30_000;
+  vi.advanceTimersByTime(249);
+  expect(turtle.style.left).toBe("0%");
+  vi.advanceTimersByTime(1);
+  expect(turtle.style.left).toBe("50%");
+});
+
+it("removes interval and slidechange listener on cleanup", () => {
+  let elapsed = 0;
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const cleanup = installTimeTracker({
+    root,
+    shell: shell({ elapsedMs: () => elapsed }),
+    plannedDurationMs: 60_000,
+    bus,
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  const rabbit = root.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')!;
+  const turtle = root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')!;
+  expect(vi.getTimerCount()).toBe(1);
+  expect(root.querySelector("[data-peitho-time-tracker]")).not.toBeNull();
+
+  cleanup();
+  cleanups.pop();
+  elapsed = 30_000;
+  vi.advanceTimersByTime(250);
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 2, total: 3, previousIndex: 1, key: "last" }
+    })
+  );
+
+  expect(vi.getTimerCount()).toBe(0);
+  expect(root.querySelector("[data-peitho-time-tracker]")).toBeNull();
+  expect(rabbit.style.left).toBe("0%");
+  expect(turtle.style.left).toBe("0%");
+});


### PR DESCRIPTION
Closes #54

## Summary

Task 10 of the time-tracking plan: the rabbit-and-turtle tracker UI component.

- `installTimeTracker`: rabbit at `index/(total-1)` (single-slide decks pin to 0), turtle at `clamp01(elapsed/planned)` with `data-peitho-overrun` when over budget, 250ms tick, cleanup function returned
- §16 compliant: reads state (`shell.elapsedMs()`, `peitho:slidechange`) and emits only the request event `peitho:timercontrol {start}` — once, on the first forward slide change; the shell remains the executor and manual Start stays idempotent
- Review hardening: construction throws on non-positive/non-finite `plannedDurationMs` (the plain `number` API would otherwise let a future caller silently break the turtle with NaN), malformed slidechange details (including `total <= 0`) are logged and ignored following the shell's handler convention, `clamp01` unified
- `dist/shell.js` rebuilt and committed (CI drift gate); public exports follow the existing index.ts convention

## Verification

- vitest 69 tests pass ×3 (positions, overrun pinning, auto-start forward-once/null-first/backward/double, construction guards, malformed detail, cleanup, 250ms boundary) / typecheck / build idempotent / Rust gates unaffected
- code-review workflow + 5-round self-review; all findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
