### PR TITLE
fix(presenter): align time tracker scale labels to bar edges

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -472,9 +472,8 @@ pub fn render_presenter_index() -> String {
     .tracker [data-peitho-marker="turtle"] { position: absolute; transition: left 120ms linear, transform 120ms linear; font-size: 18px; line-height: 1; }
     .tracker [data-peitho-marker="rabbit"] { top: -6px; }
     .tracker [data-peitho-marker="turtle"] { bottom: -6px; }
-    .tracker-scale { display: grid; grid-template-columns: repeat(5, 1fr); margin-top: 6px; color: var(--fg-dim); font-size: 10px; letter-spacing: 0.08em; }
-    .tracker-scale span { border-left: 1px solid var(--line-soft); padding-left: 6px; }
-    .tracker-scale span:first-child { border-left: none; padding-left: 0; }
+    .tracker-scale { position: relative; height: 12px; margin-top: 6px; color: var(--fg-dim); font-size: 10px; letter-spacing: 0.08em; }
+    .tracker-scale span { position: absolute; top: 0; white-space: nowrap; }
     [data-peitho-agenda] { overflow: hidden; padding: 0 16px 14px; }
     [data-peitho-agenda-head] { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 4px; color: var(--fg-dim); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; }
     [data-peitho-agenda-title] { color: var(--fg-mute); }
@@ -854,6 +853,9 @@ mod tests {
         assert!(html.contains(".tracker { position: relative; height: 30px;"));
         assert!(html.contains(".tracker-fill"));
         assert!(html.contains(".tracker-scale"));
+        assert!(html.contains(".tracker-scale { position: relative;"));
+        assert!(html.contains(".tracker-scale span { position: absolute;"));
+        assert!(!html.contains(".tracker-scale { display: grid;"));
         assert!(!html.contains("transform: translateX(-50%)"));
         assert!(html.contains("transition: left 120ms linear, transform 120ms linear"));
         assert!(html.contains(concat!(

--- a/docs/plans/2026-07-04-time-tracker-scale-labels.md
+++ b/docs/plans/2026-07-04-time-tracker-scale-labels.md
@@ -1,0 +1,114 @@
+# Time tracker scale labels — fix last-label alignment (Issue #97)
+
+## 現状
+
+presenter time tracker のスケール(0:00 / 1:15 / 2:30 / 3:45 / 5:00)は
+`display: grid; grid-template-columns: repeat(5, 1fr)` の 5 セル左端に配置される。
+結果、最終ラベル「5:00」は最後のセルの開始位置 = バー全幅の 4/5 (80%) に出て、
+バー右端(=計画時間の位置)と一致しない。
+
+## 設計方針(author 承認済み)
+
+各ラベルはバー上の 0% / 25% / 50% / 75% / 100% の**時点**を指す。
+
+- **配置**: `position: absolute` + `left: N%` で各ラベルを配置
+- **アライメント**:
+  - 先頭 (0%): 左揃え (`translateX(0%)`)
+  - 中間 (25%, 50%, 75%): 中央揃え (`translateX(-50%)`)
+  - 末尾 (100%): 右揃え (`translateX(-100%)`)
+
+これは既存の rabbit/turtle マーカーと同じ流儀(インライン style で `left` +
+`transform: translateX(...)` を付与)なので、CSS には generic な
+`.tracker-scale span { position: absolute; }` だけを置き、位置合わせは
+timeTracker.ts が付ける個別のインライン style で行う。
+
+### なぜインライン style か
+
+`crates/peitho-core/src/render.rs` の presenter CSS テストに
+`assert!(!html.contains("transform: translateX(-50%)"))` があり、CSS 内で
+translateX を宣言できない。既存 rabbit/turtle と同様に TS からインラインで
+付与する形が一貫していて、この制約とも整合する。
+
+## 変更対象
+
+### `packages/peitho-present/src/timeTracker.ts`
+
+1. `timeScaleLabels` を、テキストと配置情報を返す形へ拡張(or 呼び出し側で
+   index から派生させる)
+2. presenter バリアントの `<div class="tracker-scale mono">…</div>` 生成箇所で、
+   5 個の span それぞれに `style="left: X%; transform: translateX(Y%)"` を付与
+   - index 0: `left: 0%; transform: translateX(0%)`
+   - index 1: `left: 25%; transform: translateX(-50%)`
+   - index 2: `left: 50%; transform: translateX(-50%)`
+   - index 3: `left: 75%; transform: translateX(-50%)`
+   - index 4: `left: 100%; transform: translateX(-100%)`
+
+### `crates/peitho-core/src/render.rs`
+
+CSS を以下のように書き換え:
+
+```css
+.tracker-scale { position: relative; height: 12px; margin-top: 6px; color: var(--fg-dim); font-size: 10px; letter-spacing: 0.08em; }
+.tracker-scale span { position: absolute; top: 0; white-space: nowrap; }
+```
+
+削除:
+- `display: grid; grid-template-columns: repeat(5, 1fr)`
+- `border-left: 1px solid var(--line-soft); padding-left: 6px;` の cell 境界線
+- `:first-child { border-left: none; padding-left: 0; }`
+
+理由: 新しいレイアウトでは cell 概念自体が消えるので、cell 境界線も不要。
+Issue にも「先頭は左揃え、中間は中央揃え、末尾は右揃え」とあり、cell 境界線
+の意匠は保持要件に入っていない。
+
+### `crates/peitho-core/src/render.rs` (テスト側)
+
+新規アサーションを追加:
+
+```rust
+assert!(html.contains(".tracker-scale { position: relative;"));
+assert!(html.contains(".tracker-scale span { position: absolute;"));
+assert!(!html.contains(".tracker-scale { display: grid;"));
+```
+
+`assert!(!html.contains("transform: translateX(-50%)"))` はそのまま維持
+(CSS 内には現れず、インライン style としてのみ生成される)。
+
+## テスト
+
+### `packages/peitho-present/test/timeTracker.test.ts`
+
+既存 "renders presenter variant with legend fill track and five-point time scale"
+テストの末尾に以下のアサーションを追加:
+
+```ts
+const scaleSpans = Array.from(tracker.querySelectorAll<HTMLElement>(".tracker-scale span"));
+expect(scaleSpans.map((s) => s.style.left)).toEqual(["0%", "25%", "50%", "75%", "100%"]);
+expect(scaleSpans.map((s) => s.style.transform)).toEqual([
+  "translateX(0%)",
+  "translateX(-50%)",
+  "translateX(-50%)",
+  "translateX(-50%)",
+  "translateX(-100%)"
+]);
+```
+
+これで「末尾は right-align」「先頭は left-align」「中間は center-align」が
+DOM レベルで保証される。
+
+既存の "keeps the present variant DOM unchanged" テストは変更なし
+(present バリアントは今回の修正対象外、DOM は不変を維持)。
+
+## Verify
+
+- `cargo test --workspace` x3
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --exit-code bindings/` (ts-rs 契約に変更なし)
+- `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
+- `git diff --exit-code packages/peitho-present/dist/shell.js` (再ビルド後)
+
+## E2E (author が実機確認)
+
+`peitho present examples/deck-with-time.md --port 8080` で presenter を開き、
+スケールの「5:00」がバー右端に揃うことを目視。

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -53,6 +53,16 @@ function timeScaleLabels(plannedDurationMs) {
     (_, index) => formatMinuteSeconds(plannedDurationMs * index / 4)
   );
 }
+function timeScaleLabelTransform(index, labelCount) {
+  if (index === 0) return "translateX(0%)";
+  if (index === labelCount - 1) return "translateX(-100%)";
+  return "translateX(-50%)";
+}
+function timeScaleLabelStyle(index, labelCount) {
+  const left = Math.round(index / (labelCount - 1) * 1e4) / 100;
+  const transform = timeScaleLabelTransform(index, labelCount);
+  return `left: ${left}%; transform: ${transform}`;
+}
 function isValidSlideChangeDetail(detail) {
   if (typeof detail !== "object" || detail === null) return false;
   const candidate = detail;
@@ -72,6 +82,7 @@ function installTimeTracker(options) {
   track.className = "peitho-time-tracker";
   track.dataset.peithoTimeTracker = variant;
   if (variant === "presenter") {
+    const scaleLabels = timeScaleLabels(options.plannedDurationMs);
     track.innerHTML = [
       '<div class="tracker-legend"><span>Slide progress</span><span>Time</span></div>',
       '<div class="tracker">',
@@ -79,7 +90,9 @@ function installTimeTracker(options) {
       '<span data-peitho-marker="rabbit" aria-label="slide progress">\u{1F430}</span>',
       '<span data-peitho-marker="turtle" aria-label="time progress">\u{1F422}</span>',
       "</div>",
-      `<div class="tracker-scale mono">${timeScaleLabels(options.plannedDurationMs).map((label) => `<span>${label}</span>`).join("")}</div>`
+      `<div class="tracker-scale mono">${scaleLabels.map(
+        (label, index) => `<span style="${timeScaleLabelStyle(index, scaleLabels.length)}">${label}</span>`
+      ).join("")}</div>`
     ].join("");
   } else {
     track.innerHTML = [

--- a/packages/peitho-present/src/timeTracker.ts
+++ b/packages/peitho-present/src/timeTracker.ts
@@ -40,6 +40,18 @@ function timeScaleLabels(plannedDurationMs: number): string[] {
   );
 }
 
+function timeScaleLabelTransform(index: number, labelCount: number): string {
+  if (index === 0) return "translateX(0%)";
+  if (index === labelCount - 1) return "translateX(-100%)";
+  return "translateX(-50%)";
+}
+
+function timeScaleLabelStyle(index: number, labelCount: number): string {
+  const left = Math.round((index / (labelCount - 1)) * 10_000) / 100;
+  const transform = timeScaleLabelTransform(index, labelCount);
+  return `left: ${left}%; transform: ${transform}`;
+}
+
 function isValidSlideChangeDetail(detail: unknown): detail is SlideChangeDetail {
   if (typeof detail !== "object" || detail === null) return false;
   const candidate = detail as Partial<SlideChangeDetail>;
@@ -69,6 +81,7 @@ export function installTimeTracker(options: TimeTrackerOptions): () => void {
   track.className = "peitho-time-tracker";
   track.dataset.peithoTimeTracker = variant;
   if (variant === "presenter") {
+    const scaleLabels = timeScaleLabels(options.plannedDurationMs);
     track.innerHTML = [
       '<div class="tracker-legend"><span>Slide progress</span><span>Time</span></div>',
       '<div class="tracker">',
@@ -76,8 +89,11 @@ export function installTimeTracker(options: TimeTrackerOptions): () => void {
       '<span data-peitho-marker="rabbit" aria-label="slide progress">🐰</span>',
       '<span data-peitho-marker="turtle" aria-label="time progress">🐢</span>',
       "</div>",
-      `<div class="tracker-scale mono">${timeScaleLabels(options.plannedDurationMs)
-        .map((label) => `<span>${label}</span>`)
+      `<div class="tracker-scale mono">${scaleLabels
+        .map(
+          (label, index) =>
+            `<span style="${timeScaleLabelStyle(index, scaleLabels.length)}">${label}</span>`
+        )
         .join("")}</div>`
     ].join("");
   } else {

--- a/packages/peitho-present/test/timeTracker.test.ts
+++ b/packages/peitho-present/test/timeTracker.test.ts
@@ -117,6 +117,15 @@ it("renders presenter variant with legend fill track and five-point time scale",
   expect(
     Array.from(tracker.querySelectorAll(".tracker-scale span"), (span) => span.textContent)
   ).toEqual(["0:00", "0:15", "0:30", "0:45", "1:00"]);
+  const scaleSpans = Array.from(tracker.querySelectorAll<HTMLElement>(".tracker-scale span"));
+  expect(scaleSpans.map((s) => s.style.left)).toEqual(["0%", "25%", "50%", "75%", "100%"]);
+  expect(scaleSpans.map((s) => s.style.transform)).toEqual([
+    "translateX(0%)",
+    "translateX(-50%)",
+    "translateX(-50%)",
+    "translateX(-50%)",
+    "translateX(-100%)"
+  ]);
 
   elapsed = 45_000;
   vi.advanceTimersByTime(250);


### PR DESCRIPTION
Closes #97

## Summary

- Fix the Presenter time tracker so the last scale label (e.g. "5:00" on a 5-minute deck) no longer lands at 80% of the bar width and fails to align with the right edge
- Replace `.tracker-scale` from `display: grid; grid-template-columns: repeat(5, 1fr)` with `position: relative` + each span using `position: absolute` + inline `left: N%` / `transform: translateX(...)`
- The first is `translateX(0%)` (left-aligned), middle ones are `translateX(-50%)` (centered), and the last is `translateX(-100%)` (right-aligned)
- translateX is applied inline from the TS side, same as the existing rabbit/turtle. Not written in the CSS (preserves the existing `!contains("transform: translateX(-50%)")` assertion in `render.rs`)

## Changed files

- `crates/peitho-core/src/render.rs`: change the `.tracker-scale` definition in the presenter CSS + add CSS test assertions
- `packages/peitho-present/src/timeTracker.ts`: add `timeScaleLabelStyle` / `timeScaleLabelTransform` helpers; in the presenter branch, apply inline style to each span
- `packages/peitho-present/test/timeTracker.test.ts`: add assertions in the presenter variant validating `style.left` / `style.transform` on the 5 spans
- `packages/peitho-present/dist/shell.js`: build output updated accordingly
- `docs/plans/2026-07-04-time-tracker-scale-labels.md`: implementation plan

## Design decisions

- To satisfy the constraint that `translateX(-50%)` cannot appear in CSS (existing assertion), apply it as inline style (unified with the rabbit/turtle style)
- `timeScaleLabelStyle(index, labelCount)` does not assume a fixed count of 5; the logic is generic for any `labelCount >= 2`
- The present variant (audience side) is unchanged. The existing byte-invariant snapshot test remains intact

## Test plan

- [x] `cargo test --workspace` passes 3 times in a row
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `git diff --exit-code bindings/` — no impact on the ts-rs contract
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck` passes
- [x] `dist/shell.js` committed with `npm run build` output
- [x] `/code-review medium` — 1 finding (unreachable defensive branch) detected and fixed
- [x] All 5 rounds of self-review CLEAN
- [ ] Author to visually confirm on real hardware that "5:00" aligns with the right edge of the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
