### PR TITLE
feat(presenter): redesign presenter view with state-synced timer UI

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -388,32 +388,125 @@ pub fn render_presenter_index() -> String {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
   <title>Peitho Presenter</title>
   <style>
-    html, body { margin: 0; width: 100%; min-height: 100%; background: #111; color: #f5f5f5; }
-    body { font: 14px system-ui, sans-serif; }
-    #peitho-presenter-root { min-height: 100vh; }
-    .peitho-presenter { display: grid; grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr); gap: 16px; padding: 16px; box-sizing: border-box; min-height: 100vh; }
-    .peitho-presenter-pane { position: relative; overflow: hidden; background: #000; min-height: 180px; }
-    [data-peitho-presenter="current"] { min-height: calc(100vh - 32px); }
-    .peitho-presenter-preview-slot { position: relative; aspect-ratio: 16 / 9; }
-    [data-peitho-presenter="preview"] { position: absolute; inset: 0; }
-    [data-peitho-presenter="preview-end"] { position: absolute; inset: 0; margin: 0; display: flex; align-items: center; justify-content: center; background: #000; color: #aaa; font-size: 18px; }
-    .peitho-presenter-preview-slot > [hidden] { display: none; }
-    [data-peitho-presenter="notes"] { white-space: pre-wrap; line-height: 1.5; margin-top: 16px; }
-    [data-peitho-presenter="timer"] { display: block; font-size: 40px; font-variant-numeric: tabular-nums; margin: 16px 0; }
-    .peitho-presenter-controls { display: flex; flex-wrap: wrap; gap: 8px; }
-    .peitho-time-tracker[data-peitho-time-tracker="presenter"] { position: relative; height: 26px; margin: 12px 0; z-index: 20; pointer-events: none; background: rgba(255, 255, 255, 0.16); }
-    .peitho-time-tracker [data-peitho-marker] { position: absolute; transition: left 120ms linear, transform 120ms linear; font-size: 18px; line-height: 1; }
-    .peitho-time-tracker [data-peitho-marker="rabbit"],
-    .peitho-time-tracker [data-peitho-marker="turtle"] { top: 4px; }
-    .peitho-time-tracker[data-peitho-overrun] { background: rgba(255, 92, 92, 0.35); }
-    [data-peitho-presenter="timer"][data-peitho-overrun] { color: #ff8a8a; }
+    :root {
+      --bg: oklch(15% 0.01 250);
+      --bg-elev: oklch(19% 0.012 250);
+      --bg-slide: oklch(8% 0.005 250);
+      --line: oklch(28% 0.015 250);
+      --line-soft: oklch(24% 0.012 250);
+      --fg: oklch(96% 0.005 250);
+      --fg-mute: oklch(72% 0.01 250);
+      --fg-dim: oklch(52% 0.012 250);
+      --accent: oklch(78% 0.14 195);
+      --accent-soft: oklch(78% 0.14 195 / 0.14);
+      --warn: oklch(72% 0.19 30);
+      --warn-soft: oklch(72% 0.19 30 / 0.18);
+      --pause: oklch(82% 0.15 90);
+    }
+    html, body { margin: 0; width: 100%; height: 100%; background: var(--bg); color: var(--fg); overflow: hidden; }
+    body { font-family: "Geist", ui-sans-serif, system-ui, -apple-system, "Hiragino Kaku Gothic ProN", sans-serif; font-size: 14px; letter-spacing: 0; }
+    [hidden] { display: none !important; }
+    .mono { font-family: "Geist Mono", ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+    #peitho-presenter-root { min-height: 100vh; height: 100vh; }
+    .app { display: grid; grid-template-columns: minmax(0, 1.7fr) minmax(400px, 1fr); gap: 20px; padding: 20px; box-sizing: border-box; height: 100vh; max-height: 100vh; }
+    .left { display: grid; grid-template-rows: auto minmax(0, 1fr) auto auto; gap: 12px; min-height: 0; min-width: 0; }
+    .right { display: grid; grid-template-rows: auto minmax(0, 1fr); gap: 16px; min-height: 0; min-width: 0; }
+    .colhead { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 2px; min-width: 0; }
+    .status-line { display: inline-flex; align-items: center; gap: 10px; color: var(--fg-dim); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; min-width: 0; }
+    .status-line .sep { width: 3px; height: 3px; border-radius: 50%; background: var(--line); flex: 0 0 auto; }
+    .status-line .now { color: var(--accent); }
+    .deck-title { font-size: 12px; color: var(--fg-mute); letter-spacing: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .slide-frame { min-height: 0; min-width: 0; display: flex; align-items: center; justify-content: center; container-type: size; }
+    .slide-pane { position: relative; width: min(100cqw, calc(100cqh * 16 / 9)); aspect-ratio: 16 / 9; background: var(--bg-slide); border: 1px solid var(--line-soft); box-shadow: 0 20px 60px -30px rgba(0, 0, 0, 0.6); overflow: hidden; }
+    .peitho-presenter-pane { position: relative; overflow: hidden; background: var(--bg-slide); min-height: 0; }
+    .kbdbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 2px; color: var(--fg-dim); font-size: 12px; }
+    .kbdbar .pos { color: var(--fg-mute); font-family: "Geist Mono", ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+    .kbd { display: inline-flex; align-items: center; padding: 2px 6px; border: 1px solid var(--line); border-bottom-width: 2px; border-radius: 4px; font-family: "Geist Mono", ui-monospace, monospace; font-size: 11px; color: var(--fg-mute); line-height: 1.2; }
+    .kbdbar .grp { display: inline-flex; align-items: center; gap: 6px; margin-left: 14px; white-space: nowrap; }
+    .kbdbar .grp:first-of-type { margin-left: 0; }
+    .notes { background: var(--bg-elev); border: 1px solid var(--line-soft); display: grid; grid-template-rows: auto minmax(0, auto); min-height: 0; max-height: 42vh; overflow: hidden; }
+    .notes-head { display: flex; align-items: center; justify-content: space-between; padding: 6px 14px; border-bottom: 1px solid var(--line-soft); color: var(--fg-dim); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; }
+    .notes-head .badge { color: var(--fg-mute); letter-spacing: 0; text-transform: none; font-size: 11px; }
+    .notes-body { overflow: auto; padding: 10px 16px 12px; font-size: 16px; line-height: 1.4; color: var(--fg); white-space: pre-wrap; }
+    .card { background: var(--bg-elev); border: 1px solid var(--line-soft); display: flex; flex-direction: column; min-height: 0; }
+    .card-head { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px; border-bottom: 1px solid var(--line-soft); color: var(--fg-dim); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; }
+    .card-head .badge { color: var(--fg-mute); letter-spacing: 0; text-transform: none; font-size: 11px; }
+    .next-wrap { padding: 12px; }
+    .next-preview { position: relative; aspect-ratio: 16 / 9; background: var(--bg-slide); border: 1px solid var(--line-soft); overflow: hidden; }
+    .next-preview > [data-peitho-presenter="preview"] { position: absolute; inset: 0; }
+    [data-peitho-presenter="preview-end"] { position: absolute; inset: 0; margin: 0; display: flex; align-items: center; justify-content: center; background: var(--bg-slide); color: var(--fg-dim); font-size: 18px; }
+    .clock { display: flex; flex-direction: column; min-height: 0; }
+    .clock-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 12px; padding: 12px 16px 6px; }
+    .timer { display: block; font-size: 48px; font-weight: 500; letter-spacing: 0; line-height: 1; color: var(--fg); transition: color 200ms ease; font-variant-numeric: tabular-nums; }
+    .timer .planned { color: var(--fg-dim); font-weight: 400; margin-left: 8px; font-size: 18px; letter-spacing: 0; }
+    .timer .overrun { color: var(--warn); font-weight: 500; margin-left: 8px; font-size: 18px; letter-spacing: 0; }
+    .clock[data-peitho-state="paused"] .timer { color: var(--pause); }
+    .clock[data-peitho-state="stopped"] .timer { color: var(--fg-dim); }
+    [data-peitho-presenter="timer"][data-peitho-overrun] { color: var(--warn); }
+    .state-pill { display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px; border: 1px solid var(--line); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--fg-mute); transition: color 150ms ease, border-color 150ms ease; white-space: nowrap; }
+    .state-dot { width: 6px; height: 6px; background: var(--fg-dim); border-radius: 50%; transition: background 150ms ease, box-shadow 150ms ease; }
+    .state-pill[data-peitho-state="running"] { color: var(--accent); border-color: color-mix(in oklch, var(--accent) 45%, var(--line)); }
+    .state-pill[data-peitho-state="running"] .state-dot { background: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); animation: pulse 1.4s ease-in-out infinite; }
+    .state-pill[data-peitho-state="paused"] { color: var(--pause); border-color: color-mix(in oklch, var(--pause) 45%, var(--line)); }
+    .state-pill[data-peitho-state="paused"] .state-dot { background: var(--pause); animation: none; box-shadow: none; }
+    .state-pill[data-peitho-state="stopped"] { color: var(--fg-dim); }
+    .state-pill[data-peitho-state="stopped"] .state-dot { background: var(--fg-dim); animation: none; box-shadow: none; }
+    @keyframes pulse { 50% { box-shadow: 0 0 0 6px transparent; } }
+    .tracker-wrap { padding: 4px 16px 14px; }
+    .tracker-wrap:empty { display: none; }
+    .peitho-time-tracker[data-peitho-time-tracker="presenter"] { display: block; pointer-events: none; }
+    .tracker-legend { display: flex; justify-content: space-between; color: var(--fg-dim); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 6px; }
+    .tracker { position: relative; height: 30px; background: color-mix(in oklch, var(--fg) 8%, transparent); border: 1px solid var(--line-soft); }
+    .tracker-fill { position: absolute; top: 0; bottom: 0; left: 0; background: linear-gradient(90deg, color-mix(in oklch, var(--accent) 22%, transparent), color-mix(in oklch, var(--accent) 8%, transparent)); }
+    .peitho-time-tracker[data-peitho-overrun] .tracker { border-color: color-mix(in oklch, var(--warn) 45%, var(--line)); background: var(--warn-soft); }
+    .peitho-time-tracker[data-peitho-overrun] .tracker-fill { background: linear-gradient(90deg, color-mix(in oklch, var(--warn) 24%, transparent), color-mix(in oklch, var(--warn) 10%, transparent)); }
+    .tracker [data-peitho-marker="rabbit"],
+    .tracker [data-peitho-marker="turtle"] { position: absolute; transition: left 120ms linear, transform 120ms linear; font-size: 18px; line-height: 1; }
+    .tracker [data-peitho-marker="rabbit"] { top: -6px; }
+    .tracker [data-peitho-marker="turtle"] { bottom: -6px; }
+    .tracker-scale { display: grid; grid-template-columns: repeat(5, 1fr); margin-top: 6px; color: var(--fg-dim); font-size: 10px; letter-spacing: 0.08em; }
+    .tracker-scale span { border-left: 1px solid var(--line-soft); padding-left: 6px; }
+    .tracker-scale span:first-child { border-left: none; padding-left: 0; }
+    .controls { display: grid; grid-template-columns: minmax(max-content, 1fr) auto auto auto auto; align-items: center; gap: 6px; padding: 10px 8px; border-top: 1px solid var(--line-soft); background: color-mix(in oklch, var(--bg-elev) 92%, transparent); margin-top: auto; }
+    .btn { appearance: none; border: 1px solid var(--line); background: transparent; color: var(--fg-mute); padding: 4px 8px; font: inherit; font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; transition: background 90ms ease, color 90ms ease, border-color 90ms ease, transform 60ms ease, box-shadow 90ms ease; min-width: 0; position: relative; overflow: hidden; -webkit-tap-highlight-color: transparent; }
+    .btn .k { color: var(--fg-dim); font-family: "Geist Mono", ui-monospace, monospace; font-size: 10px; letter-spacing: 0.04em; text-transform: none; }
+    .btn:hover { color: var(--fg); border-color: color-mix(in oklch, var(--fg) 35%, var(--line)); background: color-mix(in oklch, var(--fg) 6%, transparent); }
+    .btn:focus-visible { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+    .btn:active { transform: translateY(2px); background: var(--accent); border-color: var(--accent); color: var(--bg); box-shadow: 0 0 24px var(--accent-soft), inset 0 2px 4px rgba(0, 0, 0, 0.2); }
+    .btn:active .k { color: var(--bg); }
+    .btn.primary { color: var(--bg); background: var(--accent); border-color: var(--accent); font-weight: 600; min-width: max-content; }
+    .btn.primary:hover { background: color-mix(in oklch, var(--accent) 88%, white); }
+    .btn.primary:active { background: color-mix(in oklch, var(--accent) 60%, black); border-color: color-mix(in oklch, var(--accent) 60%, black); color: white; box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.4); }
+    .clock[data-peitho-state="paused"] .btn.play.primary { background: var(--pause); border-color: var(--pause); color: var(--bg); }
+    .btn.danger { color: var(--warn); border-color: color-mix(in oklch, var(--warn) 45%, var(--line)); }
+    .btn.danger:hover { background: color-mix(in oklch, var(--warn) 12%, transparent); color: var(--warn); }
+    .btn.danger:active { background: var(--warn); color: var(--bg); border-color: var(--warn); box-shadow: 0 0 24px color-mix(in oklch, var(--warn) 30%, transparent); }
+    .btn::before { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at var(--rx, 50%) var(--ry, 50%), color-mix(in oklch, white 60%, transparent) 0%, transparent 45%); opacity: 0; pointer-events: none; transform: scale(0.3); }
+    .btn.primary::before { background: radial-gradient(circle at var(--rx, 50%) var(--ry, 50%), color-mix(in oklch, black 55%, transparent) 0%, transparent 45%); }
+    .btn.danger::before { background: radial-gradient(circle at var(--rx, 50%) var(--ry, 50%), color-mix(in oklch, white 55%, transparent) 0%, transparent 45%); }
+    .btn.pressed::before { animation: btn-ripple 500ms ease-out; }
+    @keyframes btn-ripple { 0% { opacity: 0.85; transform: scale(0.3); } 100% { opacity: 0; transform: scale(1.6); } }
+    @media (max-width: 1100px) {
+      html, body { overflow: auto; }
+      .app { grid-template-columns: 1fr; grid-template-rows: minmax(0, 1fr) auto; min-height: 100vh; height: auto; }
+      .right { grid-template-rows: auto auto; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }
+      .btn:active { transform: none; }
+      .btn.pressed::before { animation: none; }
+      .tracker [data-peitho-marker] { transition: none; }
+    }
   </style>
 </head>
 <body>
   <main id="peitho-presenter-root"></main>
-  <!-- Runtime presenter controls include data-peitho-action="close". -->
+  <!-- Runtime presenter controls include data-peitho-action="playpause" and data-peitho-action="close". -->
   <script type="module">
     import * as peitho from './shell.js';
 
@@ -684,12 +777,30 @@ mod tests {
         assert!(html.contains("await peitho.mountPresenterView({"));
         assert!(html.contains("syncChannelFactory: peitho.serverSyncChannelFactory()"));
         assert!(html.contains(r#"data-peitho-action="close""#));
-        assert!(html.contains(".peitho-presenter-pane"));
-        assert!(html.contains("grid-template-columns"));
+        assert!(html.contains(r#"data-peitho-action="playpause""#));
+        assert!(html.contains("fonts.googleapis.com"));
+        assert!(html.contains("family=Geist:wght@400;500;600;700"));
+        assert!(html.contains("family=Geist+Mono:wght@400;500;600"));
+        assert!(html.contains("display=swap"));
+        assert!(html.contains(r#"--accent: oklch(78% 0.14 195)"#));
+        assert!(html.contains(
+            ".app { display: grid; grid-template-columns: minmax(0, 1.7fr) minmax(400px, 1fr);"
+        ));
+        assert!(html.contains(".slide-pane"));
+        assert!(html.contains(".next-preview"));
+        assert!(html.contains(".notes-body"));
+        assert!(html.contains(".clock { display: flex; flex-direction: column;"));
+        assert!(html.contains(".controls {"));
+        assert!(html.contains("margin-top: auto"));
+        assert!(html.contains(".btn.pressed::before"));
+        assert!(html.contains("@media (prefers-reduced-motion: reduce)"));
         assert!(!html.contains("grid-layout-columns"));
         assert!(html.contains("overflow: hidden"));
         assert!(html.contains("Failed to load"));
         assert!(!html.contains("fetchOk(slide.src)"));
+        assert!(!html.contains(".agenda"));
+        assert!(!html.contains("Section —"));
+        assert!(!html.contains("data-omelette-injected"));
     }
 
     #[test]
@@ -698,16 +809,22 @@ mod tests {
 
         assert!(html.contains(".peitho-time-tracker"));
         assert!(html.contains(r#"[data-peitho-time-tracker="presenter"]"#));
-        assert!(html.contains("height: 26px"));
+        assert!(html.contains(".tracker-wrap"));
+        assert!(html.contains(".tracker-wrap:empty { display: none; }"));
+        assert!(html.contains(".tracker-legend"));
+        assert!(html.contains(".tracker { position: relative; height: 30px;"));
+        assert!(html.contains(".tracker-fill"));
+        assert!(html.contains(".tracker-scale"));
         assert!(!html.contains("transform: translateX(-50%)"));
         assert!(html.contains("transition: left 120ms linear, transform 120ms linear"));
         assert!(html.contains(concat!(
-            r#".peitho-time-tracker [data-peitho-marker="rabbit"],"#,
+            r#".tracker [data-peitho-marker="rabbit"],"#,
             "\n",
-            r#"    .peitho-time-tracker [data-peitho-marker="turtle"] { top: 4px; }"#
+            r#"    .tracker [data-peitho-marker="turtle"] { position: absolute; transition: left 120ms linear, transform 120ms linear; font-size: 18px; line-height: 1; }"#
         )));
-        assert!(!html.contains(r#"[data-peitho-marker="rabbit"] { top: -18px; }"#));
-        assert!(!html.contains(r#"[data-peitho-marker="turtle"] { bottom: -18px; }"#));
+        assert!(html.contains(r#".tracker [data-peitho-marker="rabbit"] { top: -6px; }"#));
+        assert!(html.contains(r#".tracker [data-peitho-marker="turtle"] { bottom: -6px; }"#));
+        assert!(!html.contains(".mark"));
         assert!(html.contains(r#"[data-peitho-presenter="timer"][data-peitho-overrun]"#));
         assert!(!html.contains(".peitho-time-tracker { position: absolute"));
         assert!(!html.contains("bottom: 0; height: 6px"));

--- a/docs/plans/2026-07-04-presenter-redesign.md
+++ b/docs/plans/2026-07-04-presenter-redesign.md
@@ -1,0 +1,43 @@
+# Presenter view redesign (Claude Design mock reflection)
+
+2026-07-04. Claude Designで作成したモック(project `73ba6a5b`/`Presenter.dc.html`、https://claude.ai/design/p/73ba6a5b-288b-46f7-a2c3-cb06863e3c5b)を発表者画面に反映する。反映後は `render_presenter_index()` のCSSが正。
+
+## デザイン概要
+
+- ダーク基調(oklch)+cyanアクセント、Geist/Geist Monoフォント(Google Fonts、オフライン時はsystem-uiへフォールバック)
+- 左カラム: ステータス行(Now・Slide N of M・デッキタイトル)→ 16:9固定の現在スライド(container query)→ キーボードヒント行 → Notesカード
+- 右カラム: Nextスライドカード(16:9)→ タイマーカード(大型タブラー数値+state pill+新見た目のトラッカー+コントロール)
+- タイマー状態(stopped/running/paused)をstate pill・タイマー色・Playボタンのラベル/色に同期
+- Start/Pause/Resumeを1つのPlayボタンに統合(状態からactionを導出、イベント契約`peitho:timercontrol`は不変)
+- ボタン押下フィードバック: 沈み込み+色反転+クリック位置からのリップル(`prefers-reduced-motion`で無効化)
+
+## スコープ外(保守的判断、報告に明記)
+
+- モックにあるAgendaセクション(セクション別実績/計画時間): peithoにセクション概念・区間時間データが存在しないため除外。必要なら別Issueで検討
+- ステータス行の「Section — ...」表示: 同上
+- キーバインド変更: Space=nextの既存マップは不変。UI表記を実挙動に合わせる(PlayボタンにSpaceヒントを付けない)
+
+## 変更ファイル
+
+1. `packages/peitho-present/src/presenter.ts`
+   - DOM構造を新デザインに全面変更(data-peitho-presenter / data-peitho-action フックは維持・拡張)
+   - タイマー状態導出: `startedAt()===null`→stopped、`isPaused()`→paused、他→running
+   - `data-peitho-action="playpause"`ボタン: stateに応じ start/pause/resume をdispatch
+   - tick()でstate pill/playラベル/クロックカードの`data-peitho-state`を更新
+   - タイマー表示をspan分割(planned/overrunの色分け)。textContentは既存フォーマット互換
+   - リップル用pointerdownハンドラ(`--rx`/`--ry`+`.pressed`)
+2. `packages/peitho-present/src/timeTracker.ts`
+   - `variant: "presenter"`のときのみ legend(Slide progress/Time)+`.tracker`ラッパ+`.fill`(時間進捗幅)+scale(計画時間5分点)を生成
+   - presentバリアントのDOMは不変。マーカー移動ロジック(left%+translateX clamp)は共通のまま
+3. `crates/peitho-core/src/render.rs` `render_presenter_index()`
+   - CSS全面差し替え+Google Fontsリンク。Agenda関連は含めない
+   - `.clock`はflex column+`.controls { margin-top: auto }`(グリッドstretchによるボタン肥大の再発防止)
+4. テスト更新
+   - `packages/peitho-present/test/presenter.test.ts`: playpause統合ボタンの状態遷移、state pill、新フック
+   - `packages/peitho-present/test/timeTracker.test.ts`: presenterバリアントのfill/scale追加分(既存presentテストは不変)
+   - `crates/peitho-core/src/render.rs`のpresenterテスト2件を新CSSアサーションへ
+5. `packages/peitho-present/dist/shell.js` 再ビルド+コミット
+
+## ゲート
+
+CLAUDE.md記載の全ゲート(cargo test×3 / clippy / fmt / bindings drift / npm build+test+typecheck / shell.js drift)+実ブラウザE2E(examplesをbuild→present→スクリーンショット)。

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -573,6 +573,18 @@ var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
 function isOverrun(elapsedMs, plannedDurationMs) {
   return elapsedMs > plannedDurationMs;
 }
+function formatScaleTime(ms) {
+  const totalSeconds = Math.round(ms / 1e3);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+function timeScaleLabels(plannedDurationMs) {
+  return Array.from(
+    { length: 5 },
+    (_, index) => formatScaleTime(plannedDurationMs * index / 4)
+  );
+}
 function isValidSlideChangeDetail(detail) {
   if (typeof detail !== "object" || detail === null) return false;
   const candidate = detail;
@@ -587,16 +599,30 @@ function installTimeTracker(options) {
   const doc = options.document ?? document;
   const log = options.console ?? console;
   const bus = options.bus ?? win;
+  const variant = options.variant ?? "present";
   const track = doc.createElement("div");
   track.className = "peitho-time-tracker";
-  track.dataset.peithoTimeTracker = options.variant ?? "present";
-  track.innerHTML = [
-    '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
-    '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>'
-  ].join("");
+  track.dataset.peithoTimeTracker = variant;
+  if (variant === "presenter") {
+    track.innerHTML = [
+      '<div class="tracker-legend"><span>Slide progress</span><span>Time</span></div>',
+      '<div class="tracker">',
+      '<div class="tracker-fill"></div>',
+      '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
+      '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>',
+      "</div>",
+      `<div class="tracker-scale mono">${timeScaleLabels(options.plannedDurationMs).map((label) => `<span>${label}</span>`).join("")}</div>`
+    ].join("");
+  } else {
+    track.innerHTML = [
+      '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
+      '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>'
+    ].join("");
+  }
   options.root.appendChild(track);
   const rabbit = track.querySelector('[data-peitho-marker="rabbit"]');
   const turtle = track.querySelector('[data-peitho-marker="turtle"]');
+  const fill = track.querySelector(".tracker-fill");
   let autoStarted = false;
   const setMarker = (element, ratio) => {
     element.style.left = `${Math.round(ratio * 1e4) / 100}%`;
@@ -609,7 +635,9 @@ function installTimeTracker(options) {
   const tick = () => {
     const elapsedMs = options.shell.elapsedMs();
     const ratio = elapsedMs / options.plannedDurationMs;
-    setMarker(turtle, clamp01(ratio));
+    const clampedRatio = clamp01(ratio);
+    setMarker(turtle, clampedRatio);
+    if (fill) fill.style.width = `${Math.round(clampedRatio * 1e4) / 100}%`;
     track.toggleAttribute(
       "data-peitho-overrun",
       isOverrun(elapsedMs, options.plannedDurationMs)
@@ -654,11 +682,43 @@ function formatElapsed(ms) {
 function formatOverrun(ms) {
   return formatSeconds(Math.ceil(ms / 1e3));
 }
-function formatPresenterTimer(elapsedMs, plannedDurationMs) {
-  if (plannedDurationMs == null) return formatElapsed(elapsedMs);
-  const base = `${formatElapsed(elapsedMs)} / ${formatElapsed(plannedDurationMs)}`;
-  if (!isOverrun(elapsedMs, plannedDurationMs)) return base;
-  return `${base} +${formatOverrun(elapsedMs - plannedDurationMs)}`;
+var STATE_LABELS = {
+  stopped: "Stopped",
+  running: "Running",
+  paused: "Paused"
+};
+var PLAY_LABELS = {
+  stopped: "Start",
+  running: "Pause",
+  paused: "Resume"
+};
+function deriveTimerState(shell) {
+  if (shell.startedAt() === null) return "stopped";
+  return shell.isPaused() ? "paused" : "running";
+}
+function playpauseActionFor(state) {
+  if (state === "stopped") return "start";
+  if (state === "paused") return "resume";
+  return "pause";
+}
+function formatSlideNumber(value) {
+  return value.toString().padStart(2, "0");
+}
+function renderPresenterTimer(doc, root, elapsedMs, plannedDurationMs) {
+  if (plannedDurationMs == null) {
+    root.textContent = formatElapsed(elapsedMs);
+    return;
+  }
+  root.replaceChildren(doc.createTextNode(formatElapsed(elapsedMs)));
+  const planned = doc.createElement("span");
+  planned.className = "planned";
+  planned.textContent = ` / ${formatElapsed(plannedDurationMs)}`;
+  root.appendChild(planned);
+  if (!isOverrun(elapsedMs, plannedDurationMs)) return;
+  const overrun = doc.createElement("span");
+  overrun.className = "overrun";
+  overrun.textContent = ` +${formatOverrun(elapsedMs - plannedDurationMs)}`;
+  root.appendChild(overrun);
 }
 function paneViewport(pane) {
   return () => ({
@@ -675,24 +735,77 @@ async function mountPresenterView(options) {
   const bus = win;
   const previewBus = new EventTarget();
   options.root.innerHTML = `
-    <section class="peitho-presenter">
-      <div class="peitho-presenter-pane" data-peitho-presenter="current"></div>
-      <aside>
-        <div class="peitho-presenter-preview-slot">
-          <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
-          <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+    <section class="peitho-presenter app" data-screen-label="Presenter view">
+      <section class="left" aria-label="Current slide and notes">
+        <header class="colhead">
+          <div class="status-line">
+            <span class="now">Now</span>
+            <span class="sep"></span>
+            <span data-peitho-presenter="position">Slide 00 of 00</span>
+          </div>
+          <div class="deck-title" data-peitho-presenter="title">Peitho Deck</div>
+        </header>
+
+        <div class="slide-frame">
+          <div
+            class="peitho-presenter-pane slide-pane"
+            data-peitho-presenter="current"
+            role="img"
+            aria-label="Current slide preview"
+          ></div>
         </div>
-        <section data-peitho-presenter="notes"></section>
-        <output data-peitho-presenter="timer">00:00</output>
-        <div class="peitho-presenter-controls">
-          <button type="button" data-peitho-action="prev">Prev</button>
-          <button type="button" data-peitho-action="next">Next</button>
-          <button type="button" data-peitho-action="start">Start</button>
-          <button type="button" data-peitho-action="pause">Pause</button>
-          <button type="button" data-peitho-action="resume">Resume</button>
-          <button type="button" data-peitho-action="reset">Reset</button>
-          <button type="button" data-peitho-action="close">Close</button>
+
+        <div class="kbdbar">
+          <div class="pos" data-peitho-presenter="position-short">00 / 00</div>
+          <div>
+            <span class="grp"><span class="kbd">\u2190</span><span class="kbd">\u2192</span> navigate</span>
+            <span class="grp"><span class="kbd">Space</span> next</span>
+            <span class="grp"><span class="kbd">Esc</span> close</span>
+          </div>
         </div>
+
+        <section class="notes" aria-label="Speaker notes">
+          <div class="notes-head">
+            <span>Notes</span>
+            <span class="badge" data-peitho-presenter="notes-slide">Slide 00</span>
+          </div>
+          <div class="notes-body" data-peitho-presenter="notes"></div>
+        </section>
+      </section>
+
+      <aside class="right">
+        <section class="card" aria-label="Next slide">
+          <div class="card-head">
+            <span>Next</span>
+            <span class="badge mono" data-peitho-presenter="next-position">00 / 00</span>
+          </div>
+          <div class="next-wrap">
+            <div class="next-preview">
+              <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
+              <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="card clock" data-peitho-presenter="clock" data-peitho-state="stopped" aria-label="Timer">
+          <div class="clock-row">
+            <output class="timer mono" data-peitho-presenter="timer">00:00</output>
+            <span class="state-pill" data-peitho-presenter="state-pill" data-peitho-state="stopped">
+              <span class="state-dot"></span>
+              <span data-peitho-presenter="state-label">Stopped</span>
+            </span>
+          </div>
+
+          <div class="tracker-wrap" data-peitho-presenter="tracker-slot"></div>
+
+          <div class="controls">
+            <button class="btn play primary" type="button" data-peitho-action="playpause"><span data-peitho-presenter="play-label">Start</span></button>
+            <button class="btn" type="button" data-peitho-action="prev">Prev <span class="k">\u2190</span></button>
+            <button class="btn" type="button" data-peitho-action="next">Next <span class="k">\u2192</span></button>
+            <button class="btn" type="button" data-peitho-action="reset">Reset</button>
+            <button class="btn danger" type="button" data-peitho-action="close">Close <span class="k">Esc</span></button>
+          </div>
+        </section>
       </aside>
     </section>`;
   const currentRoot = options.root.querySelector('[data-peitho-presenter="current"]');
@@ -702,7 +815,35 @@ async function mountPresenterView(options) {
   );
   const notesRoot = options.root.querySelector('[data-peitho-presenter="notes"]');
   const timerRoot = options.root.querySelector('[data-peitho-presenter="timer"]');
-  const asideRoot = options.root.querySelector("aside");
+  const clockRoot = options.root.querySelector('[data-peitho-presenter="clock"]');
+  const statePill = options.root.querySelector(
+    '[data-peitho-presenter="state-pill"]'
+  );
+  const stateLabel = options.root.querySelector(
+    '[data-peitho-presenter="state-label"]'
+  );
+  const playLabel = options.root.querySelector(
+    '[data-peitho-presenter="play-label"]'
+  );
+  const playButton = options.root.querySelector(
+    '[data-peitho-action="playpause"]'
+  );
+  const trackerSlot = options.root.querySelector(
+    '[data-peitho-presenter="tracker-slot"]'
+  );
+  const deckTitle = options.root.querySelector('[data-peitho-presenter="title"]');
+  const positionLong = options.root.querySelector(
+    '[data-peitho-presenter="position"]'
+  );
+  const positionShort = options.root.querySelector(
+    '[data-peitho-presenter="position-short"]'
+  );
+  const notesSlide = options.root.querySelector(
+    '[data-peitho-presenter="notes-slide"]'
+  );
+  const nextPosition = options.root.querySelector(
+    '[data-peitho-presenter="next-position"]'
+  );
   const mainShell = await mountPresentShell({
     root: currentRoot,
     fetcher,
@@ -729,7 +870,7 @@ async function mountPresenterView(options) {
     log.error("Invalid plannedDurationMs in manifest.json");
   }
   const trackerCleanup = plannedDurationMs == null ? () => void 0 : installTimeTracker({
-    root: asideRoot,
+    root: trackerSlot,
     shell: mainShell,
     plannedDurationMs,
     bus,
@@ -737,26 +878,44 @@ async function mountPresenterView(options) {
     document: doc,
     variant: "presenter"
   });
+  const rippleTimeouts = /* @__PURE__ */ new Set();
+  function setTimerStateChrome(state) {
+    clockRoot.dataset.peithoState = state;
+    statePill.dataset.peithoState = state;
+    stateLabel.textContent = STATE_LABELS[state];
+    playLabel.textContent = PLAY_LABELS[state];
+    playButton.setAttribute("aria-label", PLAY_LABELS[state]);
+  }
   function tick() {
     const elapsedMs = mainShell.elapsedMs();
-    timerRoot.textContent = formatPresenterTimer(elapsedMs, plannedDurationMs);
+    renderPresenterTimer(doc, timerRoot, elapsedMs, plannedDurationMs);
     timerRoot.toggleAttribute(
       "data-peitho-overrun",
       plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)
     );
+    setTimerStateChrome(deriveTimerState(mainShell));
   }
   function updateFromSlide(detail) {
     notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide.";
+    const slideNumber = detail.index + 1;
+    const slide = formatSlideNumber(slideNumber);
+    const total = formatSlideNumber(detail.total);
+    deckTitle.textContent = mainShell.manifest?.title ?? "Peitho Deck";
+    positionLong.textContent = `Slide ${slide} of ${total}`;
+    positionShort.textContent = `${slide} / ${total}`;
+    notesSlide.textContent = `Slide ${slide}`;
     const nextIndex = detail.index + 1;
     if (nextIndex < detail.total) {
       previewRoot.hidden = false;
       previewEnd.hidden = true;
+      nextPosition.textContent = `${formatSlideNumber(nextIndex + 1)} / ${total}`;
       previewBus.dispatchEvent(
         new CustomEvent("peitho:navigate", { detail: { to: { index: nextIndex } } })
       );
     } else {
       previewRoot.hidden = true;
       previewEnd.hidden = false;
+      nextPosition.textContent = "End";
     }
     tick();
   }
@@ -773,28 +932,69 @@ async function mountPresenterView(options) {
       previousIndex: null
     });
   }
-  options.root.querySelector('[data-peitho-action="prev"]')?.addEventListener("click", () => {
+  const buttonCleanups = [];
+  const addButtonListener = (action, listener) => {
+    const button = options.root.querySelector(`[data-peitho-action="${action}"]`);
+    if (!button) return;
+    button.addEventListener("click", listener);
+    buttonCleanups.push(() => button.removeEventListener("click", listener));
+  };
+  const dispatchTimerControl = (action) => {
+    bus.dispatchEvent(
+      new CustomEvent("peitho:timercontrol", { detail: { action } })
+    );
+    tick();
+  };
+  addButtonListener("prev", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
   });
-  options.root.querySelector('[data-peitho-action="next"]')?.addEventListener("click", () => {
+  addButtonListener("next", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
   });
-  for (const action of ["start", "pause", "resume", "reset"]) {
-    options.root.querySelector(`[data-peitho-action="${action}"]`)?.addEventListener("click", () => {
-      bus.dispatchEvent(new CustomEvent("peitho:timercontrol", { detail: { action } }));
-      tick();
-    });
-  }
-  options.root.querySelector('[data-peitho-action="close"]')?.addEventListener("click", () => {
+  addButtonListener("playpause", () => {
+    dispatchTimerControl(playpauseActionFor(deriveTimerState(mainShell)));
+  });
+  addButtonListener("reset", () => {
+    dispatchTimerControl("reset");
+  });
+  addButtonListener("close", () => {
     bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
   });
+  const onPointerDown = (event) => {
+    const pointer = event;
+    const target = pointer.target;
+    if (!target || !("closest" in target)) return;
+    const button = target.closest(".btn");
+    if (!button || !options.root.contains(button)) return;
+    const rect = button.getBoundingClientRect();
+    const width = rect.width || 1;
+    const height = rect.height || 1;
+    const x = (pointer.clientX - rect.left) / width * 100;
+    const y = (pointer.clientY - rect.top) / height * 100;
+    button.style.setProperty("--rx", `${x}%`);
+    button.style.setProperty("--ry", `${y}%`);
+    button.classList.remove("pressed");
+    void button.offsetWidth;
+    button.classList.add("pressed");
+    const timeout = win.setTimeout(() => {
+      button.classList.remove("pressed");
+      rippleTimeouts.delete(timeout);
+    }, 550);
+    rippleTimeouts.add(timeout);
+  };
+  options.root.addEventListener("pointerdown", onPointerDown);
   const interval = win.setInterval(tick, 250);
+  tick();
   return {
     mainShell,
     previewShell,
     tick,
     destroy() {
       win.clearInterval(interval);
+      for (const timeout of rippleTimeouts) win.clearTimeout(timeout);
+      rippleTimeouts.clear();
+      options.root.removeEventListener("pointerdown", onPointerDown);
+      while (buttonCleanups.length > 0) buttonCleanups.pop()?.();
       trackerCleanup();
       bus.removeEventListener("peitho:slidechange", onSlideChange);
       keyboardCleanup();

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -1,6 +1,11 @@
 import type { Notes } from "../../../bindings/Notes";
 import { installKeyboardNavigation } from "./keyboard";
-import { mountPresentShell, type PresentShell, type SlideChangeDetail } from "./shell";
+import {
+  mountPresentShell,
+  type PresentShell,
+  type SlideChangeDetail,
+  type TimerControlDetail
+} from "./shell";
 import { installSyncBridge, type SyncChannelFactory } from "./sync";
 import { installTimeTracker, isOverrun } from "./timeTracker";
 
@@ -38,14 +43,57 @@ function formatOverrun(ms: number): string {
   return formatSeconds(Math.ceil(ms / 1000));
 }
 
-function formatPresenterTimer(
+type TimerState = "stopped" | "running" | "paused";
+
+const STATE_LABELS: Record<TimerState, string> = {
+  stopped: "Stopped",
+  running: "Running",
+  paused: "Paused"
+};
+
+const PLAY_LABELS: Record<TimerState, string> = {
+  stopped: "Start",
+  running: "Pause",
+  paused: "Resume"
+};
+
+function deriveTimerState(shell: PresentShell): TimerState {
+  if (shell.startedAt() === null) return "stopped";
+  return shell.isPaused() ? "paused" : "running";
+}
+
+function playpauseActionFor(state: TimerState): TimerControlDetail["action"] {
+  if (state === "stopped") return "start";
+  if (state === "paused") return "resume";
+  return "pause";
+}
+
+function formatSlideNumber(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+function renderPresenterTimer(
+  doc: Document,
+  root: HTMLElement,
   elapsedMs: number,
-  plannedDurationMs: number | null | undefined
-): string {
-  if (plannedDurationMs == null) return formatElapsed(elapsedMs);
-  const base = `${formatElapsed(elapsedMs)} / ${formatElapsed(plannedDurationMs)}`;
-  if (!isOverrun(elapsedMs, plannedDurationMs)) return base;
-  return `${base} +${formatOverrun(elapsedMs - plannedDurationMs)}`;
+  plannedDurationMs: number | null
+): void {
+  if (plannedDurationMs == null) {
+    root.textContent = formatElapsed(elapsedMs);
+    return;
+  }
+
+  root.replaceChildren(doc.createTextNode(formatElapsed(elapsedMs)));
+  const planned = doc.createElement("span");
+  planned.className = "planned";
+  planned.textContent = ` / ${formatElapsed(plannedDurationMs)}`;
+  root.appendChild(planned);
+
+  if (!isOverrun(elapsedMs, plannedDurationMs)) return;
+  const overrun = doc.createElement("span");
+  overrun.className = "overrun";
+  overrun.textContent = ` +${formatOverrun(elapsedMs - plannedDurationMs)}`;
+  root.appendChild(overrun);
 }
 
 function paneViewport(pane: HTMLElement): () => { width: number; height: number } {
@@ -64,24 +112,77 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   const bus = win;
   const previewBus = new EventTarget();
   options.root.innerHTML = `
-    <section class="peitho-presenter">
-      <div class="peitho-presenter-pane" data-peitho-presenter="current"></div>
-      <aside>
-        <div class="peitho-presenter-preview-slot">
-          <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
-          <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+    <section class="peitho-presenter app" data-screen-label="Presenter view">
+      <section class="left" aria-label="Current slide and notes">
+        <header class="colhead">
+          <div class="status-line">
+            <span class="now">Now</span>
+            <span class="sep"></span>
+            <span data-peitho-presenter="position">Slide 00 of 00</span>
+          </div>
+          <div class="deck-title" data-peitho-presenter="title">Peitho Deck</div>
+        </header>
+
+        <div class="slide-frame">
+          <div
+            class="peitho-presenter-pane slide-pane"
+            data-peitho-presenter="current"
+            role="img"
+            aria-label="Current slide preview"
+          ></div>
         </div>
-        <section data-peitho-presenter="notes"></section>
-        <output data-peitho-presenter="timer">00:00</output>
-        <div class="peitho-presenter-controls">
-          <button type="button" data-peitho-action="prev">Prev</button>
-          <button type="button" data-peitho-action="next">Next</button>
-          <button type="button" data-peitho-action="start">Start</button>
-          <button type="button" data-peitho-action="pause">Pause</button>
-          <button type="button" data-peitho-action="resume">Resume</button>
-          <button type="button" data-peitho-action="reset">Reset</button>
-          <button type="button" data-peitho-action="close">Close</button>
+
+        <div class="kbdbar">
+          <div class="pos" data-peitho-presenter="position-short">00 / 00</div>
+          <div>
+            <span class="grp"><span class="kbd">←</span><span class="kbd">→</span> navigate</span>
+            <span class="grp"><span class="kbd">Space</span> next</span>
+            <span class="grp"><span class="kbd">Esc</span> close</span>
+          </div>
         </div>
+
+        <section class="notes" aria-label="Speaker notes">
+          <div class="notes-head">
+            <span>Notes</span>
+            <span class="badge" data-peitho-presenter="notes-slide">Slide 00</span>
+          </div>
+          <div class="notes-body" data-peitho-presenter="notes"></div>
+        </section>
+      </section>
+
+      <aside class="right">
+        <section class="card" aria-label="Next slide">
+          <div class="card-head">
+            <span>Next</span>
+            <span class="badge mono" data-peitho-presenter="next-position">00 / 00</span>
+          </div>
+          <div class="next-wrap">
+            <div class="next-preview">
+              <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
+              <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="card clock" data-peitho-presenter="clock" data-peitho-state="stopped" aria-label="Timer">
+          <div class="clock-row">
+            <output class="timer mono" data-peitho-presenter="timer">00:00</output>
+            <span class="state-pill" data-peitho-presenter="state-pill" data-peitho-state="stopped">
+              <span class="state-dot"></span>
+              <span data-peitho-presenter="state-label">Stopped</span>
+            </span>
+          </div>
+
+          <div class="tracker-wrap" data-peitho-presenter="tracker-slot"></div>
+
+          <div class="controls">
+            <button class="btn play primary" type="button" data-peitho-action="playpause"><span data-peitho-presenter="play-label">Start</span></button>
+            <button class="btn" type="button" data-peitho-action="prev">Prev <span class="k">←</span></button>
+            <button class="btn" type="button" data-peitho-action="next">Next <span class="k">→</span></button>
+            <button class="btn" type="button" data-peitho-action="reset">Reset</button>
+            <button class="btn danger" type="button" data-peitho-action="close">Close <span class="k">Esc</span></button>
+          </div>
+        </section>
       </aside>
     </section>`;
 
@@ -92,7 +193,35 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   )!;
   const notesRoot = options.root.querySelector<HTMLElement>('[data-peitho-presenter="notes"]')!;
   const timerRoot = options.root.querySelector<HTMLElement>('[data-peitho-presenter="timer"]')!;
-  const asideRoot = options.root.querySelector<HTMLElement>("aside")!;
+  const clockRoot = options.root.querySelector<HTMLElement>('[data-peitho-presenter="clock"]')!;
+  const statePill = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="state-pill"]'
+  )!;
+  const stateLabel = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="state-label"]'
+  )!;
+  const playLabel = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="play-label"]'
+  )!;
+  const playButton = options.root.querySelector<HTMLButtonElement>(
+    '[data-peitho-action="playpause"]'
+  )!;
+  const trackerSlot = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="tracker-slot"]'
+  )!;
+  const deckTitle = options.root.querySelector<HTMLElement>('[data-peitho-presenter="title"]')!;
+  const positionLong = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="position"]'
+  )!;
+  const positionShort = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="position-short"]'
+  )!;
+  const notesSlide = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="notes-slide"]'
+  )!;
+  const nextPosition = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="next-position"]'
+  )!;
 
   const mainShell = await mountPresentShell({
     root: currentRoot,
@@ -128,7 +257,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     plannedDurationMs == null
       ? () => undefined
       : installTimeTracker({
-          root: asideRoot,
+          root: trackerSlot,
           shell: mainShell,
           plannedDurationMs,
           bus,
@@ -136,28 +265,47 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
           document: doc,
           variant: "presenter"
         });
+  const rippleTimeouts = new Set<number>();
+
+  function setTimerStateChrome(state: TimerState): void {
+    clockRoot.dataset.peithoState = state;
+    statePill.dataset.peithoState = state;
+    stateLabel.textContent = STATE_LABELS[state];
+    playLabel.textContent = PLAY_LABELS[state];
+    playButton.setAttribute("aria-label", PLAY_LABELS[state]);
+  }
 
   function tick(): void {
     const elapsedMs = mainShell.elapsedMs();
-    timerRoot.textContent = formatPresenterTimer(elapsedMs, plannedDurationMs);
+    renderPresenterTimer(doc, timerRoot, elapsedMs, plannedDurationMs);
     timerRoot.toggleAttribute(
       "data-peitho-overrun",
       plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)
     );
+    setTimerStateChrome(deriveTimerState(mainShell));
   }
 
   function updateFromSlide(detail: SlideChangeDetail): void {
     notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide.";
+    const slideNumber = detail.index + 1;
+    const slide = formatSlideNumber(slideNumber);
+    const total = formatSlideNumber(detail.total);
+    deckTitle.textContent = mainShell.manifest?.title ?? "Peitho Deck";
+    positionLong.textContent = `Slide ${slide} of ${total}`;
+    positionShort.textContent = `${slide} / ${total}`;
+    notesSlide.textContent = `Slide ${slide}`;
     const nextIndex = detail.index + 1;
     if (nextIndex < detail.total) {
       previewRoot.hidden = false;
       previewEnd.hidden = true;
+      nextPosition.textContent = `${formatSlideNumber(nextIndex + 1)} / ${total}`;
       previewBus.dispatchEvent(
         new CustomEvent("peitho:navigate", { detail: { to: { index: nextIndex } } })
       );
     } else {
       previewRoot.hidden = true;
       previewEnd.hidden = false;
+      nextPosition.textContent = "End";
     }
     tick();
   }
@@ -177,23 +325,65 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     });
   }
 
-  options.root.querySelector('[data-peitho-action="prev"]')?.addEventListener("click", () => {
+  const buttonCleanups: Array<() => void> = [];
+  const addButtonListener = (
+    action: string,
+    listener: (event: MouseEvent) => void
+  ): void => {
+    const button = options.root.querySelector<HTMLButtonElement>(`[data-peitho-action="${action}"]`);
+    if (!button) return;
+    button.addEventListener("click", listener);
+    buttonCleanups.push(() => button.removeEventListener("click", listener));
+  };
+  const dispatchTimerControl = (action: TimerControlDetail["action"]): void => {
+    bus.dispatchEvent(
+      new CustomEvent<TimerControlDetail>("peitho:timercontrol", { detail: { action } })
+    );
+    tick();
+  };
+
+  addButtonListener("prev", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
   });
-  options.root.querySelector('[data-peitho-action="next"]')?.addEventListener("click", () => {
+  addButtonListener("next", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
   });
-  for (const action of ["start", "pause", "resume", "reset"] as const) {
-    options.root.querySelector(`[data-peitho-action="${action}"]`)?.addEventListener("click", () => {
-      bus.dispatchEvent(new CustomEvent("peitho:timercontrol", { detail: { action } }));
-      tick();
-    });
-  }
-  options.root.querySelector('[data-peitho-action="close"]')?.addEventListener("click", () => {
+  addButtonListener("playpause", () => {
+    dispatchTimerControl(playpauseActionFor(deriveTimerState(mainShell)));
+  });
+  addButtonListener("reset", () => {
+    dispatchTimerControl("reset");
+  });
+  addButtonListener("close", () => {
     bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
   });
 
+  const onPointerDown = (event: Event): void => {
+    const pointer = event as MouseEvent;
+    const target = pointer.target;
+    if (!target || !("closest" in target)) return;
+    const button = (target as Element).closest<HTMLButtonElement>(".btn");
+    if (!button || !options.root.contains(button)) return;
+    const rect = button.getBoundingClientRect();
+    const width = rect.width || 1;
+    const height = rect.height || 1;
+    const x = ((pointer.clientX - rect.left) / width) * 100;
+    const y = ((pointer.clientY - rect.top) / height) * 100;
+    button.style.setProperty("--rx", `${x}%`);
+    button.style.setProperty("--ry", `${y}%`);
+    button.classList.remove("pressed");
+    void button.offsetWidth;
+    button.classList.add("pressed");
+    const timeout = win.setTimeout(() => {
+      button.classList.remove("pressed");
+      rippleTimeouts.delete(timeout);
+    }, 550);
+    rippleTimeouts.add(timeout);
+  };
+  options.root.addEventListener("pointerdown", onPointerDown);
+
   const interval = win.setInterval(tick, 250);
+  tick();
 
   return {
     mainShell,
@@ -201,6 +391,10 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     tick,
     destroy(): void {
       win.clearInterval(interval);
+      for (const timeout of rippleTimeouts) win.clearTimeout(timeout);
+      rippleTimeouts.clear();
+      options.root.removeEventListener("pointerdown", onPointerDown);
+      while (buttonCleanups.length > 0) buttonCleanups.pop()?.();
       trackerCleanup();
       bus.removeEventListener("peitho:slidechange", onSlideChange);
       keyboardCleanup();

--- a/packages/peitho-present/src/timeTracker.ts
+++ b/packages/peitho-present/src/timeTracker.ts
@@ -23,6 +23,19 @@ export function isOverrun(elapsedMs: number, plannedDurationMs: number): boolean
   return elapsedMs > plannedDurationMs;
 }
 
+function formatScaleTime(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}
+
+function timeScaleLabels(plannedDurationMs: number): string[] {
+  return Array.from({ length: 5 }, (_, index) =>
+    formatScaleTime((plannedDurationMs * index) / 4)
+  );
+}
+
 function isValidSlideChangeDetail(detail: unknown): detail is SlideChangeDetail {
   if (typeof detail !== "object" || detail === null) return false;
   const candidate = detail as Partial<SlideChangeDetail>;
@@ -47,17 +60,33 @@ export function installTimeTracker(options: TimeTrackerOptions): () => void {
   const doc = options.document ?? document;
   const log = options.console ?? console;
   const bus = options.bus ?? win;
+  const variant = options.variant ?? "present";
   const track = doc.createElement("div");
   track.className = "peitho-time-tracker";
-  track.dataset.peithoTimeTracker = options.variant ?? "present";
-  track.innerHTML = [
-    '<span data-peitho-marker="rabbit" aria-label="slide progress">🐰</span>',
-    '<span data-peitho-marker="turtle" aria-label="time progress">🐢</span>'
-  ].join("");
+  track.dataset.peithoTimeTracker = variant;
+  if (variant === "presenter") {
+    track.innerHTML = [
+      '<div class="tracker-legend"><span>Slide progress</span><span>Time</span></div>',
+      '<div class="tracker">',
+      '<div class="tracker-fill"></div>',
+      '<span data-peitho-marker="rabbit" aria-label="slide progress">🐰</span>',
+      '<span data-peitho-marker="turtle" aria-label="time progress">🐢</span>',
+      "</div>",
+      `<div class="tracker-scale mono">${timeScaleLabels(options.plannedDurationMs)
+        .map((label) => `<span>${label}</span>`)
+        .join("")}</div>`
+    ].join("");
+  } else {
+    track.innerHTML = [
+      '<span data-peitho-marker="rabbit" aria-label="slide progress">🐰</span>',
+      '<span data-peitho-marker="turtle" aria-label="time progress">🐢</span>'
+    ].join("");
+  }
   options.root.appendChild(track);
 
   const rabbit = track.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')!;
   const turtle = track.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')!;
+  const fill = track.querySelector<HTMLElement>(".tracker-fill");
   let autoStarted = false;
 
   const setMarker = (element: HTMLElement, ratio: number): void => {
@@ -71,7 +100,9 @@ export function installTimeTracker(options: TimeTrackerOptions): () => void {
   const tick = (): void => {
     const elapsedMs = options.shell.elapsedMs();
     const ratio = elapsedMs / options.plannedDurationMs;
-    setMarker(turtle, clamp01(ratio));
+    const clampedRatio = clamp01(ratio);
+    setMarker(turtle, clampedRatio);
+    if (fill) fill.style.width = `${Math.round(clampedRatio * 10_000) / 100}%`;
     track.toggleAttribute(
       "data-peitho-overrun",
       isOverrun(elapsedMs, options.plannedDurationMs)

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -64,9 +64,11 @@ const cleanups: Array<() => void> = [];
 afterEach(() => {
   while (cleanups.length > 0) cleanups.pop()?.();
   while (views.length > 0) views.pop()?.destroy();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
-it("renders current slide preview next slide note and starts timer from Start button", async () => {
+it("renders the redesigned presenter shell and starts timer from the playpause button", async () => {
   let now = 1000;
   const root = document.createElement("main");
   const { factory } = mockSyncChannelFactory();
@@ -89,11 +91,33 @@ it("renders current slide preview next slide note and starts timer from Start bu
   expect(root.querySelector('[data-peitho-presenter="notes"]')?.textContent).toContain(
     "Opening note"
   );
+  expect(root.querySelector(".left")).not.toBeNull();
+  expect(root.querySelector(".right")).not.toBeNull();
+  expect(root.querySelector(".agenda")).toBeNull();
+  expect(root.querySelector(".status-line")?.textContent).not.toContain("Section");
+  expect(root.querySelector(".kbdbar")?.textContent).toContain("Space");
+
+  const clock = root.querySelector<HTMLElement>('[data-peitho-presenter="clock"]')!;
+  const pill = root.querySelector<HTMLElement>('[data-peitho-presenter="state-pill"]')!;
+  const play = root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')!;
+  expect(root.querySelector('[data-peitho-action="start"]')).toBeNull();
+  expect(root.querySelector('[data-peitho-action="pause"]')).toBeNull();
+  expect(root.querySelector('[data-peitho-action="resume"]')).toBeNull();
   expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("00:00");
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  expect(clock.dataset.peithoState).toBe("stopped");
+  expect(pill.dataset.peithoState).toBe("stopped");
+  expect(pill.textContent).toContain("Stopped");
+  expect(play.textContent).toBe("Start");
+  expect(play.textContent).not.toContain("Space");
+
+  play.click();
   now = 65000;
   view.tick();
   expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("01:04");
+  expect(clock.dataset.peithoState).toBe("running");
+  expect(pill.dataset.peithoState).toBe("running");
+  expect(pill.textContent).toContain("Running");
+  expect(play.textContent).toBe("Pause");
 });
 
 it("shows planned duration in presenter timer when manifest has time", async () => {
@@ -110,12 +134,16 @@ it("shows planned duration in presenter timer when manifest has time", async () 
   });
   views.push(view);
 
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
   now = 31_000;
   view.tick();
 
   expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("00:30 / 01:00");
-  expect(root.querySelector('[data-peitho-time-tracker="presenter"]')).not.toBeNull();
+  expect(
+    root.querySelector(
+      '[data-peitho-presenter="clock"] [data-peitho-presenter="tracker-slot"] > [data-peitho-time-tracker="presenter"]'
+    )
+  ).not.toBeNull();
 
   view.destroy();
   views.pop();
@@ -136,7 +164,7 @@ it("keeps legacy presenter timer text when manifest has no time", async () => {
   });
   views.push(view);
 
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
   now = 65_000;
   view.tick();
 
@@ -160,7 +188,7 @@ it("logs invalid planned duration and keeps presenter mounted without a tracker"
   });
   views.push(view);
 
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
   now = 65_000;
   view.tick();
 
@@ -183,12 +211,14 @@ it("marks presenter timer as overrun after the planned duration", async () => {
   });
   views.push(view);
 
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
   now = 61_500;
   view.tick();
 
   const timer = root.querySelector<HTMLElement>('[data-peitho-presenter="timer"]')!;
   expect(timer.textContent).toBe("01:00 / 01:00 +00:01");
+  expect(timer.querySelector(".planned")?.textContent).toBe(" / 01:00");
+  expect(timer.querySelector(".overrun")?.textContent).toBe(" +00:01");
   expect(timer.hasAttribute("data-peitho-overrun")).toBe(true);
 });
 
@@ -273,8 +303,9 @@ it("buttons emit navigate timercontrol and close requests", async () => {
   cleanups.push(() => window.removeEventListener("peitho:closerequest", onCloseRequest));
 
   root.querySelector<HTMLButtonElement>('[data-peitho-action="next"]')?.click();
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="start"]')?.click();
-  root.querySelector<HTMLButtonElement>('[data-peitho-action="pause"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
   root.querySelector<HTMLButtonElement>('[data-peitho-action="reset"]')?.click();
   root.querySelector<HTMLButtonElement>('[data-peitho-action="close"]')?.click();
 
@@ -282,8 +313,93 @@ it("buttons emit navigate timercontrol and close requests", async () => {
     { to: "next" },
     { action: "start" },
     { action: "pause" },
+    { action: "resume" },
     { action: "reset" }
   ]);
   expect(closeRequests).toEqual([null]);
   expect(channel.sent).toEqual([{ index: 1 }, { close: true }]);
+});
+
+it("derives playpause action labels and chrome from shell timer state", async () => {
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch(),
+    window,
+    now: () => 1000,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+  const play = root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')!;
+  const reset = root.querySelector<HTMLButtonElement>('[data-peitho-action="reset"]')!;
+  const clock = root.querySelector<HTMLElement>('[data-peitho-presenter="clock"]')!;
+  const pill = root.querySelector<HTMLElement>('[data-peitho-presenter="state-pill"]')!;
+
+  expect(clock.dataset.peithoState).toBe("stopped");
+  expect(pill.textContent).toContain("Stopped");
+  expect(play.textContent).toBe("Start");
+
+  play.click();
+  expect(clock.dataset.peithoState).toBe("running");
+  expect(pill.textContent).toContain("Running");
+  expect(play.textContent).toBe("Pause");
+
+  play.click();
+  expect(clock.dataset.peithoState).toBe("paused");
+  expect(pill.textContent).toContain("Paused");
+  expect(play.textContent).toBe("Resume");
+
+  play.click();
+  expect(clock.dataset.peithoState).toBe("running");
+  expect(play.textContent).toBe("Pause");
+
+  reset.click();
+  expect(clock.dataset.peithoState).toBe("stopped");
+  expect(pill.textContent).toContain("Stopped");
+  expect(play.textContent).toBe("Start");
+});
+
+it("adds button ripple feedback and clears pending ripple timeout on destroy", async () => {
+  vi.useFakeTimers();
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch(),
+    window,
+    now: () => 1000,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+  const play = root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')!;
+  vi.spyOn(play, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: 100,
+    bottom: 50,
+    width: 100,
+    height: 50,
+    toJSON: () => ({})
+  });
+
+  play.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 25, clientY: 10 }));
+
+  expect(play.style.getPropertyValue("--rx")).toBe("25%");
+  expect(play.style.getPropertyValue("--ry")).toBe("20%");
+  expect(play.classList.contains("pressed")).toBe(true);
+
+  vi.advanceTimersByTime(550);
+  expect(play.classList.contains("pressed")).toBe(false);
+
+  play.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, clientX: 75, clientY: 25 }));
+  expect(play.classList.contains("pressed")).toBe(true);
+
+  view.destroy();
+  views.pop();
+  expect(vi.getTimerCount()).toBe(0);
 });

--- a/packages/peitho-present/test/timeTracker.test.ts
+++ b/packages/peitho-present/test/timeTracker.test.ts
@@ -48,6 +48,57 @@ it("moves rabbit by slide progress and turtle by elapsed progress", () => {
   expect(root.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')?.style.left).toBe("50%");
 });
 
+it("keeps the present variant DOM unchanged", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell(),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document,
+      variant: "present"
+    })
+  );
+
+  expect(root.innerHTML).toBe(
+    '<div class="peitho-time-tracker" data-peitho-time-tracker="present"><span data-peitho-marker="rabbit" aria-label="slide progress" style="left: 0%; transform: translateX(0%);">🐰</span><span data-peitho-marker="turtle" aria-label="time progress" style="left: 0%; transform: translateX(0%);">🐢</span></div>'
+  );
+});
+
+it("renders presenter variant with legend fill track and five-point time scale", () => {
+  let elapsed = 30_000;
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  cleanups.push(
+    installTimeTracker({
+      root,
+      shell: shell({ currentIndex: 1, elapsedMs: () => elapsed }),
+      plannedDurationMs: 60_000,
+      bus,
+      window,
+      document,
+      variant: "presenter"
+    })
+  );
+
+  const tracker = root.querySelector<HTMLElement>('[data-peitho-time-tracker="presenter"]')!;
+  expect(tracker.querySelector(".tracker-legend")?.textContent).toBe("Slide progressTime");
+  expect(tracker.querySelector(".tracker")).not.toBeNull();
+  expect(tracker.querySelector<HTMLElement>(".tracker-fill")?.style.width).toBe("50%");
+  expect(tracker.querySelector<HTMLElement>('[data-peitho-marker="rabbit"]')?.className).toBe("");
+  expect(tracker.querySelector<HTMLElement>('[data-peitho-marker="turtle"]')?.className).toBe("");
+  expect(
+    Array.from(tracker.querySelectorAll(".tracker-scale span"), (span) => span.textContent)
+  ).toEqual(["0:00", "0:15", "0:30", "0:45", "1:00"]);
+
+  elapsed = 45_000;
+  vi.advanceTimersByTime(250);
+  expect(tracker.querySelector<HTMLElement>(".tracker-fill")?.style.width).toBe("75%");
+});
+
 it("clamps markers to the track edges so the glyph never overflows", () => {
   let elapsed = 0;
   const root = document.createElement("main");


### PR DESCRIPTION
## Summary

Presenter view redesign that adopts the Claude Design mock. Plan: `docs/plans/2026-07-04-presenter-redesign.md`.

- Dark-based (oklch palette + cyan accent, Geist/Geist Mono with a system-ui fallback) two-column layout. Left: current slide (16:9 fixed via container queries) + keyboard hints + Notes card. Right: next-slide preview + timer card
- Timer state (stopped/running/paused) is derived from the shell's real state (`startedAt()` / `isPaused()`) and drives the state pill, timer color, and Play button (Start/Pause/Resume unified into one button). The `peitho:timercontrol` event contract is unchanged
- Adds a legend, elapsed fill, and a 5-point planned-time scale to the presenter-side time tracker. **The DOM of the present variant is byte-identical** (guarded by a snapshot test)
- Button press feedback: press-in + color inversion + a ripple originating at the click point (disabled under `prefers-reduced-motion`)

## Design decisions (deliberately out of scope)

- The mock's **Agenda section** (per-section actual/planned time) and the "Section — ..." label are not implemented. Peitho has no section / interval-time data model yet (a separate issue if needed)
- **Key bindings are unchanged** (Space = next). Only the UI hint labels were adjusted to match actual behavior

## Test plan

- [x] cargo test --workspace ×3 (all 9 suites green, no race reproduced)
- [x] clippy -D warnings / fmt --check / bindings drift / shell.js drift
- [x] npm build + test (79 cases) + typecheck
- [x] Real-browser E2E: `peitho present examples/lightning-talk/deck.md --port 4173`, open the presenter, and drive Start→Running (pill lit, timer advancing)→Pause→Resume→Next (slide advance, Next 03/05 update) by hand. No console errors

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
