### PR TITLE
feat(present): unify color signals for presenter timer and agenda

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -454,11 +454,16 @@ pub fn render_presenter_index() -> String {
     .clock { display: flex; flex-direction: column; min-height: 0; }
     .clock-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 12px; padding: 12px 16px 6px; }
     .timer { display: block; font-size: 48px; font-weight: 500; letter-spacing: 0; line-height: 1; color: var(--fg); transition: color 200ms ease; font-variant-numeric: tabular-nums; }
-    .timer .planned { color: var(--fg-dim); font-weight: 400; margin-left: 8px; font-size: 18px; letter-spacing: 0; }
+    .timer .planned { color: var(--fg-dim); font-weight: 400; margin-left: 8px; font-size: 18px; letter-spacing: 0; transition: color 200ms ease; }
     .timer .overrun { color: var(--warn); font-weight: 500; margin-left: 8px; font-size: 18px; letter-spacing: 0; }
     .clock[data-peitho-state="paused"] .timer { color: var(--pause); }
     .clock[data-peitho-state="stopped"] .timer { color: var(--fg-dim); }
-    [data-peitho-presenter="timer"][data-peitho-overrun] { color: var(--warn); }
+    .clock[data-peitho-state="running"][data-peitho-urgency="warning"] .timer,
+    .clock[data-peitho-state="running"][data-peitho-urgency="warning"] .timer .planned { color: var(--pause); }
+    .clock[data-peitho-state="running"][data-peitho-urgency="urgent"] .timer,
+    .clock[data-peitho-state="running"][data-peitho-urgency="urgent"] .timer .planned { color: var(--warn); }
+    .clock[data-peitho-state][data-peitho-urgency="overrun"] .timer,
+    .clock[data-peitho-state][data-peitho-urgency="overrun"] .timer .planned { color: var(--warn); }
     .state-pill { display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px; border: 1px solid var(--line); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--fg-mute); transition: color 150ms ease, border-color 150ms ease; white-space: nowrap; }
     .state-dot { width: 6px; height: 6px; background: var(--fg-dim); border-radius: 50%; transition: background 150ms ease, box-shadow 150ms ease; }
     .state-pill[data-peitho-state="running"] { color: var(--accent); border-color: color-mix(in oklch, var(--accent) 45%, var(--line)); }
@@ -911,7 +916,8 @@ mod tests {
         assert!(html.contains(r#".tracker [data-peitho-marker="rabbit"] { top: -6px; }"#));
         assert!(html.contains(r#".tracker [data-peitho-marker="turtle"] { bottom: -6px; }"#));
         assert!(!html.contains(".mark"));
-        assert!(html.contains(r#"[data-peitho-presenter="timer"][data-peitho-overrun]"#));
+        assert!(html.contains(r#"[data-peitho-urgency="urgent"]"#));
+        assert!(!html.contains(r#"[data-peitho-presenter="timer"][data-peitho-overrun]"#));
         assert!(!html.contains(".peitho-time-tracker { position: absolute"));
         assert!(!html.contains("bottom: 0; height: 6px"));
     }

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -456,7 +456,7 @@ pub fn render_presenter_index() -> String {
     .timer { display: block; font-size: 48px; font-weight: 500; letter-spacing: 0; line-height: 1; color: var(--fg); transition: color 200ms ease; font-variant-numeric: tabular-nums; }
     .timer .planned { color: var(--fg-dim); font-weight: 400; margin-left: 8px; font-size: 18px; letter-spacing: 0; transition: color 200ms ease; }
     .timer .overrun { color: var(--warn); font-weight: 500; margin-left: 8px; font-size: 18px; letter-spacing: 0; }
-    .clock[data-peitho-state="paused"] .timer { color: var(--pause); }
+    .clock[data-peitho-state="paused"] .timer { color: var(--fg-dim); }
     .clock[data-peitho-state="stopped"] .timer { color: var(--fg-dim); }
     .clock[data-peitho-state="running"][data-peitho-urgency="warning"] .timer,
     .clock[data-peitho-state="running"][data-peitho-urgency="warning"] .timer .planned { color: var(--pause); }
@@ -510,8 +510,8 @@ pub fn render_presenter_index() -> String {
     [data-peitho-agenda-state="current"] [data-peitho-agenda-time] { color: var(--accent); }
     [data-peitho-agenda-state="done"][data-peitho-agenda-outcome="under"] [data-peitho-agenda-time],
     [data-peitho-agenda-state="done"][data-peitho-agenda-outcome="under"] [data-peitho-agenda-delta] { color: color-mix(in oklch, var(--accent) 72%, var(--fg-mute)); }
-    [data-peitho-agenda-state="done"][data-peitho-agenda-outcome="over"] [data-peitho-agenda-time],
-    [data-peitho-agenda-state="done"][data-peitho-agenda-outcome="over"] [data-peitho-agenda-delta] { color: var(--warn); }
+    [data-peitho-agenda-state][data-peitho-agenda-outcome="over"] [data-peitho-agenda-time],
+    [data-peitho-agenda-state][data-peitho-agenda-outcome="over"] [data-peitho-agenda-delta] { color: var(--warn); }
     .controls { display: grid; grid-template-columns: minmax(max-content, 1fr) auto auto auto auto auto; align-items: center; gap: 6px; padding: 10px 8px; border-top: 1px solid var(--line-soft); background: color-mix(in oklch, var(--bg-elev) 92%, transparent); margin-top: auto; }
     .btn { appearance: none; border: 1px solid var(--line); background: transparent; color: var(--fg-mute); padding: 4px 8px; font: inherit; font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; transition: background 90ms ease, color 90ms ease, border-color 90ms ease, transform 60ms ease, box-shadow 90ms ease; min-width: 0; position: relative; overflow: hidden; -webkit-tap-highlight-color: transparent; }
     .btn .k { color: var(--fg-dim); font-family: "Geist Mono", ui-monospace, monospace; font-size: 10px; letter-spacing: 0.04em; text-transform: none; }
@@ -956,9 +956,16 @@ mod tests {
         assert!(html.contains("min-width: 6ch"));
         assert!(html
             .contains(r#"[data-peitho-agenda-state="done"][data-peitho-agenda-outcome="under"]"#));
-        assert!(html
-            .contains(r#"[data-peitho-agenda-state="done"][data-peitho-agenda-outcome="over"]"#));
+        assert!(html.contains(
+            r#"[data-peitho-agenda-state][data-peitho-agenda-outcome="over"] [data-peitho-agenda-time]"#
+        ));
         assert!(html.contains(".clock { display: flex; flex-direction: column;"));
+        assert!(
+            html.contains(r#".clock[data-peitho-state="paused"] .timer { color: var(--fg-dim); }"#)
+        );
+        assert!(
+            !html.contains(r#".clock[data-peitho-state="paused"] .timer { color: var(--pause); }"#)
+        );
         assert!(html.contains(".controls {"));
         assert!(html.contains("margin-top: auto"));
         assert!(!html.contains(".agenda"));

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -92,6 +92,7 @@ fn present_no_serve_writes_presenter_html() {
     let presenter = fs::read_to_string(cache.join("presenter.html")).unwrap();
     assert!(presenter.contains("mountPresenterView"));
     assert!(presenter.contains(".peitho-presenter-pane"));
+    assert!(presenter.contains(r#"[data-peitho-urgency="urgent"]"#));
     assert!(fs::read_to_string(cache.join("present.html"))
         .unwrap()
         .contains("installPresentationControls"));

--- a/docs/plans/2026-07-05-timer-urgency.md
+++ b/docs/plans/2026-07-05-timer-urgency.md
@@ -1,14 +1,27 @@
-# Presenter timer urgency colors (Issue #107)
+# Presenter view color signals (Issue #107 +)
 
 ## 意図
 
-プレゼンター画面のタイマーは、残り時間に応じて色を変え、発表者が一目で残り時間の逼迫を認識できるようにする。
+プレゼンター画面のタイマー系表示で「色シグナル = 残り時間」の意味を一貫させる。当初は Issue #107（timer 色変化）だけを扱う予定だったが、実装レビュー中に pause/urgency の色被り、および agenda セクションの current 経過超過が色に反映されない問題が浮上したため、同じPRで整理する。
 
-- 残り3分〜1分: warning（黄/アンバー）
-- 残り1分〜0分: urgent（赤、overrunと同色。区別は state="running" ゲートで表現）
-- 経過 ≥ 計画時間: overrun（赤、既存の `--warn`）
+### タイマーの残り時間
+
+- 残り3分〜1分: warning（アンバー = `--pause` を再利用）
+- 残り1分〜0分: urgent（赤 = `--warn`）
+- 経過 ≥ 計画時間: overrun（赤 = `--warn`、state問わず）
 - `plannedDurationMs` 未設定: 中立色（現状維持）
 - 計画時間が短い場合、閾値をスキップし最も強い該当状態から開始（例:2分デックはwarning開始、40秒デックはurgent開始）
+
+### pause 時のタイマー色
+
+pause 時の timer は `--fg-dim`（stopped と同色）にする。以前はアンバー（`--pause`）だったが、これは warning urgency と色が衝突し、「amberが灯った時に一時停止か残り3分か区別できない」問題があった。色チャネルを「残り時間」に一本化し、pause は「進行が止まっている」を dim で表現する。pause と stopped の識別は state pill のドット色（pause=amber, stopped=dim）が担う。
+
+### agenda セクションタイマー
+
+- current かつ actual > planned → 行に `outcome="over"` を付け、time/delta を赤（`--warn`）表示
+- done は従来通り under/over 両方の outcome を付ける
+- upcoming は outcome なし
+- CSS の over ルールは `[data-peitho-agenda-state][data-peitho-agenda-outcome="over"]` の compound selector にして、current の青ルール (0,2,0) を specificity (0,3,0) で明示的に上回る
 
 ## 設計
 

--- a/docs/plans/2026-07-05-timer-urgency.md
+++ b/docs/plans/2026-07-05-timer-urgency.md
@@ -1,0 +1,132 @@
+# Presenter timer urgency colors (Issue #107)
+
+## 意図
+
+プレゼンター画面のタイマーは、残り時間に応じて色を変え、発表者が一目で残り時間の逼迫を認識できるようにする。
+
+- 残り3分〜1分: warning（黄/アンバー）
+- 残り1分〜0分: urgent（赤、overrunと同色。区別は state="running" ゲートで表現）
+- 経過 ≥ 計画時間: overrun（赤、既存の `--warn`）
+- `plannedDurationMs` 未設定: 中立色（現状維持）
+- 計画時間が短い場合、閾値をスキップし最も強い該当状態から開始（例:2分デックはwarning開始、40秒デックはurgent開始）
+
+## 設計
+
+### 単一の派生関数と単一のDOM属性
+
+タイマーの表示状態を1つの純関数から派生させる。`data-peitho-urgency` 属性を1つだけ切り替える。
+
+```ts
+export type TimerUrgency = "normal" | "warning" | "urgent" | "overrun";
+
+export function urgencyFor(
+  elapsedMs: number,
+  plannedDurationMs: number | null
+): TimerUrgency;
+```
+
+閾値:
+- `plannedDurationMs == null` → `"normal"`
+- `elapsedMs > plannedDurationMs` → `"overrun"`
+- 残り時間 `remaining = plannedDurationMs - elapsedMs` に対して:
+  - `remaining ≤ 60_000` → `"urgent"`
+  - `remaining ≤ 180_000` → `"warning"`
+  - それ以外 → `"normal"`
+
+境界の閉じ方は `≤`（残り1分ちょうど時点でurgentに切り替わる）。
+
+### なぜ単一属性か（3レンズ）
+
+- **long-term**: 将来閾値を増やしても `urgencyFor()` 1関数の変更で済む。CSSも属性値マッチ1箇所で完結。
+- **type-safety**: `type TimerUrgency` union型で網羅性保証。CSSも `[data-peitho-urgency="..."]` 4値をカバー。
+- **root-cause**: 「経過時間と計画時間からの派生値」というただ1つの派生を、ただ1つの純関数から作る。upstream。
+
+### 既存の `[data-peitho-overrun]` 属性の扱い
+
+- `[data-peitho-presenter="timer"][data-peitho-overrun]` は既に存在し、色を `var(--warn)` に切り替えている。この属性は `.overrun` span（`+MM:SS` の表示）の可視条件でもあると読めるが、実は `.overrun` span は `.timer` の子要素として直接 `color: var(--warn)` を持つので、属性トグルは色目的専用。
+- `urgencyFor` で `"overrun"` を返せば `data-peitho-urgency="overrun"` が同じ色を実現するため、**`data-peitho-overrun` の切り替えは撤去**する（単一属性に統一）。既存の `[data-peitho-presenter="timer"][data-peitho-overrun]` セレクタも撤去し、`.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer` に置き換える。
+- `.peitho-time-tracker[data-peitho-overrun]` はtracker側の色切替なので**そのまま残す**（別コンポーネント）。
+
+### CSS変更
+
+`crates/peitho-core/src/render.rs` の `render_presenter_index()` 内 `<style>` ブロックに追加/変更:
+
+```css
+.clock[data-peitho-urgency="warning"] .timer,
+.clock[data-peitho-urgency="warning"] .timer .planned { color: var(--pause); }
+.clock[data-peitho-urgency="urgent"] .timer,
+.clock[data-peitho-urgency="urgent"] .timer .planned { color: var(--warn); }
+.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer,
+.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer .planned { color: var(--warn); }
+```
+
+既存の `--pause`（アンバー）と `--warn`（赤）を直接参照する。値は「urgency-warning=pause」「urgency-urgent=overrun=warn」と一致するため、独立変数を作らず参照を統一する（overrunルールは元から `--warn` を直接使っていて、独立変数を作ると同PR内で不整合になる）。
+
+既存の `.clock[data-peitho-state="paused"] .timer` と `.clock[data-peitho-state="stopped"] .timer` は残す。urgencyより timer state の色（paused=amber, stopped=dim）が優先されると自然（停止中に赤くしても意味がない）。
+
+**優先順位の実装:** CSSは後勝ちなので、`:root`セレクタで書き終えた後に state セレクタを urgency の後に置く。あるいは `.clock[data-peitho-state="running"][data-peitho-urgency="warning"]` のように running時のみ urgency を適用する形が明示的で安全 → こちらを採用。
+
+```css
+.clock[data-peitho-state="running"][data-peitho-urgency="warning"] .timer,
+.clock[data-peitho-state="running"][data-peitho-urgency="warning"] .timer .planned { color: var(--pause); }
+.clock[data-peitho-state="running"][data-peitho-urgency="urgent"] .timer,
+.clock[data-peitho-state="running"][data-peitho-urgency="urgent"] .timer .planned { color: var(--warn); }
+.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer,
+.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer .planned { color: var(--warn); }
+```
+
+注: overrunだけは stopped/paused でも赤にしたい（超過してから停止 → 依然として超過を知らせる）。→ overrunに限りstate値を限定しない compound セレクタを追加:
+
+```css
+.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer,
+.clock[data-peitho-state][data-peitho-urgency="overrun"] .timer .planned { color: var(--warn); }
+```
+
+`[data-peitho-state]` も含めて state ルールより specificity を高くし、stopped/paused でも overrun は赤、それ以外は state色（stopped=dim, paused=amber）が勝つ。
+
+### TypeScript側の統合
+
+`packages/peitho-present/src/presenter.ts`:
+
+- `urgencyFor()` を別モジュール `timerUrgency.ts`（新設）にエクスポートし、presenterから import
+- `tick()` で `data-peitho-urgency` を `clockRoot` に set:
+  ```ts
+  clockRoot.dataset.peithoUrgency = urgencyFor(elapsedMs, plannedDurationMs);
+  ```
+- 既存の `timerRoot.toggleAttribute("data-peitho-overrun", ...)` は撤去
+
+### テスト（TDD）
+
+`packages/peitho-present/test/timerUrgency.test.ts`（新規）:
+- `plannedDurationMs == null` → `"normal"`
+- 残り時間 > 3分 → `"normal"`
+- 残り時間 = 3分ちょうど → `"warning"`
+- 残り時間 = 1分1秒 → `"warning"`
+- 残り時間 = 1分ちょうど → `"urgent"`
+- 残り時間 = 1秒 → `"urgent"`
+- 残り時間 = 0 → `"urgent"`（elapsed == planned はまだoverrunではない、既存 `isOverrun` の `>` 条件と合わせる）
+- elapsed > planned → `"overrun"`
+- planned = 2分 → elapsed=0で`"warning"`（3分閾値は範囲外なので skip、warning から開始）
+- planned = 30秒 → elapsed=0で`"urgent"`（両閾値をskip、urgentから開始）
+
+`packages/peitho-present/test/presenter.test.ts` に追加テスト:
+- presenterでtickすると `clockRoot.dataset.peithoUrgency` が期待値に更新される
+- planned=10分, elapsed=8分1秒 → urgency="warning"
+- planned=10分, elapsed=9分1秒 → urgency="urgent"
+- planned=10分, elapsed=10分1秒 → urgency="overrun"
+- planned=null → urgency="normal"
+
+### 影響範囲
+
+- `packages/peitho-present/src/timerUrgency.ts`（新規）
+- `packages/peitho-present/src/presenter.ts`（tick更新）
+- `packages/peitho-present/test/timerUrgency.test.ts`（新規）
+- `packages/peitho-present/test/presenter.test.ts`（追加テスト）
+- `crates/peitho-core/src/render.rs`（CSS追加、色変数追加）
+- `crates/peitho/tests/present.rs`（presenter HTMLに新CSSセレクタが含まれるかのアサーション追加、必要に応じ）
+- `packages/peitho-present/dist/shell.js`（`npm run build` で再生成、コミット）
+
+### 検証
+
+- E2Eは `docs/plans/2026-07-04-presenter-redesign.md` の手順に準ずる
+- `plannedDurationMs = 300_000` の10分デックで、開始→3分経過（残り2分）で黄、4分経過（残り1分）でオレンジ、6分経過で赤を目視確認

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -934,6 +934,16 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
   };
 }
 
+// src/timerUrgency.ts
+function urgencyFor(elapsedMs, plannedDurationMs) {
+  if (plannedDurationMs == null) return "normal";
+  if (isOverrun(elapsedMs, plannedDurationMs)) return "overrun";
+  const remainingMs = plannedDurationMs - elapsedMs;
+  if (remainingMs <= 6e4) return "urgent";
+  if (remainingMs <= 18e4) return "warning";
+  return "normal";
+}
+
 // src/presenter.ts
 function formatSeconds(totalSeconds) {
   const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, "0");
@@ -1177,10 +1187,10 @@ async function mountPresenterView(options) {
   function tick() {
     const elapsedMs = mainShell.elapsedMs();
     renderPresenterTimer(doc, timerRoot, elapsedMs, plannedDurationMs);
-    timerRoot.toggleAttribute(
-      "data-peitho-overrun",
-      plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)
-    );
+    const nextUrgency = urgencyFor(elapsedMs, plannedDurationMs);
+    if (clockRoot.dataset.peithoUrgency !== nextUrgency) {
+      clockRoot.dataset.peithoUrgency = nextUrgency;
+    }
     setTimerStateChrome(deriveTimerState(mainShell));
   }
   function updateFromSlide(detail) {

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -280,8 +280,9 @@ function createRow(doc, section) {
 function updateRow(view, index, currentSection, actual) {
   const state = agendaState(index, currentSection);
   view.row.dataset.peithoAgendaState = state;
-  if (state === "done") {
-    view.row.dataset.peithoAgendaOutcome = outcomeFor(actual, view.section.plannedDurationMs);
+  const outcome = state === "upcoming" ? null : outcomeFor(actual, view.section.plannedDurationMs);
+  if (outcome === "over" || state === "done" && outcome === "under") {
+    view.row.dataset.peithoAgendaOutcome = outcome;
   } else {
     delete view.row.dataset.peithoAgendaOutcome;
   }

--- a/packages/peitho-present/src/agenda.ts
+++ b/packages/peitho-present/src/agenda.ts
@@ -169,8 +169,10 @@ function updateRow(
 ): void {
   const state = agendaState(index, currentSection);
   view.row.dataset.peithoAgendaState = state;
-  if (state === "done") {
-    view.row.dataset.peithoAgendaOutcome = outcomeFor(actual, view.section.plannedDurationMs);
+  const outcome =
+    state === "upcoming" ? null : outcomeFor(actual, view.section.plannedDurationMs);
+  if (outcome === "over" || (state === "done" && outcome === "under")) {
+    view.row.dataset.peithoAgendaOutcome = outcome;
   } else {
     delete view.row.dataset.peithoAgendaOutcome;
   }

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -9,6 +9,7 @@ import {
   type TimerControlDetail
 } from "./shell";
 import { installSyncBridge, type SyncChannelFactory } from "./sync";
+import { urgencyFor } from "./timerUrgency";
 import { installTimeTracker, isOverrun, isValidDurationMs } from "./timeTracker";
 
 export type PresenterOptions = {
@@ -302,10 +303,10 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
   function tick(): void {
     const elapsedMs = mainShell.elapsedMs();
     renderPresenterTimer(doc, timerRoot, elapsedMs, plannedDurationMs);
-    timerRoot.toggleAttribute(
-      "data-peitho-overrun",
-      plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)
-    );
+    const nextUrgency = urgencyFor(elapsedMs, plannedDurationMs);
+    if (clockRoot.dataset.peithoUrgency !== nextUrgency) {
+      clockRoot.dataset.peithoUrgency = nextUrgency;
+    }
     setTimerStateChrome(deriveTimerState(mainShell));
   }
 

--- a/packages/peitho-present/src/timerUrgency.ts
+++ b/packages/peitho-present/src/timerUrgency.ts
@@ -1,0 +1,16 @@
+import { isOverrun } from "./timeTracker";
+
+export type TimerUrgency = "normal" | "warning" | "urgent" | "overrun";
+
+export function urgencyFor(
+  elapsedMs: number,
+  plannedDurationMs: number | null
+): TimerUrgency {
+  if (plannedDurationMs == null) return "normal";
+  if (isOverrun(elapsedMs, plannedDurationMs)) return "overrun";
+
+  const remainingMs = plannedDurationMs - elapsedMs;
+  if (remainingMs <= 60_000) return "urgent";
+  if (remainingMs <= 180_000) return "warning";
+  return "normal";
+}

--- a/packages/peitho-present/test/agenda.test.ts
+++ b/packages/peitho-present/test/agenda.test.ts
@@ -146,6 +146,83 @@ it("renders agenda header and rows with mock-compatible structure", () => {
   expect(rows[1].hasAttribute("data-peitho-agenda-outcome")).toBe(false);
 });
 
+it("marks the current agenda row over only after exceeding planned duration", () => {
+  let elapsed = 0;
+  const root = document.createElement("div");
+  const cleanup = installAgenda({
+    root,
+    shell: shell({ elapsedMs: () => elapsed }),
+    sections: [{ name: "Setup", startIndex: 0, endIndex: 0, plannedDurationMs: 60_000 }],
+    bus: new EventTarget(),
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  const row = root.querySelector<HTMLElement>("[data-peitho-agenda-row]")!;
+  elapsed = 30_000;
+  vi.advanceTimersByTime(250);
+  expect(row.dataset.peithoAgendaState).toBe("current");
+  expect(row.dataset.peithoAgendaOutcome).toBeUndefined();
+
+  elapsed = 70_000;
+  vi.advanceTimersByTime(250);
+  expect(row.dataset.peithoAgendaState).toBe("current");
+  expect(row.dataset.peithoAgendaOutcome).toBe("over");
+});
+
+it("keeps done agenda row outcomes for under and over durations", () => {
+  let elapsed = 0;
+  let currentIndex = 0;
+  const root = document.createElement("div");
+  const bus = new EventTarget();
+  const cleanup = installAgenda({
+    root,
+    shell: {
+      get currentIndex() {
+        return currentIndex;
+      },
+      elapsedMs: () => elapsed,
+      startedAt: () => 100
+    },
+    sections: [
+      { name: "Setup", startIndex: 0, endIndex: 0, plannedDurationMs: 60_000 },
+      { name: "Demo", startIndex: 1, endIndex: 1, plannedDurationMs: 60_000 },
+      { name: "Close", startIndex: 2, endIndex: 2, plannedDurationMs: 60_000 }
+    ],
+    bus,
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  elapsed = 30_000;
+  vi.advanceTimersByTime(250);
+  currentIndex = 1;
+  bus.dispatchEvent(
+    new CustomEvent<SlideChangeDetail>("peitho:slidechange", {
+      detail: { key: "demo", index: 1, total: 3, previousIndex: 0 }
+    })
+  );
+  elapsed = 100_000;
+  vi.advanceTimersByTime(250);
+  currentIndex = 2;
+  bus.dispatchEvent(
+    new CustomEvent<SlideChangeDetail>("peitho:slidechange", {
+      detail: { key: "close", index: 2, total: 3, previousIndex: 1 }
+    })
+  );
+
+  const rows = Array.from(root.querySelectorAll<HTMLElement>("[data-peitho-agenda-row]"));
+  expect(rows.map((row) => row.dataset.peithoAgendaState)).toEqual([
+    "done",
+    "done",
+    "current"
+  ]);
+  expect(rows[0].dataset.peithoAgendaOutcome).toBe("under");
+  expect(rows[1].dataset.peithoAgendaOutcome).toBe("over");
+});
+
 it("accumulates elapsed deltas into the current section and resumes when returning", () => {
   let elapsed = 0;
   let currentIndex = 0;
@@ -206,7 +283,7 @@ it("accumulates elapsed deltas into the current section and resumes when returni
 
   rows = Array.from(root.querySelectorAll<HTMLElement>("[data-peitho-agenda-row]"));
   expect(rows[0].dataset.peithoAgendaState).toBe("current");
-  expect(rows[0].hasAttribute("data-peitho-agenda-outcome")).toBe(false);
+  expect(rows[0].dataset.peithoAgendaOutcome).toBe("over");
   expect(rows[1].dataset.peithoAgendaState).toBe("upcoming");
   expect(rows[1].hasAttribute("data-peitho-agenda-outcome")).toBe(false);
 

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -179,6 +179,38 @@ it("keeps legacy presenter timer text when manifest has no time", async () => {
   expect(root.querySelector("[data-peitho-time-tracker]")).toBeNull();
 });
 
+it.each([
+  ["normal (no planned)", null, 65_000, "normal"],
+  ["normal (planned, plenty of runway)", 600_000, 60_000, "normal"],
+  ["warning", 600_000, 481_000, "warning"],
+  ["urgent", 600_000, 541_000, "urgent"],
+  ["overrun", 600_000, 601_000, "overrun"]
+] as const)(
+  "updates presenter timer urgency to %s on tick",
+  async (_label, plannedDurationMs, elapsedMs, expected) => {
+    let now = 1_000;
+    const root = document.createElement("main");
+    const { factory } = mockSyncChannelFactory();
+    const view = await mountPresenterView({
+      root,
+      notes,
+      fetcher: standardFetch({ plannedDurationMs }),
+      window,
+      now: () => now,
+      syncChannelFactory: factory
+    });
+    views.push(view);
+
+    root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
+    now = 1_000 + elapsedMs;
+    view.tick();
+
+    expect(
+      root.querySelector<HTMLElement>('[data-peitho-presenter="clock"]')?.dataset.peithoUrgency
+    ).toBe(expected);
+  }
+);
+
 it("keeps agenda slot empty when manifest has no sections", async () => {
   const root = document.createElement("main");
   const view = await mountPresenterView({
@@ -323,7 +355,6 @@ it("marks presenter timer as overrun after the planned duration", async () => {
   expect(timer.textContent).toBe("01:00 / 01:00 +00:01");
   expect(timer.querySelector(".planned")?.textContent).toBe(" / 01:00");
   expect(timer.querySelector(".overrun")?.textContent).toBe(" +00:01");
-  expect(timer.hasAttribute("data-peitho-overrun")).toBe(true);
 });
 
 it("updates preview and shows end of deck on the last slide", async () => {

--- a/packages/peitho-present/test/timerUrgency.test.ts
+++ b/packages/peitho-present/test/timerUrgency.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from "vitest";
+import { urgencyFor } from "../src/timerUrgency";
+
+it.each([
+  ["planned duration is unset", 120_000, null, "normal"],
+  ["remaining time is above three minutes", 119_999, 300_000, "normal"],
+  ["remaining time is exactly three minutes", 120_000, 300_000, "warning"],
+  ["remaining time is one minute and one second", 239_000, 300_000, "warning"],
+  ["remaining time is exactly one minute", 240_000, 300_000, "urgent"],
+  ["remaining time is one second", 299_000, 300_000, "urgent"],
+  ["remaining time is zero", 300_000, 300_000, "urgent"],
+  ["elapsed time exceeds the planned duration", 300_001, 300_000, "overrun"],
+  ["two minute plans start at warning", 0, 120_000, "warning"],
+  ["thirty second plans start at urgent", 0, 30_000, "urgent"]
+] as const)("returns %s", (_label, elapsedMs, plannedDurationMs, expected) => {
+  expect(urgencyFor(elapsedMs, plannedDurationMs)).toBe(expected);
+});


### PR DESCRIPTION
## Summary

Refactor the presenter view's color signals so that the color channel consistently means "how much time is left / how much you've overrun." Grew out of Issue #107 (timer color by remaining time), and picked up two follow-ups the review surfaced.

### Timer urgency (Issue #107)

- New pure function `urgencyFor(elapsedMs, plannedDurationMs)` returns `normal | warning | urgent | overrun`. Thresholds: remaining ≤ 3 min → warning, remaining ≤ 1 min → urgent, elapsed > planned → overrun (delegates to the existing `isOverrun`, so the boundary has a single source of truth).
- Presenter tick writes a single `data-peitho-urgency` attribute on `.clock`, guarded so it only writes when the value changes.
- CSS uses compound selectors for state precedence:
  - `warning`/`urgent` require `[data-peitho-state="running"]` — while paused/stopped, the state color wins.
  - `overrun` uses `[data-peitho-state][data-peitho-urgency="overrun"]` — specificity (0,4,0) beats state defaults so overrun stays red in any state without relying on CSS source order.
- Reuse existing `--pause` (warning) and `--warn` (urgent, overrun) instead of adding new custom properties.
- `.timer .planned` gets a matching `transition: color 200ms ease` so parent and child fade together.
- Legacy `data-peitho-overrun` attribute on the timer element is retired; the tracker's own `data-peitho-overrun` is unaffected.

### Paused timer color

- The paused timer now uses `--fg-dim` (same as stopped) instead of `--pause` (amber). Previously the amber signal meant either "paused" or "3 minutes left" (warning urgency reuses `--pause`), so a lit amber timer was ambiguous. Color signal is now dedicated to remaining time; the state pill dot (amber for paused, dim for stopped) keeps paused/stopped visually distinguishable.

### Agenda: current section overrun turns red

- Previously `outcome="over"` was only applied to `done` rows, so an actively running section past its planned duration stayed blue. Now `current` also picks up `outcome="over"` when actual exceeds planned.
- The over CSS rule is generalized to `[data-peitho-agenda-state][data-peitho-agenda-outcome="over"]` (specificity 0,3,0) so it wins over the `current` blue rule (0,2,0) by specificity, not source order.

## Design notes

- Warning uses the same `--pause` amber as the state color used to. They no longer overlap because paused timers are now dim, so the color channel is single-purpose. The state pill still carries the state label ("Running"/"Paused"/"Stopped") + a colored dot.
- Urgent and overrun share `--warn` (red). Distinction comes from the `+MM:SS` overrun span (visible only when elapsed > planned) and from the tracker bar recoloring to `--warn-soft` on overrun.
- Design record: `docs/plans/2026-07-05-timer-urgency.md`.

Closes #107

## Test plan

- [x] `cargo test --workspace` (x3, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `cd packages/peitho-present && npm test && npm run build && npm run typecheck` (131 tests pass)
- [x] `git diff --exit-code packages/peitho-present/dist/shell.js` (shell.js build is deterministic)
- [ ] E2E in a real browser with a 10-minute deck:
  - First 7 min → neutral color
  - 7:00 → amber (warning)
  - 9:00 → red (urgent)
  - Past 10:00 → red with `+MM:SS` suffix
  - Pause during warning/urgent → timer turns dim (state pill still shows "Paused"); resume → color returns
  - Agenda: run past a section's planned time → the current row's time/delta turn red before section advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
