### PR TITLE
feat: planned-time display and tracker on the presenter view

### DIFF
--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -569,12 +569,96 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
   };
 }
 
+// src/timeTracker.ts
+var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
+function isOverrun(elapsedMs, plannedDurationMs) {
+  return elapsedMs > plannedDurationMs;
+}
+function isValidSlideChangeDetail(detail) {
+  if (typeof detail !== "object" || detail === null) return false;
+  const candidate = detail;
+  const { index, previousIndex, total } = candidate;
+  return typeof index === "number" && Number.isFinite(index) && index >= 0 && typeof total === "number" && Number.isFinite(total) && total > 0 && (previousIndex === null || typeof previousIndex === "number" && Number.isFinite(previousIndex) && previousIndex >= 0);
+}
+function installTimeTracker(options) {
+  if (!Number.isFinite(options.plannedDurationMs) || options.plannedDurationMs <= 0) {
+    throw new Error("plannedDurationMs must be a positive finite number");
+  }
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const log = options.console ?? console;
+  const bus = options.bus ?? win;
+  const track = doc.createElement("div");
+  track.className = "peitho-time-tracker";
+  track.dataset.peithoTimeTracker = options.variant ?? "present";
+  track.innerHTML = [
+    '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
+    '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>'
+  ].join("");
+  options.root.appendChild(track);
+  const rabbit = track.querySelector('[data-peitho-marker="rabbit"]');
+  const turtle = track.querySelector('[data-peitho-marker="turtle"]');
+  let autoStarted = false;
+  const setMarker = (element, ratio) => {
+    element.style.left = `${Math.round(ratio * 1e4) / 100}%`;
+  };
+  const updateSlides = (index, total) => {
+    const ratio = total <= 1 ? 0 : index / (total - 1);
+    setMarker(rabbit, clamp01(ratio));
+  };
+  const tick = () => {
+    const elapsedMs = options.shell.elapsedMs();
+    const ratio = elapsedMs / options.plannedDurationMs;
+    setMarker(turtle, clamp01(ratio));
+    track.toggleAttribute(
+      "data-peitho-overrun",
+      isOverrun(elapsedMs, options.plannedDurationMs)
+    );
+  };
+  const onSlideChange = (event) => {
+    const detail = event.detail;
+    if (!isValidSlideChangeDetail(detail)) {
+      log.error("Invalid peitho:slidechange event");
+      return;
+    }
+    updateSlides(detail.index, detail.total);
+    if (!autoStarted && detail.previousIndex !== null && detail.index > detail.previousIndex) {
+      autoStarted = true;
+      bus.dispatchEvent(
+        new CustomEvent("peitho:timercontrol", {
+          detail: { action: "start" }
+        })
+      );
+    }
+  };
+  updateSlides(options.shell.currentIndex, options.shell.manifest?.slideCount ?? 0);
+  tick();
+  bus.addEventListener("peitho:slidechange", onSlideChange);
+  const interval = win.setInterval(tick, 250);
+  return () => {
+    win.clearInterval(interval);
+    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    track.remove();
+  };
+}
+
 // src/presenter.ts
