### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary
- Bump version to 0.8.0

## Changes since v0.7.0
- #143 feat: PowerPoint export via structural conversion (`peitho export pptx`)
- #144 feat: flatten CSS gradients at PDF print time for fast Preview.app rendering
- #147 fix: add monospace font-family to `.slot-code` in built-in theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)