### PR TITLE
fix(theme): wrap long code lines instead of clipping (#20)

### DIFF
--- a/examples/code-walkthrough/css/base.css
+++ b/examples/code-walkthrough/css/base.css
@@ -43,6 +43,8 @@
   font-size: 22px;
   line-height: 1.6;
   color: #d7e0ea;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .notes-pane {

--- a/examples/feature-tour/css/base.css
+++ b/examples/feature-tour/css/base.css
@@ -155,6 +155,8 @@
   background: #17142a;
   border-radius: 12px;
   overflow: hidden;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .slot-code code {

--- a/themes/base.css
+++ b/themes/base.css
@@ -53,6 +53,8 @@
   margin: 0;
   font-size: 22px;
   line-height: 1.35;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .slot-code .hl-comment {


### PR DESCRIPTION
## Summary
- Long lines in `.slot-code` used to disappear into `overflow: hidden` on the fixed 1280×720 canvas.
- Apply `white-space: pre-wrap` + `overflow-wrap: anywhere` to the base theme's `.slot-code` and to every example theme that styles it (`code-walkthrough`, `feature-tour`). Long lines now wrap inside the code slot; short lines and existing highlights are unchanged.
- Wrapping was chosen over horizontal scrolling / auto-shrinking / a dedicated wide-code layout per the author's decision (option **a**).

Closes #20.

## Test plan
- [x] `cargo test --workspace` (x3)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `packages/peitho-present` build / test / typecheck
- [x] `git diff --exit-code packages/peitho-present/dist/shell.js`
- [x] Rebuilt `examples/deck.md` and confirmed the served `peitho.css` carries the two new declarations on `.slot-code`.
- [x] Verified visually in a real browser with a synthetic deck containing a >200-char code line — line wraps inside the slot on this branch, gets clipped when the two declarations are toggled off in DevTools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)