### PR TITLE
fix: remove wall-clock flakiness from one-shot Chrome runner tests

### DIFF
--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -2460,11 +2460,13 @@ exec sleep 30
             ChromeCompletion::PdfWritten {
                 output_path: out.clone(),
             },
-            Duration::from_secs(2),
+            CHROME_ONE_SHOT_TIMEOUT,
         )
         .unwrap();
 
-        assert!(started.elapsed() < Duration::from_secs(2));
+        // Well below the child's `sleep 30`: proves the completion signal
+        // triggered the early return, with headroom for loaded CI runners.
+        assert!(started.elapsed() < Duration::from_secs(10));
         assert!(out.is_file());
         assert!(stdout.is_empty());
     }
@@ -2489,7 +2491,7 @@ printf '%s' '%PDF-test' > "$out"
             ChromeCompletion::PdfWritten {
                 output_path: out.clone(),
             },
-            Duration::from_secs(2),
+            CHROME_ONE_SHOT_TIMEOUT,
         )
         .unwrap();
 
@@ -2541,7 +2543,9 @@ exec sleep 30
         )
         .unwrap_err();
 
-        assert!(started.elapsed() < Duration::from_secs(2));
+        // Well below the child's `sleep 30`: proves the deadline killed the
+        // child instead of waiting it out, with headroom for loaded CI runners.
+        assert!(started.elapsed() < Duration::from_secs(10));
         assert!(err.to_string().contains("timed out"));
     }
 
@@ -2564,7 +2568,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
             &fake_chrome,
             &[out.clone().into_os_string()],
             ChromeCompletion::PdfWritten { output_path: out },
-            Duration::from_secs(2),
+            CHROME_ONE_SHOT_TIMEOUT,
         )
         .unwrap_err();
 


### PR DESCRIPTION
## Summary
- Fixes #167: `pdf_completion_requires_nonempty_output_file` failed on a loaded CI runner (PR #166) because its 2s deadline turned the error classification under test into `timed out`.
- Root cause is the class, not the one test: fake-chrome tests bounded the runner with idle-machine wall-clock values. All four are adjusted on the same principle:
  - Tests verifying a **classification** (success / completed-before-ready) now pass the production `CHROME_ONE_SHOT_TIMEOUT` — the fake exits immediately, so test duration is unchanged and the bound only guards a pathological hang.
  - Early-return `elapsed` asserts go from `< 2s` to `< 10s` — still far below the child's `sleep 30` (so they keep proving the early return), with 100x headroom over the normal ~ms case.
  - `one_shot_chrome_runner_times_out_and_reaps_child_without_completion` keeps its 100ms deadline: there the timeout **is** the subject.

## Test plan
- [x] cargo test --workspace (x3)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all --check
- [x] git diff --exit-code bindings/
- [x] npm build / test / typecheck
- [x] git diff --exit-code packages/peitho-present/dist/shell.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC