### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary

- Bump workspace version 0.5.0 → 0.6.0
- Changes since v0.5.0:
  - feat: configurable slide aspect ratio via `aspect_ratio:` frontmatter (16:9 / 4:3) (#23 / #135)
  - feat: include per-slide plain text (title/body/code) in manifest.json (#136 / #137)

After the tag push, `.github/workflows/release.yml` attaches the macOS arm64 / Linux x86_64 / Linux arm64 tar.gz archives to the Release.

## Test plan

- [ ] After merge, `git tag v0.6.0 && git push origin v0.6.0` triggers a successful Release workflow
- [ ] The Release page has tar.gz + sha256 for all 3 targets attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
