### PR TITLE
ci(release): drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             os: macos-latest
-          - target: x86_64-apple-darwin
-            os: macos-13
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ tar xzf peitho-vX.Y.Z-aarch64-apple-darwin.tar.gz
 mv peitho-vX.Y.Z-aarch64-apple-darwin/peitho /usr/local/bin/
 ```
 
-Available targets: `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`. Or build from source with `cargo install --path crates/peitho` after cloning (run `cd packages/peitho-present && npm ci && npm run build` first so the shell is up to date).
+Available targets: `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu` (Intel Mac は現状 GitHub Actions の macos-13 runner キュー待ちが長すぎるため対象外)。 Or build from source with `cargo install --path crates/peitho` after cloning (run `cd packages/peitho-present && npm ci && npm run build` first so the shell is up to date).
 
 ## Usage
 

--- a/docs/plans/2026-07-04-binary-release.md
+++ b/docs/plans/2026-07-04-binary-release.md
@@ -5,9 +5,10 @@
 `git tag vX.Y.Z && git push --tags` で GitHub Release が自動生成され、以下4ターゲットの `peitho` バイナリが tar.gz で添付される状態を作る。
 
 - `aarch64-apple-darwin` (macOS arm64)
-- `x86_64-apple-darwin` (macOS x86_64)
 - `x86_64-unknown-linux-gnu` (Linux x86_64)
 - `aarch64-unknown-linux-gnu` (Linux arm64)
+
+**追記 (2026-07-04)**: `x86_64-apple-darwin` は当初対象に入れていたが、GitHub Actions の `macos-13` runner のキュー待ちがリリースをブロックするため、初回リリースからは外した。必要になったら `macos-latest` (arm64) 上で `--target x86_64-apple-darwin` のクロスビルドとして復活させる (別issue)。
 
 ## 方針
 


### PR DESCRIPTION
## Summary

- The macos-13 runner queue wait exceeded 18 minutes (on the initial v0.1.0 firing) and blocked the release, so `x86_64-apple-darwin` is removed from the release matrix
- If Intel Mac is needed later, plan to reintroduce it as a cross build on macos-latest (arm64)

## Test plan

- [ ] After merging to main, re-tag v0.1.0 and confirm the Release completes for all 3 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
