### PR TITLE
feat: extract speaker notes from HTML comments

### DIFF
--- a/crates/peitho-core/src/check.rs
+++ b/crates/peitho-core/src/check.rs
@@ -24,6 +24,7 @@ pub fn check_deck(deck: Deck<Mapped>) -> Result<Deck<Checked>> {
             slide.key,
             slide.layout,
             checked_slots,
+            slide.notes,
         ));
     }
     Ok(Deck::checked(settings, slides))

--- a/crates/peitho-core/src/domain.rs
+++ b/crates/peitho-core/src/domain.rs
@@ -290,11 +290,17 @@ pub struct RenderedSlide {
     index: usize,
     key: SlideKey,
     html: String,
+    notes: Option<String>,
 }
 
 impl RenderedSlide {
-    pub(crate) fn new(index: usize, key: SlideKey, html: String) -> Self {
-        Self { index, key, html }
+    pub(crate) fn new(index: usize, key: SlideKey, html: String, notes: Option<String>) -> Self {
+        Self {
+            index,
+            key,
+            html,
+            notes,
+        }
     }
 
     pub fn index(&self) -> usize {
@@ -307,6 +313,10 @@ impl RenderedSlide {
 
     pub fn html(&self) -> &str {
         &self.html
+    }
+
+    pub fn notes(&self) -> Option<&str> {
+        self.notes.as_deref()
     }
 
     pub fn src(&self) -> String {

--- a/crates/peitho-core/src/manifest.rs
+++ b/crates/peitho-core/src/manifest.rs
@@ -118,7 +118,7 @@ pub fn build_manifest(deck: &Deck<Checked>) -> Manifest {
                 slide.index(),
                 slide.key().clone(),
                 fragment_src(slide.index(), slide.key()),
-                false,
+                slide.notes().is_some(),
             )
         })
         .collect();
@@ -231,6 +231,16 @@ mod tests {
         let json = manifest_json(&manifest).unwrap();
 
         assert!(json.contains(r#""plannedDurationMs": 900000"#));
+    }
+
+    #[test]
+    fn build_manifest_marks_has_notes_from_slide_notes() {
+        let markdown = "# Intro\n\n<!-- pre-show reminder -->\n\n---\n\n# Plain";
+        let checked = checked_deck(markdown, title_body_layout());
+        let manifest = build_manifest(&checked);
+
+        assert!(manifest.slides()[0].has_notes());
+        assert!(!manifest.slides()[1].has_notes());
     }
 
     #[test]

--- a/crates/peitho-core/src/mapping.rs
+++ b/crates/peitho-core/src/mapping.rs
@@ -121,6 +121,7 @@ fn map_slide(slide: &ParsedSlide, layout: &Layout) -> MappedSlide {
         layout: layout.clone(),
         slots,
         unassigned,
+        notes: slide.notes.clone(),
     }
 }
 

--- a/crates/peitho-core/src/notes.rs
+++ b/crates/peitho-core/src/notes.rs
@@ -2,7 +2,11 @@ use std::collections::BTreeMap;
 
 use serde::Serialize;
 
-use crate::{domain::SlideKey, error::Result, json::pretty_json};
+use crate::{
+    domain::{RenderedSlide, SlideKey},
+    error::Result,
+    json::pretty_json,
+};
 
 #[cfg_attr(any(test, feature = "ts-bindings"), derive(ts_rs::TS))]
 #[cfg_attr(
@@ -29,6 +33,21 @@ impl Notes {
 
     pub fn new(notes: BTreeMap<SlideKey, String>) -> Self {
         Self { version: 1, notes }
+    }
+
+    /// Collect speaker notes from a rendered deck. Slides without notes are
+    /// omitted from the map (they are represented by `hasNotes: false` in the
+    /// manifest, and by absence in `notes.json`).
+    pub fn from_slides(slides: &[RenderedSlide]) -> Self {
+        let map = slides
+            .iter()
+            .filter_map(|slide| {
+                slide
+                    .notes()
+                    .map(|text| (slide.key().clone(), text.to_owned()))
+            })
+            .collect();
+        Self::new(map)
     }
 }
 
@@ -79,5 +98,41 @@ mod tests {
         let json = serde_json::to_string(&notes).unwrap();
 
         assert!(json.contains(r#""arch-1":"speaker note""#));
+    }
+
+    #[test]
+    fn from_slides_skips_slides_without_notes() {
+        use crate::domain::RenderedSlide;
+
+        let slides = vec![
+            RenderedSlide::new(
+                0,
+                SlideKey::new("intro").unwrap(),
+                String::new(),
+                Some("only the intro has a note".to_owned()),
+            ),
+            RenderedSlide::new(1, SlideKey::new("plain").unwrap(), String::new(), None),
+            RenderedSlide::new(
+                2,
+                SlideKey::new("outro").unwrap(),
+                String::new(),
+                Some("closing thought".to_owned()),
+            ),
+        ];
+        let notes = Notes::new(
+            [
+                (
+                    SlideKey::new("intro").unwrap(),
+                    "only the intro has a note".to_owned(),
+                ),
+                (
+                    SlideKey::new("outro").unwrap(),
+                    "closing thought".to_owned(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+        assert_eq!(super::Notes::from_slides(&slides), notes);
     }
 }

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -416,10 +416,16 @@ fn parse_slide(source: &str, range: SlideRange, index: usize) -> Result<ParsedSl
     let mut explicit_key: Option<(SlideKey, usize)> = None;
     let mut layout_request: Option<LayoutRequest> = None;
     let mut fragments = Vec::new();
+    let mut note_fragments: Vec<String> = Vec::new();
     let mut block: Option<OpenBlock> = None;
     let mut list_depth = 0usize;
     let mut list_start = None;
     let mut seen_content = false;
+    // An HTML block can span multiple `Event::Html` events (one per source line
+    // for a multi-line comment). We buffer them between Start(HtmlBlock)/End
+    // and analyse the joined text once, so a multi-line `<!-- ... -->` isn't
+    // mistaken for an "unsupported html" per line.
+    let mut html_buf: Option<(String, usize)> = None;
 
     for (event, local_range) in Parser::new_ext(slice, parser_options()).into_offset_iter() {
         let global_start = range.start + local_range.start;
@@ -463,37 +469,24 @@ fn parse_slide(source: &str, range: SlideRange, index: usize) -> Result<ParsedSl
                 }
             }
             Event::Html(html) | Event::InlineHtml(html) => {
-                if let Some(settings) = parse_page_comment(html.as_ref(), line).map_err(|err| {
-                    attach_slide_context(err, index, explicit_key.as_ref(), &fragments)
-                })? {
-                    if list_depth > 0 || seen_content {
-                        let err = BuildError::new(
-                            ErrorKind::Parse,
-                            Some(line),
-                            "page settings comment must appear before slide content",
-                            "move the settings comment to the first non-blank line of the slide",
-                        );
-                        return Err(attach_slide_context(
-                            err,
-                            index,
-                            explicit_key.as_ref(),
-                            &fragments,
-                        ));
-                    }
-                    if let Some(key) = settings.key {
-                        explicit_key = Some((key, line));
-                    }
-                    if let Some(name) = settings.layout {
-                        layout_request = Some(LayoutRequest { name, line });
-                    }
-                } else if !is_html_comment(html.as_ref()) && !html.trim().is_empty() {
-                    let err = unsupported_construct(line, "html");
-                    return Err(attach_slide_context(
-                        err,
+                if let Some((buf, _)) = html_buf.as_mut() {
+                    buf.push_str(html.as_ref());
+                } else {
+                    // InlineHtml (or a stray Html outside a HtmlBlock): process
+                    // as a single-event chunk immediately.
+                    let ctx = explicit_key.clone();
+                    process_html_chunk(
+                        html.as_ref(),
+                        line,
                         index,
-                        explicit_key.as_ref(),
                         &fragments,
-                    ));
+                        &ctx,
+                        list_depth,
+                        seen_content,
+                        &mut explicit_key,
+                        &mut layout_request,
+                        &mut note_fragments,
+                    )?;
                 }
             }
             Event::Start(Tag::MetadataBlock(_)) => {
@@ -603,7 +596,26 @@ fn parse_slide(source: &str, range: SlideRange, index: usize) -> Result<ParsedSl
                     text.push('\n');
                 }
             }
-            Event::Start(Tag::HtmlBlock) | Event::End(TagEnd::HtmlBlock) => {}
+            Event::Start(Tag::HtmlBlock) => {
+                html_buf = Some((String::new(), line));
+            }
+            Event::End(TagEnd::HtmlBlock) => {
+                if let Some((buf, start_line)) = html_buf.take() {
+                    let ctx = explicit_key.clone();
+                    process_html_chunk(
+                        &buf,
+                        start_line,
+                        index,
+                        &fragments,
+                        &ctx,
+                        list_depth,
+                        seen_content,
+                        &mut explicit_key,
+                        &mut layout_request,
+                        &mut note_fragments,
+                    )?;
+                }
+            }
             Event::Start(tag) if unsupported_tag(&tag) => {
                 let err = unsupported_construct(line, unsupported_tag_name(&tag));
                 return Err(attach_slide_context(
@@ -641,13 +653,92 @@ fn parse_slide(source: &str, range: SlideRange, index: usize) -> Result<ParsedSl
             (key, key_source)
         });
 
+    let notes = if note_fragments.is_empty() {
+        None
+    } else {
+        Some(note_fragments.join("\n\n"))
+    };
+
     Ok(ParsedSlide {
         index,
         key,
         key_source,
         layout_request,
         fragments,
+        notes,
     })
+}
+
+/// Handle one whole HTML chunk (a completed HtmlBlock's joined text, or one
+/// stray inline HTML event). Dispatches to page-settings parsing, note
+/// collection, or an "unsupported html" error.
+#[allow(clippy::too_many_arguments)]
+fn process_html_chunk(
+    raw: &str,
+    line: usize,
+    index: usize,
+    fragments: &[SourceFragment],
+    explicit_key_ctx: &Option<(SlideKey, usize)>,
+    list_depth: usize,
+    seen_content: bool,
+    explicit_key: &mut Option<(SlideKey, usize)>,
+    layout_request: &mut Option<LayoutRequest>,
+    note_fragments: &mut Vec<String>,
+) -> Result<()> {
+    if let Some(settings) = parse_page_comment(raw, line)
+        .map_err(|err| attach_slide_context(err, index, explicit_key_ctx.as_ref(), fragments))?
+    {
+        if list_depth > 0 || seen_content {
+            let err = BuildError::new(
+                ErrorKind::Parse,
+                Some(line),
+                "page settings comment must appear before slide content",
+                "move the settings comment to the first non-blank line of the slide",
+            );
+            return Err(attach_slide_context(
+                err,
+                index,
+                explicit_key_ctx.as_ref(),
+                fragments,
+            ));
+        }
+        if let Some(key) = settings.key {
+            *explicit_key = Some((key, line));
+        }
+        if let Some(name) = settings.layout {
+            *layout_request = Some(LayoutRequest { name, line });
+        }
+        return Ok(());
+    }
+    if is_html_comment(raw) {
+        if let Some(text) = extract_html_comment_body(raw) {
+            note_fragments.push(text);
+        }
+        return Ok(());
+    }
+    if !raw.trim().is_empty() {
+        let err = unsupported_construct(line, "html");
+        return Err(attach_slide_context(
+            err,
+            index,
+            explicit_key_ctx.as_ref(),
+            fragments,
+        ));
+    }
+    Ok(())
+}
+
+/// Extract the inner text of an HTML comment (between `<!--` and `-->`).
+/// Trims surrounding whitespace and returns `None` if the body is empty,
+/// so `<!-- -->` and `<!--\n\n-->` are silently ignored (not treated as notes).
+fn extract_html_comment_body(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let body = trimmed.strip_prefix("<!--")?.strip_suffix("-->")?.trim();
+    if body.is_empty() {
+        None
+    } else {
+        Some(body.to_owned())
+    }
 }
 
 fn attach_slide_context(
@@ -997,13 +1088,58 @@ After list
     }
 
     #[test]
-    fn ignores_plain_html_comments() {
-        let deck = parse_markdown("<!-- TODO: polish copy -->\n# Title").unwrap();
+    fn collects_speaker_note_from_html_comment() {
+        let deck = parse_markdown("# Title\n\n<!-- speaker note body -->").unwrap();
 
         let slide = &deck.parsed_slides()[0];
         assert_eq!(slide.key.as_str(), "title");
         assert_eq!(slide.fragments.len(), 1);
-        assert_eq!(slide.fragments[0].line(), 2);
+        assert_eq!(slide.notes.as_deref(), Some("speaker note body"));
+    }
+
+    #[test]
+    fn joins_multiple_html_comments_with_blank_line() {
+        let deck = parse_markdown("# Title\n\n<!-- first note -->\n\nbody\n\n<!-- second note -->")
+            .unwrap();
+
+        let slide = &deck.parsed_slides()[0];
+        assert_eq!(slide.notes.as_deref(), Some("first note\n\nsecond note"));
+    }
+
+    #[test]
+    fn empty_html_comment_is_ignored_as_note() {
+        let deck = parse_markdown("# Title\n\n<!-- -->\n\n<!--\n\n-->").unwrap();
+
+        let slide = &deck.parsed_slides()[0];
+        assert!(slide.notes.is_none());
+    }
+
+    #[test]
+    fn html_comment_before_content_is_still_a_note() {
+        let deck = parse_markdown("<!-- pre-title note -->\n# Title").unwrap();
+
+        let slide = &deck.parsed_slides()[0];
+        assert_eq!(slide.key.as_str(), "title");
+        assert_eq!(slide.notes.as_deref(), Some("pre-title note"));
+    }
+
+    #[test]
+    fn page_settings_comment_and_note_coexist() {
+        let deck =
+            parse_markdown("<!-- {\"key\":\"cover\"} -->\n# Title\n\n<!-- this is a note -->")
+                .unwrap();
+
+        let slide = &deck.parsed_slides()[0];
+        assert_eq!(slide.key.as_str(), "cover");
+        assert_eq!(slide.notes.as_deref(), Some("this is a note"));
+    }
+
+    #[test]
+    fn multiline_html_comment_preserves_internal_newlines() {
+        let deck = parse_markdown("# Title\n\n<!--\nline one\nline two\n-->").unwrap();
+
+        let slide = &deck.parsed_slides()[0];
+        assert_eq!(slide.notes.as_deref(), Some("line one\nline two"));
     }
 
     #[test]

--- a/crates/peitho-core/src/phase.rs
+++ b/crates/peitho-core/src/phase.rs
@@ -76,6 +76,7 @@ pub struct ParsedSlide {
     pub key_source: KeySource,
     pub layout_request: Option<LayoutRequest>,
     pub fragments: Vec<SourceFragment>,
+    pub notes: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -93,6 +94,7 @@ pub struct MappedSlide {
     pub(crate) layout: Layout,
     pub(crate) slots: BTreeMap<SlotName, MappedSlot>,
     pub(crate) unassigned: Vec<UnassignedFragment>,
+    pub(crate) notes: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -156,6 +158,7 @@ pub struct CheckedSlide {
     key: SlideKey,
     layout: Layout,
     slots: BTreeMap<SlotName, Vec<SourceFragment>>,
+    notes: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -210,12 +213,14 @@ impl CheckedSlide {
         key: SlideKey,
         layout: Layout,
         slots: BTreeMap<SlotName, Vec<SourceFragment>>,
+        notes: Option<String>,
     ) -> Self {
         Self {
             index,
             key,
             layout,
             slots,
+            notes,
         }
     }
 
@@ -233,6 +238,10 @@ impl CheckedSlide {
 
     pub(crate) fn slots(&self) -> &BTreeMap<SlotName, Vec<SourceFragment>> {
         &self.slots
+    }
+
+    pub(crate) fn notes(&self) -> Option<&str> {
+        self.notes.as_deref()
     }
 
     pub(crate) fn title_text(&self) -> Option<String> {
@@ -357,6 +366,7 @@ mod tests {
                 key_source: KeySource::Explicit { line: 1 },
                 layout_request: None,
                 fragments: vec![SourceFragment::paragraph(3, "body")],
+                notes: None,
             }],
         );
 

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -18,7 +18,13 @@ pub fn render_deck(deck: Deck<Checked>) -> Result<Deck<Rendered>> {
     let mut slides = Vec::new();
     for slide in checked_slides {
         let html = render_slide(slide.key(), slide.slots(), slide.layout())?;
-        slides.push(RenderedSlide::new(slide.index(), slide.key().clone(), html));
+        let notes = slide.notes().map(|s| s.to_owned());
+        slides.push(RenderedSlide::new(
+            slide.index(),
+            slide.key().clone(),
+            html,
+            notes,
+        ));
     }
     Ok(Deck::rendered(settings, slides, String::new()))
 }

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -699,7 +699,9 @@ fn emit_present_cache(
     fs::write(cache.join("manifest.json"), &artifacts.manifest_json).into_diagnostic()?;
     fs::write(
         cache.join("notes.json"),
-        core(peitho_core::notes_json(&peitho_core::Notes::empty()))?,
+        core(peitho_core::notes_json(&peitho_core::Notes::from_slides(
+            artifacts.rendered.slides(),
+        )))?,
     )
     .into_diagnostic()?;
     fs::write(

--- a/docs/plans/2026-07-04-speaker-notes.md
+++ b/docs/plans/2026-07-04-speaker-notes.md
@@ -1,0 +1,91 @@
+# 発表者ノート実装計画 (2026-07-04)
+
+## 決定事項
+
+- **記法**: HTMLコメント `<!-- ... -->` （Marp / k1LoW/deck方式）
+  - 既存の「JSONオブジェクトを含むHTMLコメント = ページ設定 (`key`/`layout`)」との判別は、**JSONとしてパースできるかどうか**で行う（既存 `parse_page_comment` の分岐を再利用）
+  - JSON設定でも空HTMLコメントでもない、非空のHTMLコメントを **speaker note** として拾う
+- **配置制約**: スライド本文のどこに書いてもよい。1スライド内に複数コメントがあれば `\n\n` で連結（k1LoW/deckと同じ）
+- **中身の解釈**: 保存時はプレーンテキスト（前後の空白のみ `trim`）。presenter側での表示もv1はプレーンテキスト（`textContent`）を維持
+  - Markdown書式解釈は後段で拡張可能な軸として残す（`notes.json`はversion付きなので前方互換）
+- **配布HTMLへの埋込**: なし。既存設計どおり `dist/index.html` にはノートを含めず、`peitho present` のみが `notes.json` を読む
+
+## 三本柱・不変条件との整合
+
+- **柱1（内容と設計の分離）**: ノートはMarkdown側にHTMLコメントとして書く → 内容側に閉じる。レイアウトHTMLには一切影響しない ✅
+- **柱3（型検査・沈黙禁止）**:
+  - 現在 `parser.rs:1000` の `ignores_plain_html_comments` は「非JSONコメントを黙って捨てる」テスト。これを **「非JSONコメントは speaker note として収集される」** テストに置き換える
+  - 空HTMLコメント `<!-- -->` は現状も無視されている。明示的に「空コメントはノート扱いしない（無視）」を単体テストで固定
+  - JSONに見えるが `key`/`layout` 以外のフィールドを含むコメントは既に `parse_page_comment` がエラーにしている → 変更不要
+- **typestate**: `ParsedSlide` に `notes: Option<String>` を追加し `Mapped→Checked→Rendered` を通して運搬。`Notes` コレクションの組み立ては `Checked` から `Rendered` への遷移で `SlideKey` が確定してから
+
+## パーサ側の変更（`crates/peitho-core/src/parser.rs`）
+
+現状 `Event::Html | Event::InlineHtml` の分岐（`parser.rs:465-497`）:
+
+1. `parse_page_comment` が `Some(settings)` を返せば設定として処理
+2. それ以外の非空HTMLで、`is_html_comment` でなければ `unsupported_construct` エラー
+3. HTMLコメントかつ設定でない場合は **何もしない**（← ここが黙って捨てているポイント）
+
+変更:
+
+- 3のケースで、コメント本文（`<!--` と `-->` の間）を抽出し `trim` して、空でなければ `ParsedSlide.note_fragments: Vec<String>` に push
+- `parse_slide` の末尾で `note_fragments.join("\n\n")` を `notes: Option<String>` にまとめる（空なら `None`）
+- 位置制約は付けない（本文の前・中・後どこでもOK）。設定コメントの「先頭のみ」制約は現状維持
+- テスト:
+  - `collects_speaker_note_from_html_comment` （1個のコメントが `notes` に入る）
+  - `joins_multiple_html_comments_with_blank_line` （複数コメントは `\n\n` 連結）
+  - `note_with_page_settings_comment_coexist` （設定コメント＋別のノートコメントが両立）
+  - `empty_html_comment_is_ignored` （`<!-- -->` は無視）
+  - `note_can_appear_after_content` （本文後のコメントも拾う）
+  - 既存 `ignores_plain_html_comments` は上記に置き換え
+
+## 型・ドメイン層の変更
+
+- `ParsedSlide`（parser.rs内の型）に `notes: Option<String>` を追加
+- `Mapped<Slide>` / `Checked<Slide>` / `Rendered<Slide>` の内部でも `notes` を伝搬（既存フィールド追加パターンに従う）
+- `SlideKey` は Mapped 以降で確定するので、`Notes` コレクション（`BTreeMap<SlideKey, String>`）の構築は Rendered 段で行う
+
+## Notes構築とmanifest
+
+- `crates/peitho-core/src/notes.rs`: 既存 `Notes::new(BTreeMap)` をそのまま使う。組み立てヘルパを追加:
+  ```rust
+  impl Notes {
+      pub fn from_slides(slides: &[Rendered<Slide>]) -> Self { ... }
+  }
+  ```
+- `manifest.rs`: `SlideEntry::new` の `has_notes` に `slide.notes.is_some()` を渡す（現在は `false` 固定と思われる箇所を修正）
+- CLI（`crates/peitho/src/main.rs:701`）: 現在 `Notes::empty()` を書き出している → `Notes::from_slides(...)` に差し替え
+
+## Presenter側
+
+- 現状 `presenter.ts:150` で `notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide."`
+- v1はこのまま **プレーンテキスト表示**。Markdown解釈への拡張は将来課題（`notes.json` version bumpで対応可能）
+- 型 (`bindings/Notes.ts`) は変更なし
+
+## E2E確認
+
+- `examples/` に speaker note入りのサンプルを1つ追加（既存デックに追記でも可）
+- `peitho build` → `dist/notes.json` の中身確認
+- `peitho present` → presenter画面で Cmd+左右で切り替えつつノート表示を目視確認
+- 複数ディスプレイ実機での挙動は CLAUDE.md の [BetterDisplay仮想ディスプレイ手順](file:///Users/mizzy/.claude/projects/-Users-mizzy-src-github-com-mizzy-peitho/memory/betterdisplay-virtual-display-e2e.md) を使う
+
+## ゲート
+
+- `cargo test --workspace` を3回
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --exit-code bindings/` （今回 `Notes` の型は変えないので差分ゼロのはず）
+- `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
+- `git diff --exit-code packages/peitho-present/dist/shell.js` （presenter配線は現状のまま textContent なので shell側変更なし → 差分ゼロのはず）
+
+## Undecidedを残すもの
+
+- **Markdown書式解釈**: v1はプレーンテキスト固定。将来 `NotesFormat: "plain" | "markdown"` のような軸を frontmatter に追加する余地を残す
+- **fenced div `::: notes` 記法**: §18 の fenced div slot notation と同時に検討。今回は着手しない
+
+## PR
+
+- ブランチ: `feat/speaker-notes`（既に worktree作成済み: `../peitho-speaker-notes`）
+- draft PRで作成
+- タイトル案: `feat: extract speaker notes from HTML comments`

--- a/examples/deck.md
+++ b/examples/deck.md
@@ -7,6 +7,11 @@ Markdown is the source of truth, while HTML and CSS own layout.
 enum Phase { Parsed, Mapped, Checked, Rendered }
 ```
 
+<!--
+Open with the two-line pitch: separation of content and design,
+enforced by the typestate pipeline.
+-->
+
 ---
 
 # Convention Mapping
@@ -14,6 +19,8 @@ enum Phase { Parsed, Mapped, Checked, Rendered }
 - Shallowest heading maps to title
 - Code blocks map to code
 - Remaining blocks map to body
+
+<!-- Remind the audience: no config here — it's convention over configuration. -->
 
 ---
 <!-- {"key":"dist-1"} -->


### PR DESCRIPTION
## Summary

- Adopt the Marp / k1LoW/deck convention: HTML comments that are not JSON page-settings comments become speaker notes for that slide.
- Multiple comments per slide are joined with a blank line; empty comments are ignored; multi-line comments preserve internal newlines.
- Notes are keyed by ``SlideKey`` and ride through ``Parsed → Mapped → Checked → Rendered`` alongside the slide.
- ``manifest.hasNotes`` and ``notes.json`` are now populated from the rendered deck (previously always ``false`` / ``{}``).
- Presenter view was already wired up to read ``notes[key]``, so no TS change was required.

Design record: [``docs/plans/2026-07-04-speaker-notes.md``](docs/plans/2026-07-04-speaker-notes.md). Closes one of the §18 undecided items.

## Test plan

- [x] ``cargo test --workspace`` (3 runs, all green)
- [x] ``cargo clippy --workspace --all-targets -- -D warnings``
- [x] ``cargo fmt --all --check``
- [x] ``git diff --exit-code bindings/`` (no drift — ``Notes`` type unchanged)
- [x] ``npm run build && npm test && npm run typecheck`` in ``packages/peitho-present``
- [x] ``git diff --exit-code packages/peitho-present/dist/shell.js`` (no shell drift)
- [x] E2E: built ``examples/deck.md``, confirmed ``dist/manifest.json`` marks ``hasNotes: true`` on annotated slides
- [x] E2E: ``peitho present`` → ``.peitho/present-cache/notes.json`` contains the collected notes with newlines preserved
- [x] E2E: opened ``/presenter`` in Chrome, verified notes render per-slide with ``white-space: pre-wrap`` and slides without notes show "No notes for this slide."

## Notes on scope

- v1 stores note bodies as plain text and the presenter displays them via ``textContent``. Markdown rendering of notes remains a future extension (the ``notes.json`` version field is preserved).
- Fenced-div ``::: notes`` syntax (§18) is intentionally not tackled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)