### PR TITLE
fix: keep tracker markers inside the track at both ends

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -298,7 +298,7 @@ pub fn render_present_index() -> String {
     .peitho-control-bar { position: fixed; left: 16px; bottom: 16px; z-index: 10; display: flex; gap: 8px; align-items: center; padding: 8px; background: rgba(0, 0, 0, 0.72); color: #fff; border-radius: 6px; }
     .peitho-control-bar[hidden] { display: none; }
     .peitho-time-tracker { position: absolute; left: 0; right: 0; bottom: 0; height: 6px; z-index: 5; pointer-events: none; background: rgba(255, 255, 255, 0.18); }
-    .peitho-time-tracker [data-peitho-marker] { position: absolute; transform: translateX(-50%); transition: left 120ms linear; font-size: 18px; line-height: 1; }
+    .peitho-time-tracker [data-peitho-marker] { position: absolute; transition: left 120ms linear, transform 120ms linear; font-size: 18px; line-height: 1; }
     .peitho-time-tracker [data-peitho-marker="rabbit"],
     .peitho-time-tracker [data-peitho-marker="turtle"] { bottom: 8px; }
     .peitho-time-tracker[data-peitho-overrun] { background: rgba(255, 92, 92, 0.35); }
@@ -395,7 +395,7 @@ pub fn render_presenter_index() -> String {
     [data-peitho-presenter="timer"] { display: block; font-size: 40px; font-variant-numeric: tabular-nums; margin: 16px 0; }
     .peitho-presenter-controls { display: flex; flex-wrap: wrap; gap: 8px; }
     .peitho-time-tracker[data-peitho-time-tracker="presenter"] { position: relative; height: 26px; margin: 12px 0; z-index: 20; pointer-events: none; background: rgba(255, 255, 255, 0.16); }
-    .peitho-time-tracker [data-peitho-marker] { position: absolute; transform: translateX(-50%); transition: left 120ms linear; font-size: 18px; line-height: 1; }
+    .peitho-time-tracker [data-peitho-marker] { position: absolute; transition: left 120ms linear, transform 120ms linear; font-size: 18px; line-height: 1; }
     .peitho-time-tracker [data-peitho-marker="rabbit"],
     .peitho-time-tracker [data-peitho-marker="turtle"] { top: 4px; }
     .peitho-time-tracker[data-peitho-overrun] { background: rgba(255, 92, 92, 0.35); }
@@ -647,7 +647,8 @@ mod tests {
         assert!(html.contains("variant: 'present'"));
         assert!(html.contains(".peitho-time-tracker"));
         assert!(html.contains("z-index: 5"));
-        assert!(html.contains("transform: translateX(-50%)"));
+        assert!(!html.contains("transform: translateX(-50%)"));
+        assert!(html.contains("transition: left 120ms linear, transform 120ms linear"));
         assert!(html.contains(concat!(
             r#".peitho-time-tracker [data-peitho-marker="rabbit"],"#,
             "\n",
@@ -689,7 +690,8 @@ mod tests {
         assert!(html.contains(".peitho-time-tracker"));
         assert!(html.contains(r#"[data-peitho-time-tracker="presenter"]"#));
         assert!(html.contains("height: 26px"));
-        assert!(html.contains("transform: translateX(-50%)"));
+        assert!(!html.contains("transform: translateX(-50%)"));
+        assert!(html.contains("transition: left 120ms linear, transform 120ms linear"));
         assert!(html.contains(concat!(
             r#".peitho-time-tracker [data-peitho-marker="rabbit"],"#,
             "\n",

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -600,6 +600,7 @@ function installTimeTracker(options) {
   let autoStarted = false;
   const setMarker = (element, ratio) => {
     element.style.left = `${Math.round(ratio * 1e4) / 100}%`;
+    element.style.transform = `translateX(${-Math.round(ratio * 1e4) / 100}%)`;
   };
   const updateSlides = (index, total) => {
     const ratio = total <= 1 ? 0 : index / (total - 1);

--- a/packages/peitho-present/src/timeTracker.ts
+++ b/packages/peitho-present/src/timeTracker.ts
@@ -62,6 +62,7 @@ export function installTimeTracker(options: TimeTrackerOptions): () => void {
 
   const setMarker = (element: HTMLElement, ratio: number): void => {
     element.style.left = `${Math.round(ratio * 10_000) / 100}%`;
+    element.style.transform = `translateX(${-Math.round(ratio * 10_000) / 100}%)`;
   };
   const updateSlides = (index: number, total: number): void => {
     const ratio = total <= 1 ? 0 : index / (total - 1);

--- a/packages/peitho-present/test/timeTracker.test.ts
+++ b/packages/peitho-present/test/timeTracker.test.ts
@@ -48,6 +48,52 @@ it("moves rabbit by slide progress and turtle by elapsed progress", () => {
   expect(root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')?.style.left).toBe("50%");
 });
 
+it("clamps markers to the track edges so the glyph never overflows", () => {
+  let elapsed = 0;
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ manifest: { slideCount: 3 }, elapsedMs: () => elapsed }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document
+    })
+  );
+
+  const rabbit = root.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')!;
+  const turtle = root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')!;
+
+  expect(rabbit.style.left).toBe("0%");
+  expect(rabbit.style.transform).toBe("translateX(0%)");
+  expect(turtle.style.left).toBe("0%");
+  expect(turtle.style.transform).toBe("translateX(0%)");
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 1, total: 3, previousIndex: 0, key: "middle" }
+    })
+  );
+  elapsed = 30_000;
+  vi.advanceTimersByTime(250);
+  expect(rabbit.style.transform).toBe("translateX(-50%)");
+  expect(turtle.style.transform).toBe("translateX(-50%)");
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:slidechange", {
+      detail: { index: 2, total: 3, previousIndex: 1, key: "last" }
+    })
+  );
+  elapsed = 60_000;
+  vi.advanceTimersByTime(250);
+  expect(rabbit.style.left).toBe("100%");
+  expect(rabbit.style.transform).toBe("translateX(-100%)");
+  expect(turtle.style.left).toBe("100%");
+  expect(turtle.style.transform).toBe("translateX(-100%)");
+});
+
 it("rejects non-positive and non-finite planned durations", () => {
   for (const plannedDurationMs of [0, -1, Number.NaN]) {
     const root = document.createElement("main");


### PR DESCRIPTION
## Summary
- Rabbit🐰/turtle🐢 tracker markers used a fixed `translateX(-50%)`, so at 0% they hung half-off the left edge and at 100% half-off the right. On 1-display present mode this was the first thing you saw.
- Slide the transform amount together with the ratio: 0% → `translateX(0)`, 50% → `translateX(-50%)`, 100% → `translateX(-100%)`. Now the glyph rests flush against the edge without ever overflowing.
- Dropped the static `transform` from the present/presenter CSS (the JS now owns it) and added `transform` to the CSS `transition` so movement stays smooth.

## Test plan
- [x] `cargo test --workspace` (× 3)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `npm test` / `npm run build` / `npm run typecheck` in `packages/peitho-present`
- [x] `bindings/` and `dist/shell.js` drift check
- [x] Visual confirmation in a real browser (author)

🤖 Generated with [Claude Code](https://claude.com/claude-code)