### PR TITLE
fix: keep click navigation from swallowing text-selection gestures

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -438,7 +438,28 @@ pub fn render_distribution_index(aspect_ratio: AspectRatio) -> String {
         exitToIndex();
       }
     });
+    // Click-selection guard. Kept in sync with
+    // packages/peitho-present/src/clickNavigationGuard.ts.
+    let __clickStart = null;
+    document.addEventListener('mousedown', (event) => {
+      __clickStart = { x: event.clientX, y: event.clientY };
+    });
+    function hasNonCollapsedSelection() {
+      const selection = window.getSelection();
+      return selection !== null && !selection.isCollapsed;
+    }
+    function shouldIgnoreNavigationClick(event) {
+      if (hasNonCollapsedSelection()) {
+        __clickStart = null;
+        return true;
+      }
+      if (__clickStart === null) return false;
+      const moved = Math.hypot(event.clientX - __clickStart.x, event.clientY - __clickStart.y) > 5;
+      __clickStart = null;
+      return moved;
+    }
     document.addEventListener('click', (event) => {
+      if (shouldIgnoreNavigationClick(event)) return;
       navigate(event.clientX < window.innerWidth / 4 ? 'prev' : 'next');
     });
     let __swipeState = null;
@@ -1280,6 +1301,16 @@ Paragraph after heading.
         assert!(!html.contains("shell.js"));
         assert!(!html.contains("installPresentationControls"));
         assert!(!html.contains("data-slide-key="));
+    }
+
+    #[test]
+    fn distribution_index_click_navigation_ignores_selection_gestures() {
+        let html = render_distribution_index(AspectRatio::Ratio16To9);
+
+        assert!(html.contains("window.getSelection()"));
+        assert!(html.contains("__clickStart"));
+        assert!(html.contains("Math.hypot(event.clientX - __clickStart.x"));
+        assert!(html.contains("return selection !== null && !selection.isCollapsed"));
     }
 
     #[test]

--- a/docs/plans/2026-07-08-issue-178-click-selection-navigation.md
+++ b/docs/plans/2026-07-08-issue-178-click-selection-navigation.md
@@ -1,0 +1,35 @@
+# Issue 178: ignore selection gestures in click navigation
+
+## Problem
+
+Mouse-based slide navigation currently treats every `click` as navigation.
+Browsers still fire `click` after drag-selecting text or double-click-selecting a
+word, so the slide changes and the user's selection is immediately cleared.
+
+The behavior exists in three places: the present shell canvas click installer,
+the distribution page inline script, and preview grid tile clicks.
+
+## Plan
+
+1. Add red Vitest coverage for selection and drag-ending clicks in the present
+   click installer, plus the same guard on preview grid tile clicks.
+2. Add a shared TypeScript helper in `packages/peitho-present/src/` that records
+   pointer-down coordinates and decides whether a click should be ignored when
+   selection is non-collapsed or movement exceeds the 5 px threshold.
+3. Wire the helper into `controls.ts` and `preview.ts` without changing existing
+   control-bar exclusion or touch swipe behavior.
+4. Add a Rust template pin test for the distribution inline script, then mirror
+   the same selection and movement guard there with comments marking the TS
+   helper as the source to keep in sync.
+5. Rebuild the presentation package so `dist/shell.js` and `dist/preview.js`
+   carry the generated updates.
+
+## Gates
+
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --exit-code bindings/`
+- `cd packages/peitho-present && npm ci && npm run build && npm test && npm run typecheck`
+- `git diff --exit-code packages/peitho-present/dist/shell.js`
+- `git diff --exit-code packages/peitho-present/dist/preview.js`

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -12,6 +12,34 @@ function calculateCanvasFit(viewport, canvasWidth, canvasHeight) {
   };
 }
 
+// src/clickNavigationGuard.ts
+var DEFAULT_MOVE_THRESHOLD_PX = 5;
+function createClickNavigationGuard(options) {
+  const win = options.window ?? window;
+  const moveThresholdPx = options.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+  let clickStart = null;
+  const onMouseDown = (event) => {
+    clickStart = { x: event.clientX, y: event.clientY };
+  };
+  options.target.addEventListener("mousedown", onMouseDown);
+  return {
+    shouldIgnoreClick(event) {
+      const start = clickStart;
+      clickStart = null;
+      if (hasNonCollapsedSelection(win)) return true;
+      if (start === null) return false;
+      return Math.hypot(event.clientX - start.x, event.clientY - start.y) > moveThresholdPx;
+    },
+    destroy() {
+      options.target.removeEventListener("mousedown", onMouseDown);
+    }
+  };
+}
+function hasNonCollapsedSelection(win) {
+  const selection = win.getSelection();
+  return selection !== null && !selection.isCollapsed;
+}
+
 // src/keyboard.ts
 var navigationKeyMap = /* @__PURE__ */ new Map([
   ["ArrowRight", "next"],
@@ -267,6 +295,7 @@ var PreviewShellController = class {
   viewport;
   restoredState;
   slides = [];
+  tileClickGuardCleanups = [];
   dimensions = { width: 1280, height: 720 };
   onNavigate = (event) => {
     if (!this.isLoaded()) return;
@@ -368,6 +397,7 @@ var PreviewShellController = class {
     this.bus.removeEventListener("peitho:navigate", this.onNavigate);
     this.bus.removeEventListener("peitho:overviewrequest", this.onOverviewRequest);
     this.win.removeEventListener("resize", this.onResize);
+    while (this.tileClickGuardCleanups.length > 0) this.tileClickGuardCleanups.pop()?.();
     this.clearCanvasRootProperties();
   }
   async fetchJson(url) {
@@ -396,7 +426,10 @@ var PreviewShellController = class {
     tile.classList.add("peitho-preview-tile");
     tile.dataset.slideKey = slide.key;
     tile.dataset.slideIndex = String(slide.index);
-    tile.addEventListener("click", () => {
+    const clickGuard = createClickNavigationGuard({ target: tile, window: this.win });
+    this.tileClickGuardCleanups.push(() => clickGuard.destroy());
+    tile.addEventListener("click", (event) => {
+      if (clickGuard.shouldIgnoreClick(event)) return;
       this.setIndex(slide.index);
       this.exitGrid();
     });

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -315,6 +315,34 @@ function diffSeconds(actual, planned) {
   return Math.round((actual - planned) / 1e3);
 }
 
+// src/clickNavigationGuard.ts
+var DEFAULT_MOVE_THRESHOLD_PX = 5;
+function createClickNavigationGuard(options) {
+  const win = options.window ?? window;
+  const moveThresholdPx = options.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+  let clickStart = null;
+  const onMouseDown = (event) => {
+    clickStart = { x: event.clientX, y: event.clientY };
+  };
+  options.target.addEventListener("mousedown", onMouseDown);
+  return {
+    shouldIgnoreClick(event) {
+      const start = clickStart;
+      clickStart = null;
+      if (hasNonCollapsedSelection(win)) return true;
+      if (start === null) return false;
+      return Math.hypot(event.clientX - start.x, event.clientY - start.y) > moveThresholdPx;
+    },
+    destroy() {
+      options.target.removeEventListener("mousedown", onMouseDown);
+    }
+  };
+}
+function hasNonCollapsedSelection(win) {
+  const selection = win.getSelection();
+  return selection !== null && !selection.isCollapsed;
+}
+
 // src/keyboard.ts
 var navigationKeyMap = /* @__PURE__ */ new Map([
   ["ArrowRight", "next"],
@@ -450,13 +478,18 @@ function installPresentationControls(options) {
 function installCanvasClickNavigation(options) {
   const win = options.window ?? window;
   const bus = options.bus ?? win;
+  const clickGuard = createClickNavigationGuard({ target: options.root, window: win });
   const onClick = (event) => {
+    if (clickGuard.shouldIgnoreClick(event)) return;
     if (event.target.closest('[data-peitho-control-bar="true"]')) return;
     const to = event.clientX < win.innerWidth / 4 ? "prev" : "next";
     bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
   };
   options.root.addEventListener("click", onClick);
-  return () => options.root.removeEventListener("click", onClick);
+  return () => {
+    clickGuard.destroy();
+    options.root.removeEventListener("click", onClick);
+  };
 }
 function installSwipeNavigation(options) {
   const win = options.window ?? window;

--- a/packages/peitho-present/src/clickNavigationGuard.ts
+++ b/packages/peitho-present/src/clickNavigationGuard.ts
@@ -1,0 +1,50 @@
+export type ClickNavigationGuardOptions = {
+  target: HTMLElement;
+  window?: Window;
+  moveThresholdPx?: number;
+};
+
+export type ClickNavigationGuard = {
+  shouldIgnoreClick(event: MouseEvent): boolean;
+  destroy(): void;
+};
+
+const DEFAULT_MOVE_THRESHOLD_PX = 5;
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+// Kept in sync with crates/peitho-core/src/render.rs render_distribution_index.
+export function createClickNavigationGuard(
+  options: ClickNavigationGuardOptions
+): ClickNavigationGuard {
+  const win = options.window ?? window;
+  const moveThresholdPx = options.moveThresholdPx ?? DEFAULT_MOVE_THRESHOLD_PX;
+  let clickStart: Point | null = null;
+
+  const onMouseDown = (event: MouseEvent): void => {
+    clickStart = { x: event.clientX, y: event.clientY };
+  };
+
+  options.target.addEventListener("mousedown", onMouseDown);
+
+  return {
+    shouldIgnoreClick(event: MouseEvent): boolean {
+      const start = clickStart;
+      clickStart = null;
+      if (hasNonCollapsedSelection(win)) return true;
+      if (start === null) return false;
+      return Math.hypot(event.clientX - start.x, event.clientY - start.y) > moveThresholdPx;
+    },
+    destroy(): void {
+      options.target.removeEventListener("mousedown", onMouseDown);
+    }
+  };
+}
+
+function hasNonCollapsedSelection(win: Window): boolean {
+  const selection = win.getSelection();
+  return selection !== null && !selection.isCollapsed;
+}

--- a/packages/peitho-present/src/controls.ts
+++ b/packages/peitho-present/src/controls.ts
@@ -1,4 +1,5 @@
 import type { NavigateDetail, SlideChangeDetail } from "./shell";
+import { createClickNavigationGuard } from "./clickNavigationGuard";
 import { hasChordModifier } from "./keyboard";
 import { openPresenterPopup, type OpenPresenterPopupOptions } from "./presentDisplay";
 
@@ -106,13 +107,18 @@ export function installPresentationControls(options: PresentationControlsOptions
 export function installCanvasClickNavigation(options: CanvasClickNavigationOptions): () => void {
   const win = options.window ?? window;
   const bus = options.bus ?? win;
+  const clickGuard = createClickNavigationGuard({ target: options.root, window: win });
   const onClick = (event: MouseEvent): void => {
+    if (clickGuard.shouldIgnoreClick(event)) return;
     if ((event.target as HTMLElement).closest('[data-peitho-control-bar="true"]')) return;
     const to = event.clientX < win.innerWidth / 4 ? "prev" : "next";
     bus.dispatchEvent(new CustomEvent<NavigateDetail>("peitho:navigate", { detail: { to } }));
   };
   options.root.addEventListener("click", onClick);
-  return () => options.root.removeEventListener("click", onClick);
+  return () => {
+    clickGuard.destroy();
+    options.root.removeEventListener("click", onClick);
+  };
 }
 
 export function installSwipeNavigation(options: SwipeNavigationOptions): () => void {

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -1,6 +1,7 @@
 import type { Manifest } from "../../../bindings/Manifest";
 import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { calculateCanvasFit, type CanvasViewport } from "./canvas";
+import { createClickNavigationGuard } from "./clickNavigationGuard";
 import { hasChordModifier } from "./keyboard";
 import type { NavigateTarget, SlideChangeDetail } from "./shell";
 import {
@@ -163,6 +164,7 @@ class PreviewShellController implements PreviewShell {
   private readonly viewport?: () => CanvasViewport;
   private readonly restoredState: PreviewState | null;
   private readonly slides: PreviewSlideView[] = [];
+  private readonly tileClickGuardCleanups: Array<() => void> = [];
   private dimensions: CanvasDimensions = { width: 1280, height: 720 };
   private readonly onNavigate = (event: Event): void => {
     if (!this.isLoaded()) return;
@@ -270,6 +272,7 @@ class PreviewShellController implements PreviewShell {
     this.bus.removeEventListener("peitho:navigate", this.onNavigate);
     this.bus.removeEventListener("peitho:overviewrequest", this.onOverviewRequest);
     this.win.removeEventListener("resize", this.onResize);
+    while (this.tileClickGuardCleanups.length > 0) this.tileClickGuardCleanups.pop()?.();
     this.clearCanvasRootProperties();
   }
 
@@ -303,7 +306,10 @@ class PreviewShellController implements PreviewShell {
     tile.classList.add("peitho-preview-tile");
     tile.dataset.slideKey = slide.key;
     tile.dataset.slideIndex = String(slide.index);
-    tile.addEventListener("click", () => {
+    const clickGuard = createClickNavigationGuard({ target: tile, window: this.win });
+    this.tileClickGuardCleanups.push(() => clickGuard.destroy());
+    tile.addEventListener("click", (event) => {
+      if (clickGuard.shouldIgnoreClick(event)) return;
       this.setIndex(slide.index);
       this.exitGrid();
     });

--- a/packages/peitho-present/test/controls.test.ts
+++ b/packages/peitho-present/test/controls.test.ts
@@ -31,6 +31,10 @@ function touchEvent(
   return event;
 }
 
+function mockSelection(isCollapsed: boolean): void {
+  vi.spyOn(window, "getSelection").mockReturnValue({ isCollapsed } as Selection);
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
 });
@@ -170,6 +174,7 @@ it("clicks in the left viewport quarter request prev and other canvas clicks req
   const root = document.createElement("main");
   const requests: unknown[] = [];
   vi.spyOn(window, "innerWidth", "get").mockReturnValue(1000);
+  mockSelection(true);
   listenWindow("peitho:navigate", (event) => {
     requests.push((event as CustomEvent).detail);
   });
@@ -183,9 +188,43 @@ it("clicks in the left viewport quarter request prev and other canvas clicks req
   expect(requests).toEqual([{ to: "prev" }, { to: "next" }, { to: "next" }]);
 });
 
+it("does not navigate from a click that ends a drag gesture", () => {
+  const root = document.createElement("main");
+  const requests: unknown[] = [];
+  mockSelection(true);
+  listenWindow("peitho:navigate", (event) => {
+    requests.push((event as CustomEvent).detail);
+  });
+  const cleanup = installCanvasClickNavigation({ root, window, bus: window });
+  cleanups.push(cleanup);
+
+  root.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 100, clientY: 100 }));
+  root.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 112, clientY: 100 }));
+  root.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 112, clientY: 100 }));
+  root.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 112, clientY: 100 }));
+
+  expect(requests).toEqual([]);
+});
+
+it("does not navigate from a click while text selection is non-collapsed", () => {
+  const root = document.createElement("main");
+  const requests: unknown[] = [];
+  mockSelection(false);
+  listenWindow("peitho:navigate", (event) => {
+    requests.push((event as CustomEvent).detail);
+  });
+  const cleanup = installCanvasClickNavigation({ root, window, bus: window });
+  cleanups.push(cleanup);
+
+  root.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 900 }));
+
+  expect(requests).toEqual([]);
+});
+
 it("does not navigate when a click starts inside the control bar", () => {
   const root = document.createElement("main");
   const requests: unknown[] = [];
+  mockSelection(true);
   listenWindow("peitho:navigate", (event) => {
     requests.push((event as CustomEvent).detail);
   });

--- a/packages/peitho-present/test/preview.test.ts
+++ b/packages/peitho-present/test/preview.test.ts
@@ -88,6 +88,10 @@ function setRootWidth(root: HTMLElement, width: number): void {
   });
 }
 
+function mockSelection(isCollapsed: boolean): void {
+  vi.spyOn(window, "getSelection").mockReturnValue({ isCollapsed } as Selection);
+}
+
 const shells: PreviewShell[] = [];
 const cleanups: Array<() => void> = [];
 
@@ -366,12 +370,45 @@ it("clicking a grid tile shows that slide in single mode", async () => {
   const bus = new EventTarget();
   const root = document.createElement("main");
   const shell = await mountForTest(root, bus);
+  mockSelection(true);
 
   bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "toggle" } }));
   root.querySelectorAll<HTMLElement>(".peitho-preview-tile")[2].click();
 
   expect(shell.mode).toBe("single");
   expect(shell.currentIndex).toBe(2);
+});
+
+it("dragging across a grid tile does not activate it on the follow-up click", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+  mockSelection(true);
+
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "toggle" } }));
+  const tile = root.querySelectorAll<HTMLElement>(".peitho-preview-tile")[2];
+  tile.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX: 100, clientY: 100 }));
+  tile.dispatchEvent(new MouseEvent("mousemove", { bubbles: true, clientX: 112, clientY: 100 }));
+  tile.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, clientX: 112, clientY: 100 }));
+  tile.dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 112, clientY: 100 }));
+
+  expect(shell.mode).toBe("grid");
+  expect(shell.currentIndex).toBe(0);
+});
+
+it("clicking a grid tile with non-collapsed selection does not activate it", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+  mockSelection(false);
+
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "toggle" } }));
+  root
+    .querySelectorAll<HTMLElement>(".peitho-preview-tile")[2]
+    .dispatchEvent(new MouseEvent("click", { bubbles: true, clientX: 900 }));
+
+  expect(shell.mode).toBe("grid");
+  expect(shell.currentIndex).toBe(0);
 });
 
 it("saves and restores mode and slide index from sessionStorage", async () => {


### PR DESCRIPTION
Closes #178

## Summary
- The click-to-advance feature fired on every click, so the terminating click of a drag selection or the click of a double-click selection triggered navigate, effectively making text on slides unselectable.
- Apply a single invariant to all three click paths (present shell `installCanvasClickNavigation` / dist audience-page inline script / preview grid tile): **a click that ended a selection gesture does not navigate.**
  - If a non-collapsed selection exists at click time → suppress (leave the selection intact)
  - If movement distance from mousedown > 5px → suppress
- The TS side is consolidated in the shared helper `clickNavigationGuard.ts`. The dist inline script gets an equivalent implementation with a kept-in-sync comment, in the same style as the swipe threshold.

## Test plan
- [x] vitest: suppress drag-end click / click with existing selection, preserve normal click behavior, apply to preview tiles (TDD, 170 tests)
- [x] Rust: pin that the dist template contains the guard
- [x] cargo test --workspace (x3) / clippy / fmt / bindings drift
- [x] Real-browser E2E (3 cases): drag-equivalent click suppressed / click-with-selection suppressed + selection preserved / normal click navigates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
