### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.9.0"
+version = "0.10.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary

Bump workspace version 0.9.0 → 0.10.0 to cut a minor release with the two features merged since v0.9.0.

## Changes since v0.9.0

- feat: add `fonts:` asset key to bring fonts into the deck contract (#160)
- feat: add left/right swipe navigation for touch devices (#162)

## Test plan

- [x] All CLAUDE.md gates pass locally (cargo test 3×, clippy, fmt, bindings, npm build/test/typecheck, shell.js drift)
- [x] Cargo.lock updated so `--locked` builds in the Release workflow won't fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC