### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.3.0 to trigger the tag-driven release workflow

## Notable changes since v0.2.0
- feat(images): support Markdown images with typed asset pipeline (#120, resolves #117 and #106)
- feat(present): redesign presenter End of deck placeholder (#119)
- feat(present): unify color signals across timer and agenda (#118)
- feat(present): color presenter timer by remaining time (#118)

## Test plan
- [ ] Merge, then tag v0.3.0 on main to kick off the release workflow