### PR TITLE
fix: presenter grid used invalid property grid-layout-columns

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -387,7 +387,7 @@ pub fn render_presenter_index() -> String {
     html, body { margin: 0; width: 100%; min-height: 100%; background: #111; color: #f5f5f5; }
     body { font: 14px system-ui, sans-serif; }
     #peitho-presenter-root { min-height: 100vh; }
-    .peitho-presenter { display: grid; grid-layout-columns: minmax(0, 2fr) minmax(320px, 1fr); gap: 16px; padding: 16px; box-sizing: border-box; min-height: 100vh; }
+    .peitho-presenter { display: grid; grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr); gap: 16px; padding: 16px; box-sizing: border-box; min-height: 100vh; }
     .peitho-presenter-pane { position: relative; overflow: hidden; background: #000; min-height: 180px; }
     [data-peitho-presenter="current"] { min-height: calc(100vh - 32px); }
     [data-peitho-presenter="preview"] { aspect-ratio: 16 / 9; }
@@ -672,6 +672,8 @@ mod tests {
         assert!(html.contains("syncChannelFactory: peitho.serverSyncChannelFactory()"));
         assert!(html.contains(r#"data-peitho-action="close""#));
         assert!(html.contains(".peitho-presenter-pane"));
+        assert!(html.contains("grid-template-columns"));
+        assert!(!html.contains("grid-layout-columns"));
         assert!(html.contains("overflow: hidden"));
         assert!(html.contains("Failed to load"));
         assert!(!html.contains("fetchOk(slide.src)"));


### PR DESCRIPTION
Closes #70

## Summary

The presenter's two-column layout was declared with `grid-layout-columns` — not a CSS property — so browsers silently dropped it and the entire aside (next-slide preview, notes, timer, controls, and the new time tracker) rendered below the fold, invisible in the presenter window. Found while running the time-tracking feature's real-browser E2E (#59), where it blocked the "tracker on the presenter screen" acceptance.

- One-word fix: `grid-template-columns`, pinned by a regression assertion in the presenter render test
- Verified on a real display: the presenter window now shows the sidebar with `MM:SS / MM:SS`, controls, and the rabbit-and-turtle tracker (screenshots in #59's E2E notes)

## Verification

- `cargo test --workspace` ×3 / clippy `-D warnings` / fmt pass
- Real-browser before/after: before = slide pane fills the window, no sidebar; after = two columns with timer/tracker visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
