### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "0.10.0"
+version = "1.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "0.10.0"
+version = "1.0.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.10.0"
+version = "1.0.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.10.0 to 1.0.0.

## Test plan
- [x] cargo test --workspace (x3)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all --check
- [x] git diff --exit-code bindings/
- [x] npm build / test / typecheck
- [x] git diff --exit-code packages/peitho-present/dist/shell.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC