### PR TITLE
fix(render): let Esc on published deck return to index

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -309,6 +309,19 @@ pub fn render_distribution_index() -> String {
       }
     }
 
+    function exitToIndex() {
+      const referrer = document.referrer;
+      if (referrer !== '') {
+        try {
+          if (new URL(referrer).origin === window.location.origin) {
+            window.history.back();
+            return;
+          }
+        } catch (_error) {}
+      }
+      window.location.assign('/');
+    }
+
     document.addEventListener('keydown', (event) => {
       if (event.key === 'ArrowRight' || event.key === 'PageDown' || event.key === ' ') {
         event.preventDefault();
@@ -320,6 +333,10 @@ pub fn render_distribution_index() -> String {
       }
       if (event.key === 'Home') navigate('first');
       if (event.key === 'End') navigate('last');
+      if (event.key === 'Escape' && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        exitToIndex();
+      }
     });
     document.addEventListener('click', (event) => {
       navigate(event.clientX < window.innerWidth / 4 ? 'prev' : 'next');
@@ -1124,6 +1141,17 @@ mod tests {
         assert!(!html.contains("installTimeTracker"));
         assert!(!html.contains("peitho-time-tracker"));
         assert!(!html.contains("present.json"));
+    }
+
+    #[test]
+    fn distribution_index_maps_escape_to_index_navigation() {
+        let html = render_distribution_index();
+
+        assert!(html.contains("event.key === 'Escape'"));
+        assert!(html.contains("function exitToIndex()"));
+        assert!(html.contains("window.history.back()"));
+        assert!(html.contains("window.location.assign('/')"));
+        assert!(html.contains("new URL(referrer).origin === window.location.origin"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #128

## What was done

Made Esc on a published deck (`dist/index.html`) return to the slide list (index).

- Same-origin referrer → `history.back()` (users coming from a list return to that page)
- No referrer / cross-origin / invalid → `location.assign('/')` (to the site root)
- Cmd/Ctrl/Alt-modified Escape is left to the browser (existing arrow-key behavior is unchanged)

## Why only render.rs

The Issue originally assumed a shell-side (`packages/peitho-present`) fix, but investigation found that **`present.html` / `shell.js` are not included in the published artifact** (rejected as `PRESENTATION_ONLY_DIST_FILES` by the contamination check). What's served on publish is the self-contained `dist/index.html` generated by `render_distribution_index()`, and it wasn't handling Esc. So the fix is contained to the inline script in `render_distribution_index()`. shell.js / bindings are unchanged.

## Verification

- `cargo test --workspace` pass 3 times in a row (including the new test `distribution_index_maps_escape_to_index_navigation`)
- clippy / fmt / bindings drift / npm build/test/typecheck / shell.js drift all pass
- Real-browser E2E (Playwright + Chrome for Testing, hosted on static server):
  - Same-origin referrer (list → deck → Esc) → `history.back()` returns to the list
  - No referrer (direct link → Esc) → to `/`
  - Cross-origin referrer (`127.0.0.1` → `localhost`) → to `/`
  - ArrowRight slide advance unchanged; slides render normally (screenshot verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
