### PR TITLE
docs: add Homebrew install and completions subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Other invariants:
 
 ```
 crates/peitho-core/   Contract & pipeline (parser/layout/mapping/check/render/theme/manifest/notes)
-crates/peitho/        CLI (build/present/publish/export), server.rs (serving + /sync long polling), browser.rs, displays.rs
+crates/peitho/        CLI (build/present/publish/export/completions), server.rs (serving + /sync long polling), browser.rs, displays.rs
 packages/peitho-present/  TS presentation shell (canvas/shell/controls/keyboard/sync/presenter)
 bindings/             ts-rs generated TS types (committed)
 layouts/ themes/ examples/  Shared layouts, base theme, samples. The default layouts/base.css is embedded and used only after explicit frontmatter and deck-adjacent auto-detect have both been checked. The presentation shell dist/shell.js is embedded, committed, and checked for drift; `--shell` remains the only CLI-side shell-bundle swap and is a dev/debug override. `layouts:` / `css:` / `syntaxes:` / `fonts:` frontmatter can point at a file or a directory: layouts/css/syntaxes read `*.html` / `*.css` / `*.sublime-syntax` in filename order, while `fonts:` copies files without an extension filter so `.woff2`, `.ttf`, and `@font-face` CSS can live side by side. When omitted, auto-detects `layouts/` / `css/` / `syntaxes/` / `fonts/` **next to the deck** (zero-config convention, adopted per Issue #17; falls back to the built-in default for layouts/css/syntaxes if absent). Fonts are copied verbatim into build output, present cache, and PDF export workspace by file/directory, not by extension. CSS validation is uniform across all files: keyed selectors are checked against the slots of that slide's layout, and bare `.slot-*` are checked against the union of provided layouts

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ error: slide 2 ('code-slide'), line 7: slot 'code' got 2 item(s), but layout 'ti
 
 ## Install
 
+### Homebrew (macOS / Linux)
+
+```sh
+brew install mizzy/tap/peitho
+```
+
+Shell completions for bash/zsh/fish are installed automatically.
+
+### Prebuilt binaries
+
 Grab a prebuilt binary from the [Releases page](https://github.com/mizzy/peitho/releases). Each release ships a tarball per target with a single `peitho` binary — everything (layouts, base theme, presentation shell) is embedded, so Node.js and npm are not needed at runtime.
 
 ```sh
@@ -68,6 +78,9 @@ peitho export pdf deck.md -o deck.pdf
 
 # Publish (inspects, then delegates to your existing deploy command. Don't reinvent the deploy)
 peitho publish -- aws s3 sync dist/ s3://your-bucket/
+
+# Generate a shell completion script (bash / zsh / fish / powershell / elvish)
+peitho completions zsh
 ```
 
 Layouts, themes, and the presentation shell use defaults embedded in the binary, so a single deck file works in any directory. Point at your own assets from the deck's frontmatter (`layouts:`, `css:`, `syntaxes:`) or drop `layouts/`, `css/`, and `syntaxes/` next to the deck for zero-config pickup. Only `--shell` remains as a CLI-side dev/debug swap for the presentation shell bundle itself.


### PR DESCRIPTION
## Summary
- README: add Homebrew install section (`brew install mizzy/tap/peitho`, completions installed automatically) and a `peitho completions zsh` usage example.
- CLAUDE.md: add `completions` to the CLI subcommand list.

## Test plan
- [x] Docs-only change; CI gates cover formatting-neutral diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC