### PR TITLE
fix: add monospace font-family to .slot-code in built-in theme

### DIFF
--- a/themes/base.css
+++ b/themes/base.css
@@ -51,6 +51,7 @@
 .slot-code {
   display: block;
   margin: 0;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   font-size: 22px;
   line-height: 1.35;
   white-space: pre-wrap;


### PR DESCRIPTION
Closes #146

## Summary

The built-in theme `themes/base.css` did not specify `font-family` on `.slot-code`, so code blocks inherited the slide's sans-serif font stack and fell back to the browser's default monospace font. On Japanese-locale macOS this resolved to Osaka-Mono, which Skia could not subset, so the **entire font (1.37MB)** was being embedded in the PDF.

## Changes

Add `font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace` to `.slot-code`. Same stack already used by other example decks (code-walkthrough, feature-tour, two-column).

## Effect

- No more whole-Osaka-Mono embedding on PDF export
- Code blocks now render in monospace during presentation as well (they used to be sans-serif)

## Test

All gates green (workspace test x3, clippy, fmt, bindings, npm build/test/typecheck, shell.js drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
