### PR TITLE
fix: make the Close button behave like Esc (close all windows, stop server)

### DIFF
--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -57,7 +57,6 @@ function installPresentationControls(options) {
     window: win,
     openWindow: options.openPresenterWindow
   }));
-  const closeWindow = options.closeWindow ?? (() => win.close());
   const bar = doc.createElement("nav");
   bar.dataset.peithoControlBar = "true";
   bar.className = "peitho-control-bar";
@@ -93,7 +92,7 @@ function installPresentationControls(options) {
     if (action === "prev" || action === "next") dispatchNavigate(action);
     if (action === "presenter") void openPresenter();
     if (action === "fullscreen") toggleFullscreen(doc);
-    if (action === "close") closeWindow();
+    if (action === "close") bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
   };
   const onSlideChange = (event) => {
     const detail = event.detail;
@@ -671,7 +670,6 @@ async function mountPresenterView(options) {
   const doc = options.document ?? document;
   const fetcher = options.fetcher ?? fetch.bind(globalThis);
   const now = options.now ?? Date.now;
-  const closeWindow = options.closeWindow ?? (() => win.close());
   const log = options.console ?? console;
   const bus = win;
   const previewBus = new EventTarget();
@@ -785,7 +783,7 @@ async function mountPresenterView(options) {
     });
   }
   options.root.querySelector('[data-peitho-action="close"]')?.addEventListener("click", () => {
-    closeWindow();
+    bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
   });
   const interval = win.setInterval(tick, 250);
   return {

--- a/packages/peitho-present/src/controls.ts
+++ b/packages/peitho-present/src/controls.ts
@@ -9,7 +9,6 @@ export type PresentationControlsOptions = {
   idleMs?: number;
   openPresenter?: () => void | Promise<void>;
   openPresenterWindow?: OpenPresenterPopupOptions["openWindow"];
-  closeWindow?: () => void;
 };
 
 export type CanvasClickNavigationOptions = {
@@ -35,7 +34,6 @@ export function installPresentationControls(options: PresentationControlsOptions
         window: win,
         openWindow: options.openPresenterWindow
       }));
-  const closeWindow = options.closeWindow ?? (() => win.close());
 
   const bar = doc.createElement("nav");
   bar.dataset.peithoControlBar = "true";
@@ -74,7 +72,7 @@ export function installPresentationControls(options: PresentationControlsOptions
     if (action === "prev" || action === "next") dispatchNavigate(action);
     if (action === "presenter") void openPresenter();
     if (action === "fullscreen") toggleFullscreen(doc);
-    if (action === "close") closeWindow();
+    if (action === "close") bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
   };
   const onSlideChange = (event: Event): void => {
     const detail = (event as CustomEvent<SlideChangeDetail>).detail;

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -12,7 +12,6 @@ export type PresenterOptions = {
   document?: Document;
   now?: () => number;
   syncChannelFactory?: SyncChannelFactory;
-  closeWindow?: () => void;
   console?: Pick<Console, "error">;
 };
 
@@ -61,7 +60,6 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   const doc = options.document ?? document;
   const fetcher = options.fetcher ?? fetch.bind(globalThis);
   const now = options.now ?? Date.now;
-  const closeWindow = options.closeWindow ?? (() => win.close());
   const log = options.console ?? console;
   const bus = win;
   const previewBus = new EventTarget();
@@ -190,7 +188,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     });
   }
   options.root.querySelector('[data-peitho-action="close"]')?.addEventListener("click", () => {
-    closeWindow();
+    bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
   });
 
   const interval = win.setInterval(tick, 250);

--- a/packages/peitho-present/test/controls.test.ts
+++ b/packages/peitho-present/test/controls.test.ts
@@ -108,21 +108,23 @@ it("opens presenter popup with default display management", async () => {
   );
 });
 
-it("closes the presentation window from the close button", () => {
+it("dispatches a close request from the close button", () => {
   const root = document.createElement("main");
-  const closeWindow = vi.fn();
+  const requests: unknown[] = [];
+  listenWindow("peitho:closerequest", (event) => {
+    requests.push((event as CustomEvent).detail);
+  });
   const cleanup = installPresentationControls({
     root,
     window,
     document,
-    bus: window,
-    closeWindow
+    bus: window
   });
   cleanups.push(cleanup);
 
   root.querySelector<HTMLButtonElement>('[data-peitho-action="close"]')?.click();
 
-  expect(closeWindow).toHaveBeenCalledTimes(1);
+  expect(requests).toEqual([null]);
 });
 
 it("keeps the explicit openPresenter injection as the highest priority", () => {

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -242,31 +242,35 @@ it("scales current and next preview shells to their pane sizes", async () => {
   );
 });
 
-it("buttons emit navigate and timercontrol requests only", async () => {
+it("buttons emit navigate timercontrol and close requests", async () => {
   const root = document.createElement("main");
   const { channel, factory } = mockSyncChannelFactory();
-  const closeWindow = vi.fn();
   const view = await mountPresenterView({
     root,
     notes,
     fetcher: standardFetch(),
     window,
     now: () => 1000,
-    syncChannelFactory: factory,
-    closeWindow
+    syncChannelFactory: factory
   });
   views.push(view);
   const events: unknown[] = [];
+  const closeRequests: unknown[] = [];
   const onNavigate = (event: Event): void => {
     events.push((event as CustomEvent).detail);
   };
   const onTimerControl = (event: Event): void => {
     events.push((event as CustomEvent).detail);
   };
+  const onCloseRequest = (event: Event): void => {
+    closeRequests.push((event as CustomEvent).detail);
+  };
   window.addEventListener("peitho:navigate", onNavigate);
   window.addEventListener("peitho:timercontrol", onTimerControl);
+  window.addEventListener("peitho:closerequest", onCloseRequest);
   cleanups.push(() => window.removeEventListener("peitho:navigate", onNavigate));
   cleanups.push(() => window.removeEventListener("peitho:timercontrol", onTimerControl));
+  cleanups.push(() => window.removeEventListener("peitho:closerequest", onCloseRequest));
 
   root.querySelector<HTMLButtonElement>('[data-peitho-action="next"]')?.click();
   root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
@@ -280,6 +284,6 @@ it("buttons emit navigate and timercontrol requests only", async () => {
     { action: "pause" },
     { action: "reset" }
   ]);
-  expect(channel.sent).toEqual([{ index: 1 }]);
-  expect(closeWindow).toHaveBeenCalledTimes(1);
+  expect(closeRequests).toEqual([null]);
+  expect(channel.sent).toEqual([{ index: 1 }, { close: true }]);
 });


### PR DESCRIPTION
## Summary

The presenter/present Close buttons called `win.close()` directly, closing only their own window and leaving the other window and the server running. They now dispatch `peitho:closerequest` — the exact event Esc fires — so the sync bridge broadcasts `{close:true}` to every window and the server shuts down after its grace period. This aligns with the §16 event contract (UI parts emit request events; the shell/sync layer executes). The unused `closeWindow` options on `PresenterOptions`/`PresentationControlsOptions` are removed; sync.ts's `closeWindow` (the actual `win.close()` executor) is kept.

## Verification

Verified in a real browser: clicking Close in the presenter window also closed the untouched presentation window and stopped the server. All gates green (`cargo test --workspace` ×3, clippy, fmt, bindings/shell.js drift, vitest 74, typecheck); code-review workflow + 5-round self-review all CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)