### PR TITLE
feat: default the deck argument to deck.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,21 +60,26 @@ Available targets: `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-
 
 ## Usage
 
+The deck argument defaults to `deck.md` in the current directory, so it can be omitted when the file follows the convention.
+
 ```sh
 # Generate the distribution (dist/ with slides/ fragments + manifest.json + index.html + peitho.css)
-peitho build deck.md
+peitho build            # same as: peitho build deck.md
 
 # Rebuild on every save
-peitho build deck.md --watch
+peitho build --watch
 
 # Present (generates a volatile cache + local server + launches the browser. Auto-places across two displays)
-peitho present deck.md
+peitho present
 
 # Debug: open in a normal window instead of full-screen (Chrome restores the previous position/size. On a single display the slides open in a window too)
-peitho present deck.md --presenter-windowed
+peitho present --presenter-windowed
 
 # Export a PDF
-peitho export pdf deck.md -o deck.pdf
+peitho export pdf -o deck.pdf
+
+# A deck with a non-default name is passed explicitly
+peitho build slides.md
 
 # Publish (inspects, then delegates to your existing deploy command. Don't reinvent the deploy)
 peitho publish -- aws s3 sync dist/ s3://your-bucket/

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -212,6 +212,7 @@ struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     Build {
+        #[arg(default_value = "deck.md")]
         input: PathBuf,
         #[arg(long, default_value = "dist")]
         out: PathBuf,
@@ -219,6 +220,7 @@ enum Command {
         watch: bool,
     },
     Present {
+        #[arg(default_value = "deck.md")]
         input: PathBuf,
         #[arg(long, help = "shell bundle path (default: built-in present shell)")]
         shell: Option<PathBuf>,
@@ -251,6 +253,7 @@ enum Command {
 #[derive(Debug, Subcommand)]
 enum ExportCommand {
     Pdf {
+        #[arg(default_value = "deck.md")]
         input: PathBuf,
         #[arg(short, long)]
         out: Option<PathBuf>,
@@ -623,7 +626,12 @@ fn load_css(css_path: Option<&Path>) -> miette::Result<Vec<peitho_core::CssFile>
 }
 
 fn build_artifacts(input: &Path) -> miette::Result<BuildArtifacts> {
-    let markdown = fs::read_to_string(input).into_diagnostic()?;
+    let markdown = fs::read_to_string(input).map_err(|err| {
+        miette::miette!(
+            "failed to read {}\nhelp: the deck argument defaults to deck.md in the current directory when omitted; pass the deck path explicitly if it lives elsewhere\ncaused by: {err}",
+            input.display()
+        )
+    })?;
     let frontmatter = core(peitho_core::parse_frontmatter(&markdown))?;
     let assets = resolve_assets(input, &frontmatter)?;
     let highlighter = match assets.syntaxes.as_deref() {
@@ -2669,6 +2677,74 @@ printf '0 bytes written to file %s\n' "$out" >&2
         let mut permissions = fs::metadata(path).unwrap().permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[test]
+    fn build_command_defaults_input_to_deck_md() {
+        let cli = Cli::parse_from(["peitho", "build"]);
+
+        match cli.command {
+            Command::Build { input, .. } => {
+                assert_eq!(input, PathBuf::from("deck.md"));
+            }
+            Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected build command");
+            }
+        }
+    }
+
+    #[test]
+    fn present_command_defaults_input_to_deck_md() {
+        let cli = Cli::parse_from(["peitho", "present"]);
+
+        match cli.command {
+            Command::Present { input, .. } => {
+                assert_eq!(input, PathBuf::from("deck.md"));
+            }
+            Command::Build { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected present command");
+            }
+        }
+    }
+
+    #[test]
+    fn export_pdf_command_defaults_input_to_deck_md() {
+        let cli = Cli::parse_from(["peitho", "export", "pdf"]);
+
+        match cli.command {
+            Command::Export {
+                command: ExportCommand::Pdf { input, .. },
+            } => {
+                assert_eq!(input, PathBuf::from("deck.md"));
+            }
+            Command::Build { .. }
+            | Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Completions { .. } => {
+                panic!("expected export pdf command");
+            }
+        }
+    }
+
+    #[test]
+    fn build_artifacts_missing_input_error_names_path_and_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-deck.md");
+
+        let err = match build_artifacts(&missing) {
+            Ok(_) => panic!("expected missing input error"),
+            Err(err) => err,
+        };
+
+        let message = format!("{err:?}");
+        assert!(message.contains("no-such-deck.md"));
+        assert!(message.contains("defaults to deck.md"));
     }
 
     #[test]

--- a/docs/plans/2026-07-07-default-deck-md.md
+++ b/docs/plans/2026-07-07-default-deck-md.md
@@ -1,0 +1,23 @@
+# 入力ファイル省略時に deck.md をデフォルトにする (Issue #171)
+
+## ゴール
+
+`peitho build` / `peitho present` / `peitho export pdf` の入力引数を省略可能にし、省略時はカレントディレクトリの `deck.md` を使う。ファイル名が慣例と違う時だけ明示指定する。
+
+## 変更点
+
+1. **clap デフォルト値**: `Command::Build.input` / `Command::Present.input` / `ExportCommand::Pdf.input` に `#[arg(default_value = "deck.md")]` を付ける。`Option<PathBuf>` + 手動 unwrap にはしない — clap レベルのデフォルトなら `--help` にも `[default: deck.md]` と出て自己文書化され、下流の型は `PathBuf` のまま変わらない (呼び出し側に解決の記憶を要求しない)
+2. **読み取りエラーの自己説明化**: `build_artifacts` 冒頭の `fs::read_to_string(input).into_diagnostic()?` を、パスと help 付きのエラーに map する。デフォルト化で「`deck.md` の無いディレクトリで裸の `peitho build`」が増えるが、現状のエラーは `No such file or directory (os error 2)` とパスすら出ない。デフォルト由来か明示指定かで分岐はしない — どちらでもパスと復旧手段を示す 1 つのメッセージで足りる (症状別分岐を作らない)
+3. **README**: Usage の各例に省略形を反映
+
+## テスト (TDD)
+
+- `build_command_defaults_input_to_deck_md`: `Cli::parse_from(["peitho","build"])` → `input == "deck.md"`
+- `present_command_defaults_input_to_deck_md`: 同上
+- `export_pdf_command_defaults_input_to_deck_md`: 同上
+- `build_artifacts_missing_input_error_names_path_and_default`: 存在しないパスで `build_artifacts` → エラー文字列にパスと help が含まれる
+
+## スコープ外
+
+- `publish` は入力がデッキではなく dist なので対象外
+- deck.md 以外の慣例名 (index.md 等) の探索はしない — 単一のデフォルト + 明示指定のみ


### PR DESCRIPTION
## Summary
- Fixes #171: `peitho build` / `peitho present` / `peitho export pdf` default their deck argument to `deck.md` in the current directory (`#[arg(default_value)]`, so `--help` self-documents it). A non-default filename is passed explicitly.
- The `build_artifacts` read error now names the path and explains the default — previously a missing input surfaced a bare `No such file or directory (os error 2)` without even the path.
- README Usage updated; plan in `docs/plans/2026-07-07-default-deck-md.md`.

## Test plan
- [x] New tests: bare `peitho build` / `present` / `export pdf` parse to `deck.md`; missing-input error names the path and the default (TDD: red confirmed before implementing)
- [x] E2E: bare `peitho build` in a directory with `deck.md` builds; without it, the error is self-explanatory
- [x] cargo test --workspace (x3)
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all --check
- [x] git diff --exit-code bindings/
- [x] npm build / test / typecheck
- [x] git diff --exit-code packages/peitho-present/dist/shell.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC