### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.8.1"
+version = "0.9.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
Version bump for the v0.9.0 release.

Changes since the previous release (v0.8.1):
- #156 Remove pptx export due to quality issues (minor bump for removing the `export pptx` subcommand)
- #157 fix: silent hang in image.decode() on Linux headless Chrome, plus running E2E on Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
