### PR TITLE
style(presenter): dim empty notes placeholder

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -435,6 +435,7 @@ pub fn render_presenter_index() -> String {
     .notes-head { display: flex; align-items: center; justify-content: space-between; padding: 6px 14px; border-bottom: 1px solid var(--line-soft); color: var(--fg-dim); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; }
     .notes-head .badge { color: var(--fg-mute); letter-spacing: 0; text-transform: none; font-size: 11px; }
     .notes-body { overflow: auto; padding: 10px 16px 12px; font-size: 16px; line-height: 1.4; color: var(--fg); white-space: pre-wrap; }
+    .notes-body.is-empty { color: var(--fg-dim); font-style: italic; }
     .card { background: var(--bg-elev); border: 1px solid var(--line-soft); display: flex; flex-direction: column; min-height: 0; }
     .card-head { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px; border-bottom: 1px solid var(--line-soft); color: var(--fg-dim); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; }
     .card-head .badge { color: var(--fg-mute); letter-spacing: 0; text-transform: none; font-size: 11px; }

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -1118,7 +1118,9 @@ async function mountPresenterView(options) {
     setTimerStateChrome(deriveTimerState(mainShell));
   }
   function updateFromSlide(detail) {
-    notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide.";
+    const slideNotes = options.notes.notes[detail.key];
+    notesRoot.textContent = slideNotes ?? "No notes for this slide.";
+    notesRoot.classList.toggle("is-empty", slideNotes == null);
     const slideNumber = detail.index + 1;
     const slide = formatSlideNumber(slideNumber);
     const total = formatSlideNumber(detail.total);

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -308,7 +308,9 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   }
 
   function updateFromSlide(detail: SlideChangeDetail): void {
-    notesRoot.textContent = options.notes.notes[detail.key] ?? "No notes for this slide.";
+    const slideNotes = options.notes.notes[detail.key];
+    notesRoot.textContent = slideNotes ?? "No notes for this slide.";
+    notesRoot.classList.toggle("is-empty", slideNotes == null);
     const slideNumber = detail.index + 1;
     const slide = formatSlideNumber(slideNumber);
     const total = formatSlideNumber(detail.total);

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -89,9 +89,9 @@ it("renders the redesigned presenter shell and starts timer from the playpause b
       '[data-peitho-presenter="preview"] [data-slide-index="1"]'
     )?.shadowRoot?.textContent
   ).toContain("Details");
-  expect(root.querySelector('[data-peitho-presenter="notes"]')?.textContent).toContain(
-    "Opening note"
-  );
+  const notesEl = root.querySelector<HTMLElement>('[data-peitho-presenter="notes"]');
+  expect(notesEl?.textContent).toContain("Opening note");
+  expect(notesEl?.classList.contains("is-empty")).toBe(false);
   expect(root.querySelector(".left")).not.toBeNull();
   expect(root.querySelector(".right")).not.toBeNull();
   expect(
@@ -340,9 +340,9 @@ it("updates preview and shows end of deck on the last slide", async () => {
 
   window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
 
-  expect(root.querySelector('[data-peitho-presenter="notes"]')?.textContent).toContain(
-    "No notes for this slide."
-  );
+  const notesEl = root.querySelector<HTMLElement>('[data-peitho-presenter="notes"]');
+  expect(notesEl?.textContent).toContain("No notes for this slide.");
+  expect(notesEl?.classList.contains("is-empty")).toBe(true);
   expect(root.querySelector('[data-peitho-presenter="preview-end"]')?.textContent).toContain(
     "End of deck"
   );


### PR DESCRIPTION
## Summary
- In the presenter's NOTES section, when the current slide has no notes, display "No notes for this slide." in a dim color (--fg-dim) + italic
- Toggle an `is-empty` class based on whether notes are present (class-based rather than value-based)
- Add one line of CSS to the embedded CSS in `crates/peitho-core/src/render.rs`; `shell.js` has been rebuilt
- Add vitest class assertions for both the with-notes and without-notes branches

## Test plan
- [x] `cargo test --workspace` (3 times in a row)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `npm run build && npm test && npm run typecheck` (peitho-present)
- [x] E2E: open the presenter with `peitho present examples/deck.md` in Chrome and confirm that slides with notes appear in normal color / non-italic, and slides without notes appear in dim color / italic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
