### PR TITLE
feat(presenter): replace "Now" label with current section name

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -422,7 +422,6 @@ pub fn render_presenter_index() -> String {
     .colhead { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 2px; min-width: 0; height: var(--colhead-h); }
     .status-line { display: inline-flex; align-items: center; gap: 10px; color: var(--fg-dim); font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; min-width: 0; }
     .status-line .sep { width: 3px; height: 3px; border-radius: 50%; background: var(--line); flex: 0 0 auto; }
-    .status-line .now { color: var(--accent); }
     .deck-title { font-size: 12px; color: var(--fg-mute); letter-spacing: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .slide-frame { min-width: 0; }
     .slide-pane { position: relative; width: 100%; box-sizing: border-box; aspect-ratio: 16 / 9; background: var(--bg-slide); border: 1px solid var(--line-soft); box-shadow: 0 20px 60px -30px rgba(0, 0, 0, 0.6); overflow: hidden; }

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -33,6 +33,13 @@ function installCanvasScaler(options) {
   return () => win.removeEventListener("resize", apply);
 }
 
+// src/sections.ts
+function sectionIndexForSlide(sections, slideIndex) {
+  return sections.findIndex(
+    (section) => slideIndex >= section.startIndex && slideIndex <= section.endIndex
+  );
+}
+
 // src/timeTracker.ts
 var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
 function isOverrun(elapsedMs, plannedDurationMs) {
@@ -176,20 +183,15 @@ function installAgenda(options) {
   list.append(...rows.map(({ row }) => row));
   const actualMs = new Array(options.sections.length).fill(0);
   let lastElapsedMs = options.shell.elapsedMs();
-  function sectionIndexForSlide(slideIndex) {
-    return options.sections.findIndex(
-      (section) => slideIndex >= section.startIndex && slideIndex <= section.endIndex
-    );
-  }
   function render() {
-    const currentSection = sectionIndexForSlide(options.shell.currentIndex);
+    const currentSection = sectionIndexForSlide(options.sections, options.shell.currentIndex);
     rows.forEach((row, index) => updateRow(row, index, currentSection, actualMs[index]));
   }
   function flushElapsedToSectionOf(slideIndex) {
     if (slideIndex === null || options.shell.startedAt() === null) return;
     const elapsedMs = options.shell.elapsedMs();
     const delta = Math.max(0, elapsedMs - lastElapsedMs);
-    const sectionIndex = sectionIndexForSlide(slideIndex);
+    const sectionIndex = sectionIndexForSlide(options.sections, slideIndex);
     if (sectionIndex >= 0) actualMs[sectionIndex] += delta;
     lastElapsedMs = elapsedMs;
   }
@@ -938,9 +940,9 @@ async function mountPresenterView(options) {
         <div class="stage">
           <header class="colhead">
             <div class="status-line">
-              <span class="now">Now</span>
-              <span class="sep"></span>
               <span data-peitho-presenter="position">Slide 00 of 00</span>
+              <span class="sep" data-peitho-presenter="section-sep" hidden></span>
+              <span data-peitho-presenter="section" hidden></span>
             </div>
             <div class="deck-title" data-peitho-presenter="title">Peitho Deck</div>
           </header>
@@ -1039,6 +1041,12 @@ async function mountPresenterView(options) {
   const positionLong = options.root.querySelector(
     '[data-peitho-presenter="position"]'
   );
+  const sectionLabel = options.root.querySelector(
+    '[data-peitho-presenter="section"]'
+  );
+  const sectionSep = options.root.querySelector(
+    '[data-peitho-presenter="section-sep"]'
+  );
   const positionShort = options.root.querySelector(
     '[data-peitho-presenter="position-short"]'
   );
@@ -1118,6 +1126,16 @@ async function mountPresenterView(options) {
     positionLong.textContent = `Slide ${slide} of ${total}`;
     positionShort.textContent = `${slide} / ${total}`;
     notesSlide.textContent = `Slide ${slide}`;
+    const currentSectionIndex = sectionIndexForSlide(sections, detail.index);
+    if (currentSectionIndex >= 0) {
+      sectionLabel.textContent = `Section \u2014 \u201C${sections[currentSectionIndex].name}\u201D`;
+      sectionLabel.hidden = false;
+      sectionSep.hidden = false;
+    } else {
+      sectionLabel.textContent = "";
+      sectionLabel.hidden = true;
+      sectionSep.hidden = true;
+    }
     const nextIndex = detail.index + 1;
     if (nextIndex < detail.total) {
       previewRoot.hidden = false;

--- a/packages/peitho-present/src/agenda.ts
+++ b/packages/peitho-present/src/agenda.ts
@@ -1,4 +1,5 @@
 import type { ManifestSection } from "../../../bindings/ManifestSection";
+import { sectionIndexForSlide } from "./sections";
 import type { PresentShell, SlideChangeDetail, TimerControlDetail } from "./shell";
 import { formatMinuteSeconds, isValidDurationMs } from "./timeTracker";
 
@@ -49,14 +50,8 @@ export function installAgenda(options: AgendaOptions): () => void {
   const actualMs = new Array<number>(options.sections.length).fill(0);
   let lastElapsedMs = options.shell.elapsedMs();
 
-  function sectionIndexForSlide(slideIndex: number): number {
-    return options.sections.findIndex(
-      (section) => slideIndex >= section.startIndex && slideIndex <= section.endIndex
-    );
-  }
-
   function render(): void {
-    const currentSection = sectionIndexForSlide(options.shell.currentIndex);
+    const currentSection = sectionIndexForSlide(options.sections, options.shell.currentIndex);
     rows.forEach((row, index) => updateRow(row, index, currentSection, actualMs[index]));
   }
 
@@ -64,7 +59,7 @@ export function installAgenda(options: AgendaOptions): () => void {
     if (slideIndex === null || options.shell.startedAt() === null) return;
     const elapsedMs = options.shell.elapsedMs();
     const delta = Math.max(0, elapsedMs - lastElapsedMs);
-    const sectionIndex = sectionIndexForSlide(slideIndex);
+    const sectionIndex = sectionIndexForSlide(options.sections, slideIndex);
     if (sectionIndex >= 0) actualMs[sectionIndex] += delta;
     lastElapsedMs = elapsedMs;
   }

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -1,6 +1,7 @@
 import type { Notes } from "../../../bindings/Notes";
 import { installAgenda } from "./agenda";
 import { installPresenterKeyboard } from "./keyboard";
+import { sectionIndexForSlide } from "./sections";
 import {
   mountPresentShell,
   type PresentShell,
@@ -118,9 +119,9 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
         <div class="stage">
           <header class="colhead">
             <div class="status-line">
-              <span class="now">Now</span>
-              <span class="sep"></span>
               <span data-peitho-presenter="position">Slide 00 of 00</span>
+              <span class="sep" data-peitho-presenter="section-sep" hidden></span>
+              <span data-peitho-presenter="section" hidden></span>
             </div>
             <div class="deck-title" data-peitho-presenter="title">Peitho Deck</div>
           </header>
@@ -220,6 +221,12 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   const positionLong = options.root.querySelector<HTMLElement>(
     '[data-peitho-presenter="position"]'
   )!;
+  const sectionLabel = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="section"]'
+  )!;
+  const sectionSep = options.root.querySelector<HTMLElement>(
+    '[data-peitho-presenter="section-sep"]'
+  )!;
   const positionShort = options.root.querySelector<HTMLElement>(
     '[data-peitho-presenter="position-short"]'
   )!;
@@ -309,6 +316,16 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     positionLong.textContent = `Slide ${slide} of ${total}`;
     positionShort.textContent = `${slide} / ${total}`;
     notesSlide.textContent = `Slide ${slide}`;
+    const currentSectionIndex = sectionIndexForSlide(sections, detail.index);
+    if (currentSectionIndex >= 0) {
+      sectionLabel.textContent = `Section — “${sections[currentSectionIndex].name}”`;
+      sectionLabel.hidden = false;
+      sectionSep.hidden = false;
+    } else {
+      sectionLabel.textContent = "";
+      sectionLabel.hidden = true;
+      sectionSep.hidden = true;
+    }
     const nextIndex = detail.index + 1;
     if (nextIndex < detail.total) {
       previewRoot.hidden = false;

--- a/packages/peitho-present/src/sections.ts
+++ b/packages/peitho-present/src/sections.ts
@@ -1,0 +1,10 @@
+import type { ManifestSection } from "../../../bindings/ManifestSection";
+
+export function sectionIndexForSlide(
+  sections: ManifestSection[],
+  slideIndex: number
+): number {
+  return sections.findIndex(
+    (section) => slideIndex >= section.startIndex && slideIndex <= section.endIndex
+  );
+}

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -222,6 +222,59 @@ it("mounts agenda between tracker and controls when manifest has sections", asyn
   ).not.toBeNull();
 });
 
+it("shows the current section name in the status line and follows slide navigation", async () => {
+  const root = document.createElement("main");
+  const { factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch({
+      plannedDurationMs: 180_000,
+      sections: [
+        { name: "Setup", startIndex: 0, endIndex: 0, plannedDurationMs: 60_000 },
+        { name: "Demo", startIndex: 1, endIndex: 1, plannedDurationMs: 120_000 }
+      ]
+    }),
+    window,
+    now: () => 1000,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+
+  const sectionEl = root.querySelector<HTMLElement>('[data-peitho-presenter="section"]')!;
+  const sepEl = root.querySelector<HTMLElement>('[data-peitho-presenter="section-sep"]')!;
+  expect(sectionEl.hidden).toBe(false);
+  expect(sepEl.hidden).toBe(false);
+  expect(sectionEl.textContent).toBe("Section — “Setup”");
+  expect(root.querySelector(".status-line")?.textContent).not.toContain("Now");
+
+  window.dispatchEvent(
+    new CustomEvent("peitho:navigate", { detail: { to: { index: 1 } } })
+  );
+  await Promise.resolve();
+  expect(sectionEl.textContent).toBe("Section — “Demo”");
+});
+
+it("hides the section chip in the status line when the manifest has no sections", async () => {
+  const root = document.createElement("main");
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch({ sections: [] }),
+    window,
+    now: () => 1000,
+    syncChannelFactory: mockSyncChannelFactory().factory
+  });
+  views.push(view);
+
+  const sectionEl = root.querySelector<HTMLElement>('[data-peitho-presenter="section"]')!;
+  const sepEl = root.querySelector<HTMLElement>('[data-peitho-presenter="section-sep"]')!;
+  expect(sectionEl.hidden).toBe(true);
+  expect(sepEl.hidden).toBe(true);
+  expect(sectionEl.textContent).toBe("");
+  expect(root.querySelector(".status-line")?.textContent).not.toContain("Now");
+});
+
 it("logs invalid planned duration and keeps presenter mounted without a tracker", async () => {
   let now = 1_000;
   const root = document.createElement("main");


### PR DESCRIPTION
## Summary

- Remove the redundant "Now" label from the top-left status line of the presenter view
- Instead, display the name of the section the current slide belongs to (`Slide 07 of 24 • Section — "How it works"` format)
- When sections are undefined (`manifest.sections` is empty) or none applies, keep the section display hidden
- Track the update to the Claude Design mock (`Presenter.dc.html`)

## Implementation notes

- Add `sectionIndexForSlide` to `packages/peitho-present/src/sections.ts` and use it from both `agenda.ts` and `presenter.ts` (avoid duplicating the logic)
- Replace the status line HTML with "Slide XX of YY" → `.sep` → section name in that order; the latter two default to `hidden` and are toggled per-tick by `updateFromSlide`
- Remove `.status-line .now { color: var(--accent); }` from the embedded CSS since it is no longer referenced

## Test plan

- [x] `packages/peitho-present && npm test` (100 tests pass, 2 section-display cases added)
- [x] `npm run typecheck`
- [x] `npm run build` (`dist/shell.js` updated as well)
- [x] `cargo test --workspace` 3 times in a row
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/` (no diff)
- [ ] Launch present in a real browser against a deck with sections (`examples/lightning-talk`) and one without, and verify visually

Closes #100