-function formatElapsed(ms) {
-  const totalSeconds = Math.floor(ms / 1e3);
+function formatSeconds(totalSeconds) {
   const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, "0");
   const seconds = (totalSeconds % 60).toString().padStart(2, "0");
   return `${minutes}:${seconds}`;
+}
+function formatElapsed(ms) {
+  return formatSeconds(Math.floor(ms / 1e3));
+}
+function formatOverrun(ms) {
+  return formatSeconds(Math.ceil(ms / 1e3));
+}
+function formatPresenterTimer(elapsedMs, plannedDurationMs) {
+  if (plannedDurationMs == null) return formatElapsed(elapsedMs);
+  const base = `${formatElapsed(elapsedMs)} / ${formatElapsed(plannedDurationMs)}`;
+  if (!isOverrun(elapsedMs, plannedDurationMs)) return base;
+  return `${base} +${formatOverrun(elapsedMs - plannedDurationMs)}`;
 }
 function paneViewport(pane) {
   return () => ({
@@ -588,6 +672,7 @@ async function mountPresenterView(options) {
   const fetcher = options.fetcher ?? fetch.bind(globalThis);
   const now = options.now ?? Date.now;
   const closeWindow = options.closeWindow ?? (() => win.close());
+  const log = options.console ?? console;
   const bus = win;
   const previewBus = new EventTarget();
   options.root.innerHTML = `
@@ -616,6 +701,7 @@ async function mountPresenterView(options) {
   );
   const notesRoot = options.root.querySelector('[data-peitho-presenter="notes"]');
   const timerRoot = options.root.querySelector('[data-peitho-presenter="timer"]');
+  const asideRoot = options.root.querySelector("aside");
   const mainShell = await mountPresentShell({
     root: currentRoot,
     fetcher,
@@ -636,8 +722,27 @@ async function mountPresenterView(options) {
   });
   const keyboardCleanup = installKeyboardNavigation(win, bus);
   const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
+  const rawPlannedDurationMs = mainShell.manifest?.plannedDurationMs ?? null;
+  const plannedDurationMs = rawPlannedDurationMs != null && Number.isFinite(rawPlannedDurationMs) && rawPlannedDurationMs > 0 ? rawPlannedDurationMs : null;
+  if (rawPlannedDurationMs != null && plannedDurationMs == null) {
+    log.error("Invalid plannedDurationMs in manifest.json");
+  }
+  const trackerCleanup = plannedDurationMs == null ? () => void 0 : installTimeTracker({
+    root: asideRoot,
+    shell: mainShell,
+    plannedDurationMs,
+    bus,
+    window: win,
+    document: doc,
+    variant: "presenter"
+  });
   function tick() {
-    timerRoot.textContent = formatElapsed(mainShell.elapsedMs());
+    const elapsedMs = mainShell.elapsedMs();
+    timerRoot.textContent = formatPresenterTimer(elapsedMs, plannedDurationMs);
+    timerRoot.toggleAttribute(
+      "data-peitho-overrun",
+      plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)
+    );
   }
   function updateFromSlide(detail) {
     notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide.";
@@ -689,78 +794,13 @@ async function mountPresenterView(options) {
     tick,
     destroy() {
       win.clearInterval(interval);
+      trackerCleanup();
       bus.removeEventListener("peitho:slidechange", onSlideChange);
       keyboardCleanup();
       syncCleanup();
       previewShell.destroy();
       mainShell.destroy();
     }
-  };
-}
-
-// src/timeTracker.ts
-var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
-function isValidSlideChangeDetail(detail) {
-  if (typeof detail !== "object" || detail === null) return false;
-  const candidate = detail;
-  const { index, previousIndex, total } = candidate;
-  return typeof index === "number" && Number.isFinite(index) && index >= 0 && typeof total === "number" && Number.isFinite(total) && total > 0 && (previousIndex === null || typeof previousIndex === "number" && Number.isFinite(previousIndex) && previousIndex >= 0);
-}
-function installTimeTracker(options) {
-  if (!Number.isFinite(options.plannedDurationMs) || options.plannedDurationMs <= 0) {
-    throw new Error("plannedDurationMs must be a positive finite number");
-  }
-  const win = options.window ?? window;
-  const doc = options.document ?? document;
-  const log = options.console ?? console;
-  const bus = options.bus ?? win;
-  const track = doc.createElement("div");
-  track.className = "peitho-time-tracker";
-  track.dataset.peithoTimeTracker = options.variant ?? "present";
-  track.innerHTML = [
-    '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
-    '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>'
-  ].join("");
-  options.root.appendChild(track);
-  const rabbit = track.querySelector('[data-peitho-marker="rabbit"]');
-  const turtle = track.querySelector('[data-peitho-marker="turtle"]');
-  let autoStarted = false;
-  const setMarker = (element, ratio) => {
-    element.style.left = `${Math.round(ratio * 1e4) / 100}%`;
-  };
-  const updateSlides = (index, total) => {
-    const ratio = total <= 1 ? 0 : index / (total - 1);
-    setMarker(rabbit, clamp01(ratio));
-  };
-  const tick = () => {
-    const ratio = options.shell.elapsedMs() / options.plannedDurationMs;
-    setMarker(turtle, clamp01(ratio));
-    track.toggleAttribute("data-peitho-overrun", ratio > 1);
-  };
-  const onSlideChange = (event) => {
-    const detail = event.detail;
-    if (!isValidSlideChangeDetail(detail)) {
-      log.error("Invalid peitho:slidechange event");
-      return;
-    }
-    updateSlides(detail.index, detail.total);
-    if (!autoStarted && detail.previousIndex !== null && detail.index > detail.previousIndex) {
-      autoStarted = true;
-      bus.dispatchEvent(
-        new CustomEvent("peitho:timercontrol", {
-          detail: { action: "start" }
-        })
-      );
-    }
-  };
-  updateSlides(options.shell.currentIndex, options.shell.manifest?.slideCount ?? 0);
-  tick();
-  bus.addEventListener("peitho:slidechange", onSlideChange);
-  const interval = win.setInterval(tick, 250);
-  return () => {
-    win.clearInterval(interval);
-    bus.removeEventListener("peitho:slidechange", onSlideChange);
-    track.remove();
   };
 }
 export {
@@ -777,6 +817,7 @@ export {
   installPresentationControls,
   installSyncBridge,
   installTimeTracker,
+  isOverrun,
   mountPresentShell,
   mountPresenterView,
   openPresenterPopup,

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -26,7 +26,7 @@ export { installCloseOnEscape, installKeyboardNavigation } from "./keyboard";
 export { mountPresenterView } from "./presenter";
 export { mountPresentShell } from "./shell";
 export { installSyncBridge, serverSyncChannelFactory } from "./sync";
-export { installTimeTracker } from "./timeTracker";
+export { installTimeTracker, isOverrun } from "./timeTracker";
 export type { PresenterOptions, PresenterView } from "./presenter";
 export type {
   NavigateDetail,

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -2,6 +2,7 @@ import type { Notes } from "../../../bindings/Notes";
 import { installKeyboardNavigation } from "./keyboard";
 import { mountPresentShell, type PresentShell, type SlideChangeDetail } from "./shell";
 import { installSyncBridge, type SyncChannelFactory } from "./sync";
+import { installTimeTracker, isOverrun } from "./timeTracker";
 
 export type PresenterOptions = {
   root: HTMLElement;
@@ -12,6 +13,7 @@ export type PresenterOptions = {
   now?: () => number;
   syncChannelFactory?: SyncChannelFactory;
   closeWindow?: () => void;
+  console?: Pick<Console, "error">;
 };
 
 export type PresenterView = {
@@ -21,13 +23,30 @@ export type PresenterView = {
   destroy(): void;
 };
 
-function formatElapsed(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
+function formatSeconds(totalSeconds: number): string {
   const minutes = Math.floor(totalSeconds / 60)
     .toString()
     .padStart(2, "0");
   const seconds = (totalSeconds % 60).toString().padStart(2, "0");
   return `${minutes}:${seconds}`;
+}
+
+function formatElapsed(ms: number): string {
+  return formatSeconds(Math.floor(ms / 1000));
+}
+
+function formatOverrun(ms: number): string {
+  return formatSeconds(Math.ceil(ms / 1000));
+}
+
+function formatPresenterTimer(
+  elapsedMs: number,
+  plannedDurationMs: number | null | undefined
+): string {
+  if (plannedDurationMs == null) return formatElapsed(elapsedMs);
+  const base = `${formatElapsed(elapsedMs)} / ${formatElapsed(plannedDurationMs)}`;
+  if (!isOverrun(elapsedMs, plannedDurationMs)) return base;
+  return `${base} +${formatOverrun(elapsedMs - plannedDurationMs)}`;
 }
 
 function paneViewport(pane: HTMLElement): () => { width: number; height: number } {
@@ -43,6 +62,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   const fetcher = options.fetcher ?? fetch.bind(globalThis);
   const now = options.now ?? Date.now;
   const closeWindow = options.closeWindow ?? (() => win.close());
+  const log = options.console ?? console;
   const bus = win;
   const previewBus = new EventTarget();
   options.root.innerHTML = `
@@ -72,6 +92,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   )!;
   const notesRoot = options.root.querySelector<HTMLElement>('[data-peitho-presenter="notes"]')!;
   const timerRoot = options.root.querySelector<HTMLElement>('[data-peitho-presenter="timer"]')!;
+  const asideRoot = options.root.querySelector<HTMLElement>("aside")!;
 
   const mainShell = await mountPresentShell({
     root: currentRoot,
@@ -93,9 +114,36 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   });
   const keyboardCleanup = installKeyboardNavigation(win, bus);
   const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
+  const rawPlannedDurationMs = mainShell.manifest?.plannedDurationMs ?? null;
+  const plannedDurationMs =
+    rawPlannedDurationMs != null &&
+    Number.isFinite(rawPlannedDurationMs) &&
+    rawPlannedDurationMs > 0
+      ? rawPlannedDurationMs
+      : null;
+  if (rawPlannedDurationMs != null && plannedDurationMs == null) {
+    log.error("Invalid plannedDurationMs in manifest.json");
+  }
+  const trackerCleanup =
+    plannedDurationMs == null
+      ? () => undefined
+      : installTimeTracker({
+          root: asideRoot,
+          shell: mainShell,
+          plannedDurationMs,
+          bus,
+          window: win,
+          document: doc,
+          variant: "presenter"
+        });
 
   function tick(): void {
-    timerRoot.textContent = formatElapsed(mainShell.elapsedMs());
+    const elapsedMs = mainShell.elapsedMs();
+    timerRoot.textContent = formatPresenterTimer(elapsedMs, plannedDurationMs);
+    timerRoot.toggleAttribute(
+      "data-peitho-overrun",
+      plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)
+    );
   }
 
   function updateFromSlide(detail: SlideChangeDetail): void {
@@ -153,6 +201,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     tick,
     destroy(): void {
       win.clearInterval(interval);
+      trackerCleanup();
       bus.removeEventListener("peitho:slidechange", onSlideChange);
       keyboardCleanup();
       syncCleanup();

--- a/packages/peitho-present/src/timeTracker.ts
+++ b/packages/peitho-present/src/timeTracker.ts
@@ -19,6 +19,10 @@ export type TimeTrackerOptions = {
 
 const clamp01 = (ratio: number): number => Math.min(Math.max(ratio, 0), 1);
 
+export function isOverrun(elapsedMs: number, plannedDurationMs: number): boolean {
+  return elapsedMs > plannedDurationMs;
+}
+
 function isValidSlideChangeDetail(detail: unknown): detail is SlideChangeDetail {
   if (typeof detail !== "object" || detail === null) return false;
   const candidate = detail as Partial<SlideChangeDetail>;
@@ -64,9 +68,13 @@ export function installTimeTracker(options: TimeTrackerOptions): () => void {
     setMarker(rabbit, clamp01(ratio));
   };
   const tick = (): void => {
-    const ratio = options.shell.elapsedMs() / options.plannedDurationMs;
+    const elapsedMs = options.shell.elapsedMs();
+    const ratio = elapsedMs / options.plannedDurationMs;
     setMarker(turtle, clamp01(ratio));
-    track.toggleAttribute("data-peitho-overrun", ratio > 1);
+    track.toggleAttribute(
+      "data-peitho-overrun",
+      isOverrun(elapsedMs, options.plannedDurationMs)
+    );
   };
   const onSlideChange = (event: Event): void => {
     const detail = (event as CustomEvent<unknown>).detail;

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, it, vi } from "vitest";
 import { mountPresenterView } from "../src/index";
 import type { PresenterView, SyncChannel, SyncChannelFactory } from "../src/index";
+import type { Manifest } from "../../../bindings/Manifest";
 import type { Notes } from "../../../bindings/Notes";
 
 function okJson(value: unknown): Response {
@@ -11,7 +12,7 @@ function okText(value: string): Response {
   return { ok: true, status: 200, text: async () => value } as Response;
 }
 
-const manifest = {
+const manifest: Manifest = {
   version: 1,
   peithoVersion: "0.1.0",
   title: "Demo",
@@ -25,9 +26,9 @@ const manifest = {
 
 const notes: Notes = { version: 1, notes: { intro: "Opening note" } };
 
-function standardFetch(): typeof fetch {
+function standardFetch(overrides: Partial<typeof manifest> = {}): typeof fetch {
   return vi.fn(async (url: string) => {
-    if (url === "manifest.json") return okJson(manifest);
+    if (url === "manifest.json") return okJson(Object.assign({}, manifest, overrides));
     if (url === "peitho.css") return okText(".slot-title { color: red; }");
     if (url === "slides/000-intro.html") return okText("<section><h1>Intro</h1></section>");
     if (url === "slides/001-details.html")
@@ -93,6 +94,102 @@ it("renders current slide preview next slide note and starts timer from Start bu
   now = 65000;
   view.tick();
   expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("01:04");
+});
+
+it("shows planned duration in presenter timer when manifest has time", async () => {
+  let now = 1_000;
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch({ plannedDurationMs: 60_000 }),
+    window,
+    now: () => now,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  now = 31_000;
+  view.tick();
+
+  expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("00:30 / 01:00");
+  expect(root.querySelector('[data-peitho-time-tracker="presenter"]')).not.toBeNull();
+
+  view.destroy();
+  views.pop();
+  expect(root.querySelector("[data-peitho-time-tracker]")).toBeNull();
+});
+
+it("keeps legacy presenter timer text when manifest has no time", async () => {
+  let now = 1_000;
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch({ plannedDurationMs: null }),
+    window,
+    now: () => now,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  now = 65_000;
+  view.tick();
+
+  expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("01:04");
+  expect(root.querySelector("[data-peitho-time-tracker]")).toBeNull();
+});
+
+it("logs invalid planned duration and keeps presenter mounted without a tracker", async () => {
+  let now = 1_000;
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const log = { error: vi.fn() };
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch({ plannedDurationMs: 0 }),
+    window,
+    now: () => now,
+    syncChannelFactory: factory,
+    console: log
+  });
+  views.push(view);
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  now = 65_000;
+  view.tick();
+
+  expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("01:04");
+  expect(root.querySelector("[data-peitho-time-tracker]")).toBeNull();
+  expect(log.error).toHaveBeenCalledWith("Invalid plannedDurationMs in manifest.json");
+});
+
+it("marks presenter timer as overrun after the planned duration", async () => {
+  let now = 1_000;
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch({ plannedDurationMs: 60_000 }),
+    window,
+    now: () => now,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  now = 61_500;
+  view.tick();
+
+  const timer = root.querySelector<HTMLElement>('[data-peitho-presenter="timer"]')!;
+  expect(timer.textContent).toBe("01:00 / 01:00 +00:01");
+  expect(timer.hasAttribute("data-peitho-overrun")).toBe(true);
 });
 
 it("updates preview and shows end of deck on the last slide", async () => {

--- a/packages/peitho-present/test/timeTracker.test.ts
+++ b/packages/peitho-present/test/timeTracker.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { installTimeTracker, type TimeTrackerShell } from "../src/index";
+import { installTimeTracker, isOverrun, type TimeTrackerShell } from "../src/index";
 
 const cleanups: Array<() => void> = [];
 
@@ -285,6 +285,11 @@ it("pins turtle at one hundred percent and marks overrun after planned time", ()
       "data-peitho-overrun"
     )
   ).toBe(true);
+});
+
+it("detects overrun with millisecond precision", () => {
+  expect(isOverrun(60_000, 60_000)).toBe(false);
+  expect(isOverrun(60_001, 60_000)).toBe(true);
 });
 
 it("updates turtle on a 250ms interval", () => {


### PR DESCRIPTION
Closes #55

## Summary

Task 11 of the time-tracking plan: presenter view integration.

- Timer text: `MM:SS` (no planned time) / `MM:SS / MM:SS` (planned) / `… +MM:SS` while over budget. The overrun suffix rounds up so the attribute and the text never contradict (the review caught `+00:00` during the first overrun second)
- The overrun predicate is a single shared `isOverrun` helper used by both the presenter tick and the tracker tick — no drift between the number display and the bar
- Tracker mounts in the presenter aside (`variant: "presenter"`), cleaned up in `destroy()`
- Boundary hardening from review: manifest `plannedDurationMs` of 0/negative/NaN (hand-edited or externally generated manifests) is logged (`Invalid plannedDurationMs in manifest.json`) and degrades to the legacy display — the tracker component's programmer-facing throw no longer meets untrusted data mid-mount
- Manual Start/Pause/Resume/Reset dispatch paths untouched; auto-start remains latched to the first forward slide change per design D6 (a post-Reset forward advance may restart the timer — consistent with the "advancing = presenting" model; noted as a design point)

## Verification

- vitest 74 tests ×3 / typecheck / build / Rust gates all pass
- 5-round self-review incl. a bus-interaction round verifying the auto-start stays presenter-local (sync carries only slide indexes) and destroy() leaves no listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)
