### PR TITLE
fix: dispatch slot rendering on the slot contract, not the first fragment's kind

### DIFF
--- a/crates/peitho-core/src/check.rs
+++ b/crates/peitho-core/src/check.rs
@@ -4,7 +4,10 @@ use crate::{
     domain::{Accepts, FragmentKind, SlotName, SourceFragment},
     error::{BuildError, ErrorKind, Result},
     layout::Layout,
-    phase::{Checked, CheckedSlide, Deck, Mapped, MappedSlide, MappedSlot, UnassignedFragment},
+    phase::{
+        Checked, CheckedSlide, CheckedSlot, Deck, Mapped, MappedSlide, MappedSlot,
+        UnassignedFragment,
+    },
 };
 
 pub fn check_deck(deck: Deck<Mapped>) -> Result<Deck<Checked>> {
@@ -14,11 +17,26 @@ pub fn check_deck(deck: Deck<Mapped>) -> Result<Deck<Checked>> {
         let slide_number = slide.index + 1;
         let slide_key = slide.key.as_str().to_owned();
         check_slide(&slide).map_err(|err| err.with_slide(slide_number, Some(&slide_key)))?;
+        let mut mapped_slots = slide.slots;
         let checked_slots = slide
-            .slots
-            .into_iter()
-            .map(|(slot, mapped_slot)| (slot, mapped_slot.fragments().to_vec()))
+            .layout
+            .slots()
+            .iter()
+            .map(|(slot, contract)| {
+                let (checked_contract, fragments) = mapped_slots
+                    .remove(slot)
+                    .map(|mapped_slot| {
+                        (
+                            mapped_slot.contract().clone(),
+                            mapped_slot.fragments().to_vec(),
+                        )
+                    })
+                    .unwrap_or_else(|| (contract.clone(), Vec::new()));
+                (slot.clone(), CheckedSlot::new(checked_contract, fragments))
+            })
             .collect();
+        check_no_unknown_mapped_slots(&mapped_slots, &slide.layout)
+            .map_err(|err| err.with_slide(slide_number, Some(&slide_key)))?;
         slides.push(CheckedSlide::new(
             slide.index,
             slide.key,
@@ -28,6 +46,29 @@ pub fn check_deck(deck: Deck<Mapped>) -> Result<Deck<Checked>> {
         ));
     }
     Ok(Deck::checked(settings, slides))
+}
+
+fn check_no_unknown_mapped_slots(
+    mapped_slots: &BTreeMap<SlotName, MappedSlot>,
+    layout: &Layout,
+) -> Result<()> {
+    if mapped_slots.is_empty() {
+        return Ok(());
+    }
+    let names = mapped_slots
+        .keys()
+        .map(SlotName::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(BuildError::new(
+        ErrorKind::Layout,
+        None,
+        format!(
+            "mapped slide for layout '{}' contains slot(s) not declared by layout: {names}",
+            layout.name()
+        ),
+        "keep mapping output synchronized with the layout slot contracts",
+    ))
 }
 
 /// Validate one mapped slide against the layout it carries. Also used by
@@ -139,7 +180,7 @@ fn check_no_unassigned(unassigned: &[UnassignedFragment]) -> Result<()> {
 mod tests {
     use super::*;
     use crate::{
-        domain::{RawImagePath, SlideKey},
+        domain::{Arity, RawImagePath, SlideKey, SlotContract},
         error::ErrorKind,
         layout::parse_layout,
         mapping::map_by_convention,
@@ -318,6 +359,51 @@ mod tests {
         };
 
         check_slide(&slide).unwrap();
+    }
+
+    #[test]
+    fn rejects_mapped_slot_not_declared_by_layout_before_checked_conversion() {
+        let layout = parse_layout(
+            "title-only",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let title = SlotName::new("title").unwrap();
+        let extra = SlotName::new("extra").unwrap();
+        let mut title_slot = MappedSlot::new(layout.slot_by_name(&title).unwrap().clone());
+        title_slot.push(SourceFragment::heading(1, 1, "# Title", "Title"));
+        let mut extra_slot = MappedSlot::new(SlotContract {
+            name: extra.clone(),
+            accepts: Accepts::Blocks,
+            arity: Arity::ZeroOrMore,
+        });
+        extra_slot.push(SourceFragment::paragraph(3, "Should not disappear"));
+        let mut slots = BTreeMap::new();
+        slots.insert(title, title_slot);
+        slots.insert(extra, extra_slot);
+        let mapped = Deck::mapped(
+            crate::phase::DeckSettings::default(),
+            vec![MappedSlide {
+                index: 0,
+                key: SlideKey::new("title").unwrap(),
+                layout,
+                slots,
+                unassigned: Vec::new(),
+                notes: None,
+            }],
+        );
+
+        let err = check_deck(mapped).unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Layout);
+        assert!(err.to_string().contains("slide 1 ('title')"));
+        assert!(err
+            .to_string()
+            .contains("slot(s) not declared by layout: extra"));
+        assert_eq!(
+            err.help,
+            "keep mapping output synchronized with the layout slot contracts"
+        );
     }
 
     #[test]

--- a/crates/peitho-core/src/phase.rs
+++ b/crates/peitho-core/src/phase.rs
@@ -286,8 +286,14 @@ pub struct CheckedSlide<S = RawImagePath> {
     index: usize,
     key: SlideKey,
     layout: Layout,
-    slots: BTreeMap<SlotName, Vec<SourceFragment<S>>>,
+    slots: BTreeMap<SlotName, CheckedSlot<S>>,
     notes: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CheckedSlot<S = RawImagePath> {
+    contract: SlotContract,
+    fragments: Vec<SourceFragment<S>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -357,7 +363,7 @@ impl<S> CheckedSlide<S> {
         index: usize,
         key: SlideKey,
         layout: Layout,
-        slots: BTreeMap<SlotName, Vec<SourceFragment<S>>>,
+        slots: BTreeMap<SlotName, CheckedSlot<S>>,
         notes: Option<String>,
     ) -> Self {
         Self {
@@ -381,7 +387,7 @@ impl<S> CheckedSlide<S> {
         &self.key
     }
 
-    pub(crate) fn slots(&self) -> &BTreeMap<SlotName, Vec<SourceFragment<S>>> {
+    pub(crate) fn slots(&self) -> &BTreeMap<SlotName, CheckedSlot<S>> {
         &self.slots
     }
 
@@ -393,8 +399,26 @@ impl<S> CheckedSlide<S> {
         let title = SlotName::new("title").ok()?;
         self.slots
             .get(&title)?
+            .fragments()
             .iter()
             .find_map(SourceFragment::heading_text)
+    }
+}
+
+impl<S> CheckedSlot<S> {
+    pub(crate) fn new(contract: SlotContract, fragments: Vec<SourceFragment<S>>) -> Self {
+        Self {
+            contract,
+            fragments,
+        }
+    }
+
+    pub fn contract(&self) -> &SlotContract {
+        &self.contract
+    }
+
+    pub fn fragments(&self) -> &[SourceFragment<S>] {
+        &self.fragments
     }
 }
 
@@ -473,7 +497,11 @@ where
         let slide_key_for_error = key.as_str().to_owned();
         let mut resolved_slots = BTreeMap::new();
 
-        for (slot, fragments) in slots {
+        for (slot, checked_slot) in slots {
+            let CheckedSlot {
+                contract,
+                fragments,
+            } = checked_slot;
             let mut resolved_fragments = Vec::with_capacity(fragments.len());
             for fragment in fragments {
                 let line = fragment.line();
@@ -500,7 +528,7 @@ where
                 })?;
                 resolved_fragments.push(resolved);
             }
-            resolved_slots.insert(slot, resolved_fragments);
+            resolved_slots.insert(slot, CheckedSlot::new(contract, resolved_fragments));
         }
 
         slides.push(CheckedSlide::new(index, key, layout, resolved_slots, notes));
@@ -718,13 +746,17 @@ mod tests {
         )
         .unwrap();
         let hero = SlotName::new("hero").unwrap();
+        let contract = layout.slot("hero").unwrap().clone();
         let mut slots = BTreeMap::new();
         slots.insert(
             hero,
-            vec![
-                SourceFragment::image(3, "A", RawImagePath::new_unchecked("a.png".into())),
-                SourceFragment::image(5, "B", RawImagePath::new_unchecked("b.png".into())),
-            ],
+            CheckedSlot::new(
+                contract,
+                vec![
+                    SourceFragment::image(3, "A", RawImagePath::new_unchecked("a.png".into())),
+                    SourceFragment::image(5, "B", RawImagePath::new_unchecked("b.png".into())),
+                ],
+            ),
         );
         let deck = Deck::checked(
             DeckSettings::default(),

--- a/crates/peitho-core/src/plain.rs
+++ b/crates/peitho-core/src/plain.rs
@@ -7,7 +7,8 @@ pub(crate) fn slide_text<S>(slide: &CheckedSlide<S>) -> ManifestSlideText {
     let mut body = Vec::new();
     let mut code = Vec::new();
 
-    for (slot, fragments) in slide.slots() {
+    for (slot, checked_slot) in slide.slots() {
+        let fragments = checked_slot.fragments();
         match slot.as_str() {
             "title" => {
                 title.extend(
@@ -89,7 +90,7 @@ mod tests {
         layout::{parse_layout, Layout},
         mapping::map_by_convention,
         parser::{parse_frontmatter, parse_markdown},
-        phase::{Checked, Deck},
+        phase::{Checked, CheckedSlot, Deck},
     };
 
     #[test]
@@ -173,19 +174,18 @@ mod tests {
 
     #[test]
     fn body_slot_image_markdown_produces_no_text() {
+        let layout = all_slots_layout();
         let body = SlotName::new("body").unwrap();
+        let contract = layout.slot("body").unwrap().clone();
         let mut slots = BTreeMap::new();
         slots.insert(
             body,
-            vec![SourceFragment::paragraph(1, "![Alt text](x.png)")],
+            CheckedSlot::new(
+                contract,
+                vec![SourceFragment::paragraph(1, "![Alt text](x.png)")],
+            ),
         );
-        let slide = CheckedSlide::new(
-            0,
-            SlideKey::new("intro").unwrap(),
-            all_slots_layout(),
-            slots,
-            None,
-        );
+        let slide = CheckedSlide::new(0, SlideKey::new("intro").unwrap(), layout, slots, None);
 
         let text = slide_text(&slide);
 

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -8,13 +8,13 @@ use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
 
 use crate::{
     domain::{
-        AspectRatio, FragmentKind, RenderedSlide, ResolvedImagePath, SlideKey, SlotName,
+        Accepts, AspectRatio, FragmentKind, RenderedSlide, ResolvedImagePath, SlideKey, SlotName,
         SourceFragment,
     },
     error::{BuildError, ErrorKind, Result},
     highlight::Highlighter,
     layout::Layout,
-    phase::{Checked, Deck, Rendered},
+    phase::{Checked, CheckedSlot, Deck, Rendered},
 };
 
 const PDF_FLATTEN_JS: &str = include_str!("pdf_flatten.js");
@@ -45,7 +45,7 @@ pub fn render_deck(
 
 fn render_slide(
     key: &SlideKey,
-    slots: &BTreeMap<SlotName, Vec<SourceFragment<ResolvedImagePath>>>,
+    slots: &BTreeMap<SlotName, CheckedSlot<ResolvedImagePath>>,
     layout: &Layout,
     highlighter: &Highlighter,
 ) -> Result<String> {
@@ -88,9 +88,21 @@ fn render_slide(
                             "rename the slot",
                         ))
                     })?;
-                    let fragments = slot_values.get(&slot).cloned().unwrap_or_default();
-                    let html =
-                        render_slot(&slot, &fragments, highlighter).map_err(box_build_error)?;
+                    let checked_slot = slot_values.get(&slot).ok_or_else(|| {
+                        box_build_error(BuildError::new(
+                            ErrorKind::Layout,
+                            None,
+                            format!("checked slot '{}' is missing its contract", slot.as_str()),
+                            "keep checked slides synchronized with layout slots",
+                        ))
+                    })?;
+                    let html = render_slot(
+                        &slot,
+                        checked_slot.contract().accepts,
+                        checked_slot.fragments(),
+                        highlighter,
+                    )
+                    .map_err(box_build_error)?;
                     el.replace(&html, ContentType::Html);
                     Ok(())
                 }),
@@ -115,6 +127,7 @@ fn render_slide(
 
 fn render_slot(
     slot: &SlotName,
+    accepts: Accepts,
     fragments: &[SourceFragment<ResolvedImagePath>],
     highlighter: &Highlighter,
 ) -> Result<String> {
@@ -123,16 +136,16 @@ fn render_slot(
     }
 
     let class_name = slot.class_name();
-    Ok(match fragments.first().map(SourceFragment::kind) {
-        Some(FragmentKind::Heading { .. }) => {
+    Ok(match accepts {
+        Accepts::Inline => {
             let body = fragments
                 .iter()
-                .map(|fragment| render_heading_inline(fragment.markdown()))
-                .collect::<Vec<_>>()
+                .map(render_heading_inline_fragment)
+                .collect::<Result<Vec<_>>>()?
                 .join(" ");
             format!(r#"<span class="{class_name}">{body}</span>"#)
         }
-        Some(FragmentKind::Code) => {
+        Accepts::Code => {
             let body = fragments
                 .iter()
                 .map(|fragment| render_code_fragment(fragment, highlighter))
@@ -140,25 +153,38 @@ fn render_slot(
                 .join("\n");
             format!(r#"<pre class="{class_name}"><code>{body}</code></pre>"#)
         }
-        Some(FragmentKind::Image { .. }) => {
-            let body = fragments
-                .iter()
-                .map(render_image_fragment)
-                .collect::<Result<Vec<_>>>()?
-                .join("\n");
-            body
-        }
-        _ => {
-            let markdown = fragments
-                .iter()
-                .map(SourceFragment::markdown)
-                .collect::<Vec<_>>()
-                .join("\n\n");
-            let mut body = String::new();
-            html::push_html(&mut body, Parser::new_ext(&markdown, Options::empty()));
-            format!(r#"<div class="{class_name}">{body}</div>"#)
+        Accepts::Image => fragments
+            .iter()
+            .map(render_image_fragment)
+            .collect::<Result<Vec<_>>>()?
+            .join("\n"),
+        Accepts::Blocks | Accepts::Text | Accepts::List => {
+            render_block_slot(&class_name, accepts, fragments)?
         }
     })
+}
+
+fn render_block_slot(
+    class_name: &str,
+    accepts: Accepts,
+    fragments: &[SourceFragment<ResolvedImagePath>],
+) -> Result<String> {
+    for fragment in fragments {
+        ensure_fragment_matches_contract(accepts, fragment)?;
+    }
+    let markdown = fragments
+        .iter()
+        .map(SourceFragment::markdown)
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let mut body = String::new();
+    html::push_html(&mut body, Parser::new_ext(&markdown, Options::empty()));
+    Ok(format!(r#"<div class="{class_name}">{body}</div>"#))
+}
+
+fn render_heading_inline_fragment(fragment: &SourceFragment<ResolvedImagePath>) -> Result<String> {
+    ensure_fragment_matches_contract(Accepts::Inline, fragment)?;
+    Ok(render_heading_inline(fragment.markdown()))
 }
 
 /// A tagged code block is highlighted at build time into `hl-*` classed
@@ -168,6 +194,7 @@ fn render_code_fragment(
     fragment: &SourceFragment<ResolvedImagePath>,
     highlighter: &Highlighter,
 ) -> Result<String> {
+    ensure_fragment_matches_contract(Accepts::Code, fragment)?;
     match fragment.language() {
         Some(language) => highlighter
             .highlight_html(fragment.code_text(), language, fragment.line())
@@ -177,19 +204,61 @@ fn render_code_fragment(
 }
 
 fn render_image_fragment(fragment: &SourceFragment<ResolvedImagePath>) -> Result<String> {
+    ensure_fragment_matches_contract(Accepts::Image, fragment)?;
     match fragment.kind() {
         FragmentKind::Image { alt, src } => Ok(format!(
             r#"<img src="{}" alt="{}">"#,
             encode_double_quoted_attribute(src.as_str()),
             encode_double_quoted_attribute(alt),
         )),
-        other => Err(BuildError::new(
-            ErrorKind::Layout,
-            Some(fragment.line()),
-            format!("expected image fragment, got {other}"),
-            "keep image slots mapped only to image fragments",
-        )),
+        FragmentKind::Heading { .. }
+        | FragmentKind::Paragraph
+        | FragmentKind::Text
+        | FragmentKind::Code
+        | FragmentKind::List
+        | FragmentKind::SlotGroup { .. } => unreachable!("validated by contract guard"),
     }
+}
+
+fn ensure_fragment_matches_contract(
+    accepts: Accepts,
+    fragment: &SourceFragment<ResolvedImagePath>,
+) -> Result<()> {
+    if accepts_fragment(accepts, fragment) {
+        return Ok(());
+    }
+    let expected = expected_fragment_label(accepts);
+    Err(BuildError::new(
+        ErrorKind::Layout,
+        Some(fragment.line()),
+        format!("expected {expected} fragment, got {}", fragment.kind()),
+        format!("keep {accepts} slots mapped only to {expected} fragments"),
+    ))
+}
+
+fn expected_fragment_label(accepts: Accepts) -> &'static str {
+    match accepts {
+        Accepts::Inline => "heading",
+        Accepts::Blocks => "block",
+        Accepts::Text => "text",
+        Accepts::Code => "code",
+        Accepts::Image => "image",
+        Accepts::List => "list",
+    }
+}
+
+fn accepts_fragment(accepts: Accepts, fragment: &SourceFragment<ResolvedImagePath>) -> bool {
+    matches!(
+        (accepts, fragment.kind()),
+        (Accepts::Inline, FragmentKind::Heading { .. })
+            | (Accepts::Blocks, FragmentKind::Heading { .. })
+            | (Accepts::Blocks, FragmentKind::Paragraph)
+            | (Accepts::Blocks, FragmentKind::List)
+            | (Accepts::Text, FragmentKind::Text)
+            | (Accepts::Code, FragmentKind::Code)
+            | (Accepts::Image, FragmentKind::Image { .. })
+            | (Accepts::List, FragmentKind::List)
+    )
 }
 
 fn render_heading_inline(markdown: &str) -> String {
@@ -887,7 +956,7 @@ mod tests {
         layout::parse_layout,
         mapping::map_by_convention,
         parser::{parse_frontmatter, parse_markdown as parse_markdown_impl},
-        phase::{CheckedSlide, DeckSettings, PlannedTime},
+        phase::{CheckedSlide, CheckedSlot, DeckSettings, PlannedTime},
     };
 
     fn parse_markdown(
@@ -1019,14 +1088,18 @@ mod tests {
         )
         .unwrap();
         let hero = SlotName::new("hero").unwrap();
+        let contract = layout.slot("hero").unwrap().clone();
         let mut slots = BTreeMap::new();
         slots.insert(
             hero,
-            vec![SourceFragment::image(
-                3,
-                "<Diagram>, \"Notes\" & emoji 🎉",
-                ResolvedImagePath::from_string("assets/xxx.png".to_owned()),
-            )],
+            CheckedSlot::new(
+                contract,
+                vec![SourceFragment::image(
+                    3,
+                    "<Diagram>, \"Notes\" & emoji 🎉",
+                    ResolvedImagePath::from_string("assets/xxx.png".to_owned()),
+                )],
+            ),
         );
         let checked = Deck::checked(
             DeckSettings::default(),
@@ -1087,6 +1160,50 @@ mod tests {
         let atx_html = render_checked(atx).slides()[0].html().to_owned();
         assert!(atx_html.contains(r#"<span class="slot-title">Architecture</span>"#));
         assert!(!atx_html.contains("Architecture #"));
+    }
+
+    #[test]
+    fn renders_heading_paragraph_and_list_in_blocks_slot_as_block_html() {
+        let markdown = r#"# Title
+
+::: {slot=left}
+
+## Block Heading
+
+Paragraph after heading.
+
+- First
+- Second
+
+:::
+"#;
+        let layout = parse_layout(
+            "two-column",
+            r#"<section>
+  <h1><slot name="title" accepts="inline" arity="1"></slot></h1>
+  <slot name="left" accepts="blocks" arity="1..*"></slot>
+</section>"#,
+        )
+        .unwrap();
+        let checked = check_deck(
+            map_by_convention(
+                parse_markdown(markdown, &crate::highlight::Highlighter::defaults()).unwrap(),
+                &layout,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let rendered = render_checked(checked);
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains(r#"<div class="slot-left">"#));
+        assert!(html.contains("<h2>Block Heading</h2>"));
+        assert!(html.contains("<p>Paragraph after heading.</p>"));
+        assert!(html.contains("<ul>"));
+        assert!(html.contains("<li>First</li>"));
+        assert!(html.contains("<li>Second</li>"));
+        assert!(!html.contains(r#"<span class="slot-left">"#));
     }
 
     #[test]

--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -833,6 +833,30 @@ fn lightning_talk_example_declares_five_minute_planned_duration() {
 }
 
 #[test]
+fn two_column_example_preserves_blocks_slot_paragraph_after_heading() {
+    let out = tempdir().unwrap();
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .current_dir(workspace_root())
+        .args([
+            "build",
+            "examples/two-column/deck.md",
+            "--out",
+            out.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("built 3 slide(s)"));
+
+    let html = fs::read_to_string(out.path().join("slides/001-vs.html")).unwrap();
+    assert!(html.contains("<h2>慣習マッピング</h2>"));
+    assert!(html.contains("見出しは<code>title</code>、コードは<code>code</code>、それ以外はまとめて<code>body</code>。"));
+    assert!(html.contains("<h2>明示指定</h2>"));
+    assert!(html.contains("複数の<code>blocks</code> slotを持つレイアウト"));
+}
+
+#[test]
 fn lightning_talk_example_declares_agenda_sections() {
     let out = tempdir().unwrap();
 

--- a/docs/plans/2026-07-08-issue-175-render-slot-contract.md
+++ b/docs/plans/2026-07-08-issue-175-render-slot-contract.md
@@ -1,0 +1,29 @@
+# Issue 175: render slots by checked contract
+
+## Problem
+
+`render_slot` dispatches from the first fragment kind. A `blocks` slot that starts
+with a heading is rendered through the inline-heading path, so later paragraph or
+list fragments can become empty output. This violates the no-silent-drop
+invariant because the checked slot contract is ignored after checking.
+
+## Plan
+
+1. Add red tests for a `blocks` slot containing heading, paragraph, and list
+   fragments; inline title rendering; code/image rendering; and the two-column
+   example slide that currently loses paragraph text.
+2. Preserve slot contracts in the checked phase by carrying a checked slot value
+   instead of only `Vec<SourceFragment>`.
+3. Pass the checked `Accepts` contract into `render_slot`.
+4. Replace first-fragment dispatch with an exhaustive `Accepts` match. Keep
+   inline/code/image behavior unchanged; render `blocks`, `list`, and existing
+   `text` slots through markdown block rendering.
+5. Keep mismatch handling explicit in specialized branches so accidental
+   contract drift returns a build error instead of producing silent output loss.
+
+## Gates
+
+- `cargo fmt --all --check`
+- `cargo test --workspace` three consecutive times
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `git diff --exit-code bindings/`


### PR DESCRIPTION
Closes #175

## Summary
- `render_slot` was inferring the rendering strategy from the kind of `fragments.first()`, so when the first fragment of a blocks slot was a heading, subsequent paragraphs and lists were **silently dropped** through `render_heading_inline` (real impact: two-column comparison slides were being deployed with empty panels). Violation of pillar 3 (silent drop is forbidden).
- The fix is contract-based: `CheckedSlot { contract, fragments }` carries the contract into the Checked phase, and `render_slot` takes `Accepts` as a required argument with an **exhaustive match** (no `_` arm). Inline stays as spans, Code/Image keep prior behavior + explicit errors on out-of-contract fragments, and Blocks/Text/List render real blocks (headings inside blocks come out as h2/h3).
- Also added a guard in `check_deck` at the Checked conversion so "slots the layout does not declare" cannot be silently dropped (unreachable structurally today, but this closes the future silent-drop path with an error rather than at the type level, in case mapping changes).
- Because the type signature demands the contract, a future call site that renders without consulting the contract is not reproducible.

## Test plan
- [x] TDD: blocks slot [Heading, Paragraph, List] → h2/p/ul output (Red confirmed before implementation)
- [x] Integration: examples/two-column 001-vs.html contains h2 + paragraph text (Red confirmed before implementation)
- [x] inline (title) / code / image slot existing behavior unchanged
- [x] Unit test for the residual slot guard
- [x] cargo test --workspace (x3) / clippy -D warnings / fmt / bindings drift
- [x] npm ci + build + test (166) + typecheck / no dist drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
