### PR TITLE
feat(present): redesign presenter End of deck placeholder

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -448,9 +448,24 @@ pub fn render_presenter_index() -> String {
     .card-head { display: flex; align-items: center; justify-content: space-between; padding: 8px 14px; border-bottom: 1px solid var(--line-soft); color: var(--fg-dim); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; }
     .card-head .badge { color: var(--fg-mute); letter-spacing: 0; text-transform: none; font-size: 11px; }
     .next-wrap { padding: 12px; }
-    .next-preview { position: relative; aspect-ratio: 16 / 9; background: var(--bg-slide); border: 1px solid var(--line-soft); overflow: hidden; }
+    .next-preview { position: relative; aspect-ratio: 16 / 9; background: var(--bg-slide); border: 1px solid var(--line-soft); overflow: hidden; container-type: inline-size; }
     .next-preview > [data-peitho-presenter="preview"] { position: absolute; inset: 0; }
-    [data-peitho-presenter="preview-end"] { position: absolute; inset: 0; margin: 0; display: flex; align-items: center; justify-content: center; background: var(--bg-slide); color: var(--fg-dim); font-size: 18px; }
+    [data-peitho-presenter="preview-end"] { position: absolute; inset: 0; margin: 0; box-sizing: border-box; padding: 9.6% 13.5%; display: flex; flex-direction: column; background: var(--bg-slide); color: var(--fg); }
+    [data-peitho-presenter="preview-end"] .eod-top,
+    [data-peitho-presenter="preview-end"] .eod-bottom { display: flex; justify-content: space-between; font-size: 10px; line-height: 1; letter-spacing: 0.16em; text-transform: uppercase; color: var(--fg-dim); }
+    [data-peitho-presenter="preview-end"] .eod-center { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4.5%; }
+    [data-peitho-presenter="preview-end"] .eod-fin { display: flex; align-items: center; gap: 16px; font-size: 10px; line-height: 1; letter-spacing: 0.24em; text-transform: uppercase; color: var(--fg-dim); }
+    [data-peitho-presenter="preview-end"] .eod-rule { display: block; width: 42px; height: 1px; background: var(--line); }
+    [data-peitho-presenter="preview-end"] .eod-title { font-size: 8.3cqi; font-weight: 600; line-height: 1; letter-spacing: -0.015em; color: var(--fg); }
+    @media (prefers-reduced-motion: no-preference) {
+      [data-peitho-presenter="preview-end"]:not([hidden]) { animation: eod-fade-in 500ms ease-out both; }
+      [data-peitho-presenter="preview-end"]:not([hidden]) .eod-rule:first-child { transform-origin: right center; animation: eod-rule-in 500ms cubic-bezier(0.6, 0, 0.2, 1) 150ms both; }
+      [data-peitho-presenter="preview-end"]:not([hidden]) .eod-rule:last-child { transform-origin: left center; animation: eod-rule-in 500ms cubic-bezier(0.6, 0, 0.2, 1) 150ms both; }
+      [data-peitho-presenter="preview-end"]:not([hidden]) .eod-title { animation: eod-title-in 550ms cubic-bezier(0.2, 0, 0.2, 1) 350ms both; }
+    }
+    @keyframes eod-fade-in { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes eod-rule-in { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+    @keyframes eod-title-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
     .clock { display: flex; flex-direction: column; min-height: 0; }
     .clock-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 12px; padding: 12px 16px 6px; }
     .timer { display: block; font-size: 48px; font-weight: 500; letter-spacing: 0; line-height: 1; color: var(--fg); transition: color 200ms ease; font-variant-numeric: tabular-nums; }

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -1060,7 +1060,14 @@ async function mountPresenterView(options) {
           <div class="next-wrap">
             <div class="next-preview">
               <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
-              <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+              <div data-peitho-presenter="preview-end" hidden>
+                <div class="eod-top mono"><span>Peitho</span></div>
+                <div class="eod-center">
+                  <div class="eod-fin mono"><span class="eod-rule"></span><span>Fin</span><span class="eod-rule"></span></div>
+                  <div class="eod-title">End of deck</div>
+                </div>
+                <div class="eod-bottom mono"><span>&mdash;</span><span>&mdash;</span></div>
+              </div>
             </div>
           </div>
         </section>

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -165,7 +165,14 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
           <div class="next-wrap">
             <div class="next-preview">
               <div class="peitho-presenter-pane" data-peitho-presenter="preview"></div>
-              <p data-peitho-presenter="preview-end" hidden>End of deck</p>
+              <div data-peitho-presenter="preview-end" hidden>
+                <div class="eod-top mono"><span>Peitho</span></div>
+                <div class="eod-center">
+                  <div class="eod-fin mono"><span class="eod-rule"></span><span>Fin</span><span class="eod-rule"></span></div>
+                  <div class="eod-title">End of deck</div>
+                </div>
+                <div class="eod-bottom mono"><span>&mdash;</span><span>&mdash;</span></div>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Replaces the flat centered `End of deck` text in the presenter's next-slide preview with a three-layer colophon: `Peitho` brand mark (top), `— Fin —` divider + `End of deck` title (center), bookend dashes (bottom).
- Title uses container-relative sizing (`cqi`) so it scales with the preview frame; entrance animation is gated on `prefers-reduced-motion` and **settles** — no infinite loop while the presenter sits on the last slide.
- Design produced in Claude Design (project: `peitho presenter — End of deck screen`), then ported into the presenter's inline stylesheet in `crates/peitho-core/src/render.rs` and the shell markup in `packages/peitho-present/src/presenter.ts`.

## Design decisions
- **Palette:** reuses the existing presenter tokens (`--bg-slide`, `--fg`, `--fg-dim`, `--line`). No new hues. `--warn` deliberately not used (it means time-urgency elsewhere).
- **Number/status rows dropped from designer proposal:** the `Slide 24 · 24` counter was redundant with the existing `next-position` badge in the card header; the `Awaiting Q & A` status row was too presumptuous (not every deck ends in Q&A).
- **Container queries:** `.next-preview` now sets `container-type: inline-size` so the End of deck title tracks the actual preview width instead of being pinned at 40px.

## Test plan
- [x] `cargo test --workspace` (x3) — 154 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bindings/` drift check — clean
- [x] `packages/peitho-present`: `npm run build`, `npm test` (131 passed), `npm run typecheck` — clean
- [x] `dist/shell.js` drift committed
- [ ] **Visual check on real Chrome**: open a deck, navigate to the last slide, confirm the End of deck panel renders correctly, entrance animation plays once, and the panel doesn't loop while sitting on the final slide. (jsdom cannot verify `cqi` sizing or animation replay on `hidden` toggle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)