### PR TITLE
fix: update Cargo.lock to match v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "html-escape",
  "lol_html",


### PR DESCRIPTION
## Summary
- Update Cargo.lock to reflect the v0.8.0 version bump from #148
- The release workflow failed because `--locked` found a stale lockfile

## Test plan
- [x] `cargo build --locked` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)