### PR TITLE
feat(render): URL deep-link to slide via ?slide=N (#115)

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -274,6 +274,24 @@ pub fn render_distribution_index() -> String {
       canvas.style.transform = `translate(${left}px, ${top}px) scale(${scale})`;
     }
 
+    function parsePositiveInt(raw) {
+      const match = raw.trim().match(/^\d+$/);
+      return match === null ? 1 : Number(match[0]);
+    }
+
+    function readSlideIndexFromUrl() {
+      const searchSlide = new URLSearchParams(location.search).get('slide');
+      if (searchSlide !== null) return parsePositiveInt(searchSlide);
+      const hash = location.hash;
+      if (hash.startsWith('#slide=')) {
+        return parsePositiveInt(hash.slice('#slide='.length).split('&')[0]);
+      }
+      if (hash.startsWith('#') && hash.length > 1) {
+        return parsePositiveInt(hash.slice(1).split('&')[0]);
+      }
+      return 1;
+    }
+
     function showSlide(index) {
       if (slides.length === 0) {
         document.getElementById('peitho-canvas').replaceChildren();
@@ -281,8 +299,15 @@ pub fn render_distribution_index() -> String {
       }
       const next = Math.max(0, Math.min(index, slides.length - 1));
       currentIndex = next;
+      writeSlideIndexToUrl(currentIndex + 1);
       const canvas = document.getElementById('peitho-canvas');
       canvas.innerHTML = slides[next].html;
+    }
+
+    function writeSlideIndexToUrl(oneBased) {
+      const params = new URLSearchParams(location.search);
+      params.set('slide', String(oneBased));
+      history.replaceState(null, '', location.pathname + '?' + params.toString() + location.hash);
     }
 
     function navigate(to) {
@@ -302,7 +327,7 @@ pub fn render_distribution_index() -> String {
             html: await fetchOk(slide.src).then((response) => response.text())
           }))
         );
-        showSlide(0);
+        showSlide(readSlideIndexFromUrl() - 1);
         resizeCanvas();
       } catch (error) {
         showError(error.message);
@@ -340,6 +365,10 @@ pub fn render_distribution_index() -> String {
     });
     document.addEventListener('click', (event) => {
       navigate(event.clientX < window.innerWidth / 4 ? 'prev' : 'next');
+    });
+    // `#slide=N` / `#N` are load-time fallbacks only; after load, query is canonical.
+    window.addEventListener('popstate', () => {
+      showSlide(readSlideIndexFromUrl() - 1);
     });
     window.addEventListener('resize', resizeCanvas);
     loadDeck();
@@ -913,6 +942,80 @@ mod tests {
         assert!(!html.contains("shell.js"));
         assert!(!html.contains("installPresentationControls"));
         assert!(!html.contains("data-slide-key="));
+    }
+
+    #[test]
+    fn distribution_index_reads_slide_query_on_load() {
+        let html = render_distribution_index();
+
+        assert!(html.contains("URLSearchParams(location.search)"));
+        assert!(html.contains(".get('slide')"));
+        assert!(html.contains("showSlide(readSlideIndexFromUrl() - 1)"));
+    }
+
+    #[test]
+    fn distribution_index_supports_hash_fallback() {
+        let html = render_distribution_index();
+
+        assert!(html.contains("location.hash"));
+        assert!(html.contains("hash.startsWith('#slide=')"));
+        assert!(html.contains("hash.startsWith('#')"));
+        assert!(html.contains(".split('&')[0]"));
+    }
+
+    #[test]
+    fn distribution_index_updates_url_on_slide_change() {
+        let html = render_distribution_index();
+
+        assert!(html.contains("history.replaceState"));
+        let show_slide_index = html.find("function showSlide(index)").unwrap();
+        let current_index = html.find("currentIndex = next;").unwrap();
+        let write_call_index = html
+            .find("writeSlideIndexToUrl(currentIndex + 1);")
+            .unwrap();
+        let replace_state_index = html[current_index..]
+            .find("history.replaceState")
+            .map(|index| current_index + index)
+            .unwrap();
+
+        assert!(show_slide_index < current_index);
+        assert!(current_index < write_call_index);
+        assert!(current_index < replace_state_index);
+    }
+
+    #[test]
+    fn distribution_index_never_uses_pushstate() {
+        let html = render_distribution_index();
+
+        assert!(!html.contains("history.pushState"));
+    }
+
+    #[test]
+    fn distribution_index_handles_popstate() {
+        let html = render_distribution_index();
+
+        assert!(html.contains("window.addEventListener('popstate'"));
+    }
+
+    #[test]
+    fn distribution_index_preserves_query_and_hash_when_writing_slide() {
+        let html = render_distribution_index();
+
+        assert!(html.contains("location.pathname"));
+        assert!(html.contains("params.set('slide'"));
+        assert!(html.contains("location.hash"));
+        assert!(html.contains("location.pathname + '?' + params.toString() + location.hash"));
+    }
+
+    #[test]
+    fn distribution_index_url_deep_link_leaves_present_and_presenter_alone() {
+        let present_html = render_present_index();
+        let presenter_html = render_presenter_index();
+
+        assert!(!present_html.contains("?slide="));
+        assert!(!present_html.contains("URLSearchParams"));
+        assert!(!presenter_html.contains("?slide="));
+        assert!(!presenter_html.contains("URLSearchParams"));
     }
 
     #[test]

--- a/docs/plans/2026-07-05-url-deep-link.md
+++ b/docs/plans/2026-07-05-url-deep-link.md
@@ -1,0 +1,129 @@
+# URL deep-link to a specific slide (Issue #115)
+
+## Motivation
+
+The published deck viewer always starts at slide 1. There is no way to
+link directly to slide N (SpeakerDeck-style `?slide=10`), which hurts
+both authoring (sharing a specific point during review) and reading
+(someone linking to "the slide where you said X").
+
+The runtime already jumps to any index via `showSlide(n)` — it just is
+not wired to the URL.
+
+## Scope
+
+**Published-deck runtime only.** The change lives entirely inside the
+inline `<script>` block of `render_distribution_index()` in
+`crates/peitho-core/src/render.rs`, which is what ships to `dist/`.
+
+**Explicitly out of scope:**
+
+- `render_present_index()` / `render_presenter_index()`. Those are used
+  only by `peitho present`. Navigation there is owned by
+  `packages/peitho-present` and the sync bridge; the server holds the
+  authoritative `index` and every `/sync` response carries it. Writing
+  `?slide=N` there would race the server, and it is not what the Issue
+  asks for.
+- Slide-key deep links (`?slide=arch-1`). The Issue calls this
+  nice-to-have, not required for v1.
+- Any change to `manifest.json` or the build pipeline. Runtime-only.
+
+## Design
+
+URL contract (matches SpeakerDeck):
+
+- Primary: `?slide=N` (1-based; internal `currentIndex` stays 0-based).
+- Fallbacks accepted on load: `#slide=N`, `#N`.
+- On invalid / OOB / non-integer: clamp to `[1, slides.length]`; if
+  totally unparseable, start at 1.
+
+Behavior:
+
+1. **On load**, before calling `showSlide`, read the desired index
+   from the URL (primary → hash `slide=` → bare `#N`) and pass
+   `desiredIndex - 1` to `showSlide`. `showSlide` already clamps, so
+   we only need to parse.
+2. **On every `showSlide(index)`**, immediately after `currentIndex`
+   is set, call the URL writer. It reads
+   `URLSearchParams(location.search)`, sets `slide`, and rebuilds the
+   URL as `location.pathname + '?' + params.toString() + location.hash`
+   so non-slide query params and the fragment are preserved.
+   Doing it inside `showSlide` (rather than at each `navigate`
+   caller) is the *single point* of URL sync: keyboard, click, and
+   any future caller get it for free — no "remember to also update
+   the URL" convention leaks to callers. This is the root-cause /
+   long-term-view choice.
+3. **On `popstate`**, re-read the URL and call `showSlide(index - 1)`.
+   Because we only ever `replaceState`, popstate rarely fires inside
+   the deck (there is no per-slide history entry to pop to); it is
+   installed as a belt-and-suspenders for browser session restore,
+   manual URL bar edits, or scripts that mutate history externally.
+
+Compatibility with existing behavior:
+
+- `exitToIndex()` (Escape) still uses `history.back()`. Because we
+  only ever `replaceState` (never `pushState`), history depth is
+  unchanged and Escape still leaves the deck. No change needed.
+- Referrer-scoped back / `location.assign('/')` fallback is unchanged.
+
+## Non-behavior
+
+- No `pushState`. Ever. `pushState` per slide would trap the browser
+  Back button inside the deck — a known anti-pattern the Issue calls
+  out.
+- The runtime does not emit `#slide=N`, but any user-authored fragment
+  (e.g. `#note`) is preserved on subsequent `replaceState` writes.
+- Do not react to `hashchange`. The hash form (`#slide=N`, `#N`) is a
+  load-time fallback only; the query is canonical, and
+  `readSlideIndexFromUrl` prioritizes query over hash on any re-read.
+  Reacting to `hashchange` would be a no-op (or worse, misleading)
+  because the query would still win.
+- Do not touch `render_present_index()` or `render_presenter_index()`.
+- No new manifest fields, no new module files. The runtime is small
+  and self-contained; a helper function inside the inline script is
+  fine.
+
+## Test plan
+
+Rust side (same shape as the existing `distribution_index_*` tests in
+`render.rs`):
+
+- `distribution_index_reads_slide_query_on_load` — asserts the
+  runtime contains a call to parse `?slide=` (e.g. via
+  `URLSearchParams` on `location.search`) and passes the parsed index
+  to `showSlide`.
+- `distribution_index_supports_hash_fallback` — asserts hash parsing
+  (`#slide=N` and bare `#N`) is present.
+- `distribution_index_updates_url_on_slide_change` — asserts
+  `history.replaceState` is called with a query starting with
+  `?slide=` from inside `showSlide`.
+- `distribution_index_never_uses_pushstate` — asserts
+  `history.pushState` does **not** appear anywhere in the runtime
+  (guard against regressions).
+- `distribution_index_handles_popstate` — asserts a `popstate`
+  listener is installed.
+- `distribution_index_preserves_query_and_hash_when_writing_slide` —
+  asserts the writer preserves the path, non-slide query params, and
+  fragment while setting `slide`.
+- `distribution_index_url_deep_link_leaves_present_and_presenter_alone`
+  — asserts `render_present_index()` and `render_presenter_index()`
+  contain no `?slide=` / `URLSearchParams` markers (invariant guard).
+
+TS side (`packages/peitho-present`): no code change, no new tests.
+
+E2E (real browser, per the CLAUDE.md rule that jsdom cannot detect
+layout / navigation behavior):
+
+1. `peitho build` a small deck; serve `dist/` with any static server.
+2. Open `?slide=3` — asserts the 3rd slide is displayed on load.
+3. Arrow-right — asserts the URL becomes `?slide=4`.
+4. Browser Back — asserts navigation leaves the deck (not stepping
+   back to `?slide=3`).
+5. Open `#slide=2` — asserts fallback parsing.
+6. Open `?slide=999` — asserts clamp to last slide.
+7. Open `?slide=abc` — asserts clamp to slide 1.
+
+## Downstream
+
+Once merged and tagged, `mizzy/decks` bumps `PEITHO_VERSION` in
+`.github/workflows/deploy.yml` to pick this up (per Issue #115).


### PR DESCRIPTION
Closes #115

## Summary

- Published-deck runtime (`render_distribution_index()`) now reads `?slide=N` on load and mirrors `currentIndex` into the URL on every navigation.
- Load-time fallbacks: `#slide=N` and bare `#N` are accepted, then normalized to the canonical `?slide=N` query.
- Non-slide query params (e.g. `?slide=3&utm_source=x`) and user-authored fragments (e.g. `?slide=3#note`) are preserved on rewrite.
- `replaceState` only — never `pushState`. Browser Back button leaves the deck instead of stepping through slides.

## Design

`docs/plans/2026-07-05-url-deep-link.md`. Key choices:

- **Single URL-sync seam inside `showSlide`**. Every caller (keyboard, click, `navigate`, initial load, popstate) gets URL sync for free; there is no "remember to also update the URL" convention leaking to callers.
- **`writeSlideIndexToUrl` rebuilds as `pathname + '?' + params + hash`**. Uses `URLSearchParams(location.search)` + `.set('slide', ...)`, so it preserves other params and any user-authored fragment.
- **Strict positive-integer parse** (`/^\d+$/`). Rejects `0x10`, `1e3`, signed input; `?slide=abc` → slide 1; `?slide=0` and `?slide=999` clamp to `[1, slides.length]` via `showSlide`'s existing `Math.max/Math.min`.
- **No `hashchange` listener**. The hash form is a load-time fallback only; the query is canonical after load, so a `hashchange` handler would be a no-op or misleading. Rationale is recorded in the plan doc under "Non-behavior".

## Scope

- Only `render_distribution_index()` in `crates/peitho-core/src/render.rs` (~100 lines of runtime JS).
- `render_present_index()` / `render_presenter_index()` are intentionally untouched — `peitho present` navigation is owned by `packages/peitho-present` and the sync bridge (server holds authoritative `index`). Pinned by the `distribution_index_url_deep_link_leaves_present_and_presenter_alone` test.
- No changes to `manifest.json`, the build pipeline, `bindings/`, or `packages/peitho-present`.

## Behavior changes downstream readers should know

1. Opening a bare URL (e.g. `/deck.html`) now writes `?slide=1` to the address bar on first paint. Existing bookmarks remain valid (idempotent), but the URL becomes canonical.
2. A load-time `#slide=N` hash is preserved verbatim after canonicalization to `?slide=N` (so the address bar may show `?slide=N#slide=N` for one load). Harmless — the query wins on any re-read.

## Test plan

- [x] `cargo test --workspace` × 3 (guard against test races) — all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/` (contract drift)
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
- [x] `git diff --exit-code packages/peitho-present/dist/shell.js`
- [x] E2E in real browser (published deck served locally):
    - `?slide=3` opens the 3rd slide
    - ArrowRight advances URL `?slide=3 → ?slide=4`, `history.length` stays constant (no per-slide history growth)
    - `#slide=2` and `#2` fallbacks work
    - `?slide=2&utm_source=x#note` preserves both after navigation
    - `?slide=0x2` / `?slide=1e2` / `?slide=abc` all clamp to slide 1
    - `#slide=2&foo=bar` extracts the value up to `&`
    - `?slide=999` clamps to the last slide

Once merged and tagged, `mizzy/decks` bumps `PEITHO_VERSION` in `.github/workflows/deploy.yml` to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)