### PR TITLE
fix(presenter): Space controls timer start/pause/resume

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -480,9 +480,12 @@ pub fn render_presenter_index() -> String {
     .btn:active { transform: translateY(2px); background: var(--accent); border-color: var(--accent); color: var(--bg); box-shadow: 0 0 24px var(--accent-soft), inset 0 2px 4px rgba(0, 0, 0, 0.2); }
     .btn:active .k { color: var(--bg); }
     .btn.primary { color: var(--bg); background: var(--accent); border-color: var(--accent); font-weight: 600; min-width: max-content; }
+    .btn.primary .k { color: color-mix(in oklch, var(--bg) 60%, var(--accent)); }
     .btn.primary:hover { background: color-mix(in oklch, var(--accent) 88%, white); }
     .btn.primary:active { background: color-mix(in oklch, var(--accent) 60%, black); border-color: color-mix(in oklch, var(--accent) 60%, black); color: white; box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.4); }
+    .btn.primary:active .k { color: color-mix(in oklch, white 60%, var(--accent)); }
     .clock[data-peitho-state="paused"] .btn.play.primary { background: var(--pause); border-color: var(--pause); color: var(--bg); }
+    .clock[data-peitho-state="paused"] .btn.play.primary .k { color: color-mix(in oklch, var(--bg) 60%, var(--pause)); }
     .btn.danger { color: var(--warn); border-color: color-mix(in oklch, var(--warn) 45%, var(--line)); }
     .btn.danger:hover { background: color-mix(in oklch, var(--warn) 12%, transparent); color: var(--warn); }
     .btn.danger:active { background: var(--warn); color: var(--bg); border-color: var(--warn); box-shadow: 0 0 24px color-mix(in oklch, var(--warn) 30%, transparent); }
@@ -792,6 +795,9 @@ mod tests {
         assert!(html.contains(".clock { display: flex; flex-direction: column;"));
         assert!(html.contains(".controls {"));
         assert!(html.contains("margin-top: auto"));
+        assert!(html.contains(
+            ".btn.primary .k { color: color-mix(in oklch, var(--bg) 60%, var(--accent)); }"
+        ));
         assert!(html.contains(".btn.pressed::before"));
         assert!(html.contains("@media (prefers-reduced-motion: reduce)"));
         assert!(!html.contains("grid-layout-columns"));

--- a/docs/plans/2026-07-04-presenter-redesign-followups.md
+++ b/docs/plans/2026-07-04-presenter-redesign-followups.md
@@ -1,0 +1,28 @@
+# Presenter redesign follow-up fixes (2026-07-04)
+
+PR #79で反映したpresenterリデザインに対するユーザーからの修正指示を、このセッションで順次取り込む。修正項目は逐次追加される想定なので、本planも項目単位で追記していく。
+
+## 修正1: SpaceキーでタイマーStart/Pause/Resumeを発動
+
+**指示**: StartやPauseはクリックだけでなくスペースキーで発動する。元デザイン(Claude Designモック `Presenter.dc.html`)がそうなっているので、ヒント表記もそれに合わせる。
+
+PR #79時点では「キーバインド不変(Space=next)、ヒント表記は実挙動準拠」と判断していたが、ユーザー決定により上書きされた。スコープはpresenterウィンドウのみで、スライド側(present index)のSpace=nextは変えない。
+
+### 挙動
+
+- presenterウィンドウのSpaceキーは、Playボタンのクリックと同一コードパスで `peitho:timercontrol` をdispatchする(stopped→`start` / running→`pause` / paused→`resume`)
+- `event.preventDefault()` により、Playボタンにフォーカスがある状態でもネイティブclickと二重発火しない
+- `event.repeat`(長押し)ではトグルしない
+- ←/→/PageUp/PageDown/Home/Endのナビゲーションは従来通り
+- §16イベント契約は不変: キーボード層はリクエストイベントをdispatchするだけで、状態遷移はshellのみが行う
+
+### 変更箇所
+
+- `packages/peitho-present/src/keyboard.ts` — ナビゲーションキーのベースマップを切り出し、`installPresenterKeyboard(win, bus, onPlaypause)` を追加。既存 `installKeyboardNavigation` はAPI・挙動とも不変(埋め込みentryが呼ぶため後方互換必須)
+- `packages/peitho-present/src/presenter.ts` — キーボード設置を `installPresenterKeyboard` に差し替え。kbdbarを「`Space` start / pause」表記に、Playボタンに `<span class="k">Space</span>` ヒントを追加(モック準拠)
+- `crates/peitho-core/src/render.rs` — モックにあったがヒント不在のため落とされていた `.btn.primary .k` / `.btn.primary:active .k` / paused時のPlayボタン `.k` の3ルールを追加
+- テスト: presenter.test.tsのSpaceヒント非存在assertを反転、Space→timercontrol各遷移・repeat抑止・navigate非発火のテストを追加。render.rs側は追加CSSの存在assert
+
+### 検証
+
+通常ゲート(cargo test×3 / clippy / fmt / npmビルド+テスト+typecheck / shell.js drift)に加え、実ブラウザでSpaceキーによるStart→Pause→Resumeの遷移とヒント表記をスクリーンショットで確認する。

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -83,13 +83,13 @@ function installPresentationControls(options) {
       hideTimer = null;
     }, idleMs);
   };
-  const dispatchNavigate = (to) => {
+  const dispatchNavigate2 = (to) => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
   };
   const onClick = (event) => {
     event.stopPropagation();
     const action = event.target.closest("[data-peitho-action]")?.dataset.peithoAction;
-    if (action === "prev" || action === "next") dispatchNavigate(action);
+    if (action === "prev" || action === "next") dispatchNavigate2(action);
     if (action === "presenter") void openPresenter();
     if (action === "fullscreen") toggleFullscreen(doc);
     if (action === "close") bus.dispatchEvent(new CustomEvent("peitho:closerequest"));
@@ -141,21 +141,40 @@ function toggleFullscreen(doc = document) {
 }
 
 // src/keyboard.ts
-var keyMap = /* @__PURE__ */ new Map([
+var navigationKeyMap = /* @__PURE__ */ new Map([
   ["ArrowRight", "next"],
   ["PageDown", "next"],
-  [" ", "next"],
   ["ArrowLeft", "prev"],
   ["PageUp", "prev"],
   ["Home", "first"],
   ["End", "last"]
 ]);
+var keyMap = new Map([...navigationKeyMap, [" ", "next"]]);
+function dispatchNavigate(bus, to) {
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+}
 function installKeyboardNavigation(win = window, bus = win) {
   const onKeyDown = (event) => {
     const to = keyMap.get(event.key);
     if (!to) return;
     event.preventDefault();
-    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+    dispatchNavigate(bus, to);
+  };
+  win.addEventListener("keydown", onKeyDown);
+  return () => win.removeEventListener("keydown", onKeyDown);
+}
+function installPresenterKeyboard(win, bus, onPlaypause) {
+  const onKeyDown = (event) => {
+    const to = navigationKeyMap.get(event.key);
+    if (to) {
+      event.preventDefault();
+      dispatchNavigate(bus, to);
+      return;
+    }
+    if (event.key !== " ") return;
+    event.preventDefault();
+    if (event.repeat) return;
+    onPlaypause();
   };
   win.addEventListener("keydown", onKeyDown);
   return () => win.removeEventListener("keydown", onKeyDown);
@@ -759,7 +778,7 @@ async function mountPresenterView(options) {
           <div class="pos" data-peitho-presenter="position-short">00 / 00</div>
           <div>
             <span class="grp"><span class="kbd">\u2190</span><span class="kbd">\u2192</span> navigate</span>
-            <span class="grp"><span class="kbd">Space</span> next</span>
+            <span class="grp"><span class="kbd">Space</span> start / pause</span>
             <span class="grp"><span class="kbd">Esc</span> close</span>
           </div>
         </div>
@@ -799,7 +818,7 @@ async function mountPresenterView(options) {
           <div class="tracker-wrap" data-peitho-presenter="tracker-slot"></div>
 
           <div class="controls">
-            <button class="btn play primary" type="button" data-peitho-action="playpause"><span data-peitho-presenter="play-label">Start</span></button>
+            <button class="btn play primary" type="button" data-peitho-action="playpause"><span data-peitho-presenter="play-label">Start</span> <span class="k">Space</span></button>
             <button class="btn" type="button" data-peitho-action="prev">Prev <span class="k">\u2190</span></button>
             <button class="btn" type="button" data-peitho-action="next">Next <span class="k">\u2192</span></button>
             <button class="btn" type="button" data-peitho-action="reset">Reset</button>
@@ -862,7 +881,7 @@ async function mountPresenterView(options) {
     now,
     viewport: paneViewport(previewRoot)
   });
-  const keyboardCleanup = installKeyboardNavigation(win, bus);
+  const keyboardCleanup = installPresenterKeyboard(win, bus, dispatchPlaypause);
   const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
   const rawPlannedDurationMs = mainShell.manifest?.plannedDurationMs ?? null;
   const plannedDurationMs = rawPlannedDurationMs != null && Number.isFinite(rawPlannedDurationMs) && rawPlannedDurationMs > 0 ? rawPlannedDurationMs : null;
@@ -939,21 +958,22 @@ async function mountPresenterView(options) {
     button.addEventListener("click", listener);
     buttonCleanups.push(() => button.removeEventListener("click", listener));
   };
-  const dispatchTimerControl = (action) => {
+  function dispatchTimerControl(action) {
     bus.dispatchEvent(
       new CustomEvent("peitho:timercontrol", { detail: { action } })
     );
     tick();
-  };
+  }
+  function dispatchPlaypause() {
+    dispatchTimerControl(playpauseActionFor(deriveTimerState(mainShell)));
+  }
   addButtonListener("prev", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
   });
   addButtonListener("next", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
   });
-  addButtonListener("playpause", () => {
-    dispatchTimerControl(playpauseActionFor(deriveTimerState(mainShell)));
-  });
+  addButtonListener("playpause", dispatchPlaypause);
   addButtonListener("reset", () => {
     dispatchTimerControl("reset");
   });
@@ -1016,6 +1036,7 @@ export {
   installFullscreenShortcut,
   installKeyboardNavigation,
   installPresentationControls,
+  installPresenterKeyboard,
   installSyncBridge,
   installTimeTracker,
   isOverrun,

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -22,7 +22,7 @@ export {
   PRESENTER_URL
 } from "./presentDisplay";
 export type { OpenPresenterPopupOptions } from "./presentDisplay";
-export { installCloseOnEscape, installKeyboardNavigation } from "./keyboard";
+export { installCloseOnEscape, installKeyboardNavigation, installPresenterKeyboard } from "./keyboard";
 export { mountPresenterView } from "./presenter";
 export { mountPresentShell } from "./shell";
 export { installSyncBridge, serverSyncChannelFactory } from "./sync";

--- a/packages/peitho-present/src/keyboard.ts
+++ b/packages/peitho-present/src/keyboard.ts
@@ -1,14 +1,19 @@
 import type { NavigateTarget } from "./shell";
 
-const keyMap = new Map<string, NavigateTarget>([
+const navigationKeyMap = new Map<string, NavigateTarget>([
   ["ArrowRight", "next"],
   ["PageDown", "next"],
-  [" ", "next"],
   ["ArrowLeft", "prev"],
   ["PageUp", "prev"],
   ["Home", "first"],
   ["End", "last"]
 ]);
+
+const keyMap = new Map<string, NavigateTarget>([...navigationKeyMap, [" ", "next"]]);
+
+function dispatchNavigate(bus: EventTarget, to: NavigateTarget): void {
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+}
 
 export function installKeyboardNavigation(
   win: Window = window,
@@ -18,7 +23,28 @@ export function installKeyboardNavigation(
     const to = keyMap.get(event.key);
     if (!to) return;
     event.preventDefault();
-    bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+    dispatchNavigate(bus, to);
+  };
+  win.addEventListener("keydown", onKeyDown);
+  return () => win.removeEventListener("keydown", onKeyDown);
+}
+
+export function installPresenterKeyboard(
+  win: Window,
+  bus: EventTarget,
+  onPlaypause: () => void
+): () => void {
+  const onKeyDown = (event: KeyboardEvent): void => {
+    const to = navigationKeyMap.get(event.key);
+    if (to) {
+      event.preventDefault();
+      dispatchNavigate(bus, to);
+      return;
+    }
+    if (event.key !== " ") return;
+    event.preventDefault();
+    if (event.repeat) return;
+    onPlaypause();
   };
   win.addEventListener("keydown", onKeyDown);
   return () => win.removeEventListener("keydown", onKeyDown);

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -1,5 +1,5 @@
 import type { Notes } from "../../../bindings/Notes";
-import { installKeyboardNavigation } from "./keyboard";
+import { installPresenterKeyboard } from "./keyboard";
 import {
   mountPresentShell,
   type PresentShell,
@@ -136,7 +136,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
           <div class="pos" data-peitho-presenter="position-short">00 / 00</div>
           <div>
             <span class="grp"><span class="kbd">←</span><span class="kbd">→</span> navigate</span>
-            <span class="grp"><span class="kbd">Space</span> next</span>
+            <span class="grp"><span class="kbd">Space</span> start / pause</span>
             <span class="grp"><span class="kbd">Esc</span> close</span>
           </div>
         </div>
@@ -176,7 +176,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
           <div class="tracker-wrap" data-peitho-presenter="tracker-slot"></div>
 
           <div class="controls">
-            <button class="btn play primary" type="button" data-peitho-action="playpause"><span data-peitho-presenter="play-label">Start</span></button>
+            <button class="btn play primary" type="button" data-peitho-action="playpause"><span data-peitho-presenter="play-label">Start</span> <span class="k">Space</span></button>
             <button class="btn" type="button" data-peitho-action="prev">Prev <span class="k">←</span></button>
             <button class="btn" type="button" data-peitho-action="next">Next <span class="k">→</span></button>
             <button class="btn" type="button" data-peitho-action="reset">Reset</button>
@@ -241,7 +241,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     now,
     viewport: paneViewport(previewRoot)
   });
-  const keyboardCleanup = installKeyboardNavigation(win, bus);
+  const keyboardCleanup = installPresenterKeyboard(win, bus, dispatchPlaypause);
   const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
   const rawPlannedDurationMs = mainShell.manifest?.plannedDurationMs ?? null;
   const plannedDurationMs =
@@ -335,12 +335,16 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     button.addEventListener("click", listener);
     buttonCleanups.push(() => button.removeEventListener("click", listener));
   };
-  const dispatchTimerControl = (action: TimerControlDetail["action"]): void => {
+  function dispatchTimerControl(action: TimerControlDetail["action"]): void {
     bus.dispatchEvent(
       new CustomEvent<TimerControlDetail>("peitho:timercontrol", { detail: { action } })
     );
     tick();
-  };
+  }
+
+  function dispatchPlaypause(): void {
+    dispatchTimerControl(playpauseActionFor(deriveTimerState(mainShell)));
+  }
 
   addButtonListener("prev", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
@@ -348,9 +352,7 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   addButtonListener("next", () => {
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
   });
-  addButtonListener("playpause", () => {
-    dispatchTimerControl(playpauseActionFor(deriveTimerState(mainShell)));
-  });
+  addButtonListener("playpause", dispatchPlaypause);
   addButtonListener("reset", () => {
     dispatchTimerControl("reset");
   });

--- a/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
+++ b/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it, vi } from "vitest";
-import { installKeyboardNavigation, mountPresentShell } from "../src/index";
+import { installKeyboardNavigation, installPresenterKeyboard, mountPresentShell } from "../src/index";
 import type { PresentShell } from "../src/index";
 
 function okJson(value: unknown): Response {
@@ -255,6 +255,49 @@ it("keyboard emits navigate events to an injected bus", () => {
   window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
 
   expect(requests).toEqual([{ to: "next" }]);
+});
+
+it("presenter keyboard maps Space to playpause and navigation keys to navigate", () => {
+  const bus = new EventTarget();
+  const requests: unknown[] = [];
+  const onPlaypause = vi.fn();
+  bus.addEventListener("peitho:navigate", (event) => {
+    requests.push((event as CustomEvent).detail);
+  });
+
+  const teardown = installPresenterKeyboard(window, bus, onPlaypause);
+  windowListenerCleanups.push(teardown);
+  const space = new KeyboardEvent("keydown", { key: " ", cancelable: true });
+  const repeatedSpace = new KeyboardEvent("keydown", {
+    key: " ",
+    repeat: true,
+    cancelable: true
+  });
+  const arrowRight = new KeyboardEvent("keydown", { key: "ArrowRight", cancelable: true });
+  const arrowLeft = new KeyboardEvent("keydown", { key: "ArrowLeft", cancelable: true });
+  const home = new KeyboardEvent("keydown", { key: "Home", cancelable: true });
+  const end = new KeyboardEvent("keydown", { key: "End", cancelable: true });
+
+  window.dispatchEvent(space);
+  window.dispatchEvent(repeatedSpace);
+  window.dispatchEvent(arrowRight);
+  window.dispatchEvent(arrowLeft);
+  window.dispatchEvent(home);
+  window.dispatchEvent(end);
+
+  expect(space.defaultPrevented).toBe(true);
+  expect(repeatedSpace.defaultPrevented).toBe(true);
+  expect(arrowRight.defaultPrevented).toBe(true);
+  expect(arrowLeft.defaultPrevented).toBe(true);
+  expect(home.defaultPrevented).toBe(true);
+  expect(end.defaultPrevented).toBe(true);
+  expect(onPlaypause).toHaveBeenCalledTimes(1);
+  expect(requests).toEqual([
+    { to: "next" },
+    { to: "prev" },
+    { to: "first" },
+    { to: "last" }
+  ]);
 });
 
 it("shows a visible error when a fragment fetch fails", async () => {

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -96,6 +96,7 @@ it("renders the redesigned presenter shell and starts timer from the playpause b
   expect(root.querySelector(".agenda")).toBeNull();
   expect(root.querySelector(".status-line")?.textContent).not.toContain("Section");
   expect(root.querySelector(".kbdbar")?.textContent).toContain("Space");
+  expect(root.querySelector(".kbdbar")?.textContent).toContain("start / pause");
 
   const clock = root.querySelector<HTMLElement>('[data-peitho-presenter="clock"]')!;
   const pill = root.querySelector<HTMLElement>('[data-peitho-presenter="state-pill"]')!;
@@ -107,8 +108,8 @@ it("renders the redesigned presenter shell and starts timer from the playpause b
   expect(clock.dataset.peithoState).toBe("stopped");
   expect(pill.dataset.peithoState).toBe("stopped");
   expect(pill.textContent).toContain("Stopped");
-  expect(play.textContent).toBe("Start");
-  expect(play.textContent).not.toContain("Space");
+  expect(play.textContent).toContain("Start");
+  expect(play.textContent).toContain("Space");
 
   play.click();
   now = 65000;
@@ -117,7 +118,8 @@ it("renders the redesigned presenter shell and starts timer from the playpause b
   expect(clock.dataset.peithoState).toBe("running");
   expect(pill.dataset.peithoState).toBe("running");
   expect(pill.textContent).toContain("Running");
-  expect(play.textContent).toBe("Pause");
+  expect(play.textContent).toContain("Pause");
+  expect(play.textContent).toContain("Space");
 });
 
 it("shows planned duration in presenter timer when manifest has time", async () => {
@@ -320,6 +322,86 @@ it("buttons emit navigate timercontrol and close requests", async () => {
   expect(channel.sent).toEqual([{ index: 1 }, { close: true }]);
 });
 
+it("maps presenter Space to timer playpause without navigating", async () => {
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch(),
+    window,
+    now: () => 1000,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+  const timerRequests: unknown[] = [];
+  const navigateRequests: unknown[] = [];
+  const onTimerControl = (event: Event): void => {
+    timerRequests.push((event as CustomEvent).detail);
+  };
+  const onNavigate = (event: Event): void => {
+    navigateRequests.push((event as CustomEvent).detail);
+  };
+  window.addEventListener("peitho:timercontrol", onTimerControl);
+  window.addEventListener("peitho:navigate", onNavigate);
+  cleanups.push(() => window.removeEventListener("peitho:timercontrol", onTimerControl));
+  cleanups.push(() => window.removeEventListener("peitho:navigate", onNavigate));
+
+  const startEvent = new KeyboardEvent("keydown", { key: " ", cancelable: true });
+  window.dispatchEvent(startEvent);
+  const pauseEvent = new KeyboardEvent("keydown", { key: " ", cancelable: true });
+  window.dispatchEvent(pauseEvent);
+  const resumeEvent = new KeyboardEvent("keydown", { key: " ", cancelable: true });
+  window.dispatchEvent(resumeEvent);
+
+  expect(startEvent.defaultPrevented).toBe(true);
+  expect(pauseEvent.defaultPrevented).toBe(true);
+  expect(resumeEvent.defaultPrevented).toBe(true);
+  expect(timerRequests).toEqual([{ action: "start" }, { action: "pause" }, { action: "resume" }]);
+  expect(navigateRequests).toEqual([]);
+  expect(view.mainShell.currentIndex).toBe(0);
+});
+
+it("ignores repeated presenter Space keydown and keeps arrow navigation", async () => {
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch(),
+    window,
+    now: () => 1000,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+  const timerRequests: unknown[] = [];
+  const navigateRequests: unknown[] = [];
+  const onTimerControl = (event: Event): void => {
+    timerRequests.push((event as CustomEvent).detail);
+  };
+  const onNavigate = (event: Event): void => {
+    navigateRequests.push((event as CustomEvent).detail);
+  };
+  window.addEventListener("peitho:timercontrol", onTimerControl);
+  window.addEventListener("peitho:navigate", onNavigate);
+  cleanups.push(() => window.removeEventListener("peitho:timercontrol", onTimerControl));
+  cleanups.push(() => window.removeEventListener("peitho:navigate", onNavigate));
+
+  const repeatEvent = new KeyboardEvent("keydown", { key: " ", repeat: true, cancelable: true });
+  window.dispatchEvent(repeatEvent);
+  const nextEvent = new KeyboardEvent("keydown", { key: "ArrowRight", cancelable: true });
+  window.dispatchEvent(nextEvent);
+  const prevEvent = new KeyboardEvent("keydown", { key: "ArrowLeft", cancelable: true });
+  window.dispatchEvent(prevEvent);
+
+  expect(repeatEvent.defaultPrevented).toBe(true);
+  expect(nextEvent.defaultPrevented).toBe(true);
+  expect(prevEvent.defaultPrevented).toBe(true);
+  expect(timerRequests).toEqual([]);
+  expect(navigateRequests).toEqual([{ to: "next" }, { to: "prev" }]);
+  expect(view.mainShell.currentIndex).toBe(0);
+});
+
 it("derives playpause action labels and chrome from shell timer state", async () => {
   const root = document.createElement("main");
   const { factory } = mockSyncChannelFactory();
@@ -339,26 +421,26 @@ it("derives playpause action labels and chrome from shell timer state", async ()
 
   expect(clock.dataset.peithoState).toBe("stopped");
   expect(pill.textContent).toContain("Stopped");
-  expect(play.textContent).toBe("Start");
+  expect(play.textContent).toContain("Start");
 
   play.click();
   expect(clock.dataset.peithoState).toBe("running");
   expect(pill.textContent).toContain("Running");
-  expect(play.textContent).toBe("Pause");
+  expect(play.textContent).toContain("Pause");
 
   play.click();
   expect(clock.dataset.peithoState).toBe("paused");
   expect(pill.textContent).toContain("Paused");
-  expect(play.textContent).toBe("Resume");
+  expect(play.textContent).toContain("Resume");
 
   play.click();
   expect(clock.dataset.peithoState).toBe("running");
-  expect(play.textContent).toBe("Pause");
+  expect(play.textContent).toContain("Pause");
 
   reset.click();
   expect(clock.dataset.peithoState).toBe("stopped");
   expect(pill.textContent).toContain("Stopped");
-  expect(play.textContent).toBe("Start");
+  expect(play.textContent).toContain("Start");
 });
 
 it("adds button ripple feedback and clears pending ripple timeout on destroy", async () => {


### PR DESCRIPTION
## Summary

First follow-up to the presenter redesign landed in PR #79.

- Bind the presenter window's Space key to the same `peitho:timercontrol` dispatch path as clicking the Play button (stopped→start / running→pause / paused→resume)
- Change the kbdbar Space hint from "next" to "start / pause", and add a `Space` hint to the Play button (matches the original Claude Design mock)
- The slides-side Space=next binding is unchanged (`installKeyboardNavigation`'s API and behavior are preserved)
- The §16 event contract is preserved: the keyboard layer only dispatches events; state transitions live in the shell

Introduces `installPresenterKeyboard`, which handles Space with `event.preventDefault()` plus an `event.repeat` guard so double-firing (when the Play button has focus) and long-press toggle spam are suppressed.

The design rationale is captured in `docs/plans/2026-07-04-presenter-redesign-followups.md` (further follow-ups will be appended to the same plan).

## Test plan

- [x] `cargo test --workspace` (3 runs in a row)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `npm run build && npm test && npm run typecheck` (peitho-present, 82 tests)
- [x] Space does not fire twice while the Play button has focus (verified in a real browser; `timerControlLog` matches expectations)
- [x] Screenshot check: Play button shows `RESUME Space`, kbdbar shows `Space start / pause`, other button hints (Reset/Close/etc.) preserved

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
