### PR TITLE
feat: add completions subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +794,7 @@ version = "1.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "clap_complete",
  "miette",
  "notify",
  "notify-debouncer-mini",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "1.0.0"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 assert_cmd = "2"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 html-escape = "0.2"
 lol_html = "2"
 miette = { version = "7", features = ["fancy"] }

--- a/crates/peitho/Cargo.toml
+++ b/crates/peitho/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
+clap_complete.workspace = true
 miette.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -11,7 +11,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{generate, Shell};
 use miette::IntoDiagnostic;
 use notify::{PollWatcher, RecursiveMode};
 use notify_debouncer_mini::{new_debouncer_opt, Config as DebounceConfig, DebounceEventResult};
@@ -242,6 +243,9 @@ enum Command {
         #[command(subcommand)]
         command: ExportCommand,
     },
+    Completions {
+        shell: Shell,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -306,6 +310,12 @@ fn main() -> miette::Result<()> {
         Command::Export { command } => match command {
             ExportCommand::Pdf { input, out } => export_pdf(input, out),
         },
+        Command::Completions { shell } => {
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            generate(shell, &mut cmd, name, &mut std::io::stdout());
+            Ok(())
+        }
     }
 }
 
@@ -2241,7 +2251,10 @@ contexts:
                 assert_eq!(input, PathBuf::from("deck.md"));
                 assert!(presenter_windowed);
             }
-            Command::Build { .. } | Command::Publish { .. } | Command::Export { .. } => {
+            Command::Build { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
                 panic!("expected present command");
             }
         }
@@ -2258,8 +2271,28 @@ contexts:
                 assert_eq!(input, PathBuf::from("deck.md"));
                 assert_eq!(out, Some(PathBuf::from("out.pdf")));
             }
-            Command::Build { .. } | Command::Present { .. } | Command::Publish { .. } => {
+            Command::Build { .. }
+            | Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Completions { .. } => {
                 panic!("expected export pdf command");
+            }
+        }
+    }
+
+    #[test]
+    fn completions_command_accepts_shell_argument() {
+        let cli = Cli::parse_from(["peitho", "completions", "bash"]);
+
+        match cli.command {
+            Command::Completions { shell } => {
+                assert_eq!(shell, Shell::Bash);
+            }
+            Command::Build { .. }
+            | Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. } => {
+                panic!("expected completions command");
             }
         }
     }
@@ -2643,7 +2676,10 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
                 assert!(watch);
             }
-            Command::Present { .. } | Command::Publish { .. } | Command::Export { .. } => {
+            Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
                 panic!("expected build command");
             }
         }
@@ -2659,7 +2695,10 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(out, PathBuf::from("dist"));
                 assert!(!watch);
             }
-            Command::Present { .. } | Command::Publish { .. } | Command::Export { .. } => {
+            Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
                 panic!("expected build command");
             }
         }


### PR DESCRIPTION
## Summary
- Add `peitho completions <SHELL>` powered by clap_complete.
- Supports bash / zsh / fish / powershell / elvish.
- Enables packagers (Homebrew etc.) to install completions automatically.

## Test plan
- [x] cargo test --workspace (x3)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all --check
- [x] git diff --exit-code bindings/
- [x] npm build / test / typecheck
- [x] git diff --exit-code packages/peitho-present/dist/shell.js
- [x] `peitho completions bash|zsh|fish` prints valid script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC