### PR TITLE
chore: bump version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary
- Patch release: bump workspace version 0.8.0 → 0.8.1
- Update Cargo.lock to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)