### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -119,6 +119,7 @@ struct PresentOptions {
 
 #[derive(Debug, Parser)]
 #[command(name = "peitho")]
+#[command(version)]
 #[command(about = "Build HTML-native presentations from Markdown")]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- Add `peitho --version`. Uses clap's `#[command(version)]` to emit the version from Cargo.toml directly

## Test plan
- [x] `cargo run -- --version` → `peitho 0.4.0`
- [x] `cargo test --workspace` (3 times in a row)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `npm run build && npm test && npm run typecheck` (packages/peitho-present)
- [x] No drift in bindings/ or dist/shell.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

