### PR TITLE
ci: bump actions to Node 24 supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -28,7 +28,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -40,8 +40,8 @@ jobs:
       run:
         working-directory: packages/peitho-present
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Verify tag matches workspace version
         run: |
           TAG="${GITHUB_REF_NAME#v}"
@@ -33,8 +33,8 @@ jobs:
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -71,7 +71,7 @@ jobs:
           cp LICENSE "${STAGE}/" 2>/dev/null || true
           tar czf "dist/${NAME}.tar.gz" -C dist "${NAME}"
           (cd dist && shasum -a 256 "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256")
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}
           path: |
@@ -84,7 +84,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
## Summary

To clear the Node 20 runtime deprecation warnings (runners are being force-migrated to Node 24), align GitHub-owned actions to the minimum major that supports Node 24.

| action | before | after | notes |
|---|---|---|---|
| actions/checkout | v4 | v5 | Node 24 support |
| actions/setup-node | v4 | v6 | Node 24 support |
| actions/upload-artifact | v4 | v6 | v6 defaults to Node 24. v7's ESM/direct-upload is not needed |
| actions/download-artifact | v4 | v6 | v6 defaults to Node 24. The v5 path change is unaffected since we specify name, and this avoids v8's digest-mismatch=error change |

## Test plan

- [ ] Confirm this PR's CI (test/lint/node) passes
- [ ] Confirm the next tag-push release workflow passes after merge with the same upgrade (release.yml can only be validated by review until it actually fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
