### PR TITLE
fix(presenter): keep preview slot stable at end of deck

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -390,7 +390,10 @@ pub fn render_presenter_index() -> String {
     .peitho-presenter { display: grid; grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr); gap: 16px; padding: 16px; box-sizing: border-box; min-height: 100vh; }
     .peitho-presenter-pane { position: relative; overflow: hidden; background: #000; min-height: 180px; }
     [data-peitho-presenter="current"] { min-height: calc(100vh - 32px); }
-    [data-peitho-presenter="preview"] { aspect-ratio: 16 / 9; }
+    .peitho-presenter-preview-slot { position: relative; aspect-ratio: 16 / 9; }
+    [data-peitho-presenter="preview"] { position: absolute; inset: 0; }
+    [data-peitho-presenter="preview-end"] { position: absolute; inset: 0; margin: 0; display: flex; align-items: center; justify-content: center; background: #000; color: #aaa; font-size: 18px; }
+    .peitho-presenter-preview-slot > [hidden] { display: none; }
     [data-peitho-presenter="notes"] { white-space: pre-wrap; line-height: 1.5; margin-top: 16px; }
     [data-peitho-presenter="timer"] { display: block; font-size: 40px; font-variant-numeric: tabular-nums; margin: 16px 0; }
     .peitho-presenter-controls { display: flex; flex-wrap: wrap; gap: 8px; }

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -677,8 +677,10 @@ async function mountPresenterView(options) {
     <section class="peitho-presenter">
       <div class="peitho-presenter-pane" data-peitho-presenter="current"></div>
       <aside>
-        <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
-        <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+        <div class="peitho-presenter-preview-slot">
+          <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
+          <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+        </div>
         <section data-peitho-presenter="notes"></section>
         <output data-peitho-presenter="timer">00:00</output>
         <div class="peitho-presenter-controls">

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -67,8 +67,10 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     <section class="peitho-presenter">
       <div class="peitho-presenter-pane" data-peitho-presenter="current"></div>
       <aside>
-        <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
-        <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+        <div class="peitho-presenter-preview-slot">
+          <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
+          <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+        </div>
         <section data-peitho-presenter="notes"></section>
         <output data-peitho-presenter="timer">00:00</output>
         <div class="peitho-presenter-controls">


### PR DESCRIPTION
## Summary
- Fix a bug where the timer/controls shifted vertically when the preview pane was hidden on the last slide
- Wrap the preview and "End of deck" in `.peitho-presenter-preview-slot` and hold the aspect-ratio on the parent
- Explicitly declare `[hidden] { display: none }` so a child with `position: absolute` no longer overrides the `hidden` attribute (this was causing "End of deck" to render on every slide)

## Test plan
- [x] cargo test --workspace (3 runs in a row)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all --check
- [x] npm run build / npm test / npm run typecheck (packages/peitho-present)
- [ ] Launch `peitho present <deck>` and confirm the preview correctly shows the next slide on middle slides
- [ ] Confirm "End of deck" appears on the last slide and the timer's vertical position is unchanged

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
