### PR TITLE
feat: follow the preview grid selection with scroll and make Esc a toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ peitho build            # same as: peitho build deck.md
 # Daily editing loop: watch, serve, open, and reload on every successful rebuild
 peitho preview
 
-# Preview controls: o or Enter toggles single-slide and tile overview modes; Esc exits overview; arrows move horizontally and vertically in overview; click opens the selected tile
+# Preview controls: o, Enter, or Esc toggles single-slide and tile overview modes; arrows move horizontally and vertically in overview; click opens the selected tile
 
 # Rebuild on every save for an external server or pipeline
 peitho build --watch

--- a/docs/plans/2026-07-08-issue-181-escape-overview-toggle.md
+++ b/docs/plans/2026-07-08-issue-181-escape-overview-toggle.md
@@ -1,0 +1,31 @@
+# Issue 181 follow-up: Escape toggles preview overview
+
+## Problem
+
+Preview keyboard handling currently emits `peitho:overviewrequest` with
+`{ action: "exit" }` for Escape. That preserves grid-to-single behavior, but it
+does not let users enter grid overview from single mode even though `o`, Enter,
+and reveal.js-style Escape conventions are toggle-oriented.
+
+## Plan
+
+1. Update red Vitest coverage so keyboard Escape emits `toggle` instead of
+   `exit`, while chord-modified Escape remains ignored.
+2. Replace the old shell behavior test that expected single-mode Escape/exit to
+   be a no-op with coverage for Escape toggling single-to-grid and grid-to-single
+   through keyboard events.
+3. Change only the keyboard mapping from `exit` to `toggle`; keep the `exit`
+   action and shell handler for internal/direct request paths.
+4. Update README preview controls to describe `o`, Enter, and Esc as overview
+   toggles.
+5. Rebuild `packages/peitho-present/dist/preview.js`; `dist/shell.js` should
+   remain unchanged.
+
+## Gates
+
+- `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `git diff --check`
+- Verify `packages/peitho-present/dist/shell.js` is unchanged and
+  `packages/peitho-present/dist/preview.js` is rebuilt.

--- a/docs/plans/2026-07-08-issue-181-preview-grid-scroll.md
+++ b/docs/plans/2026-07-08-issue-181-preview-grid-scroll.md
@@ -1,0 +1,31 @@
+# Issue 181: preview grid follows the selected tile
+
+## Problem
+
+In `peitho preview` grid mode, keyboard navigation can move the selected tile
+outside the scroll viewport. The selection state updates, but the grid container
+does not scroll, so the visible selection outline is lost on decks with many
+slides.
+
+## Plan
+
+1. Add red Vitest coverage in `packages/peitho-present/test/preview.test.ts`
+   for grid arrow navigation, grid entry, and single-mode navigation. Tests will
+   attach a spy to tile-level `scrollIntoView` because jsdom does not implement
+   it.
+2. Add a small `PreviewShellController` helper that scrolls the selected tile
+   with `{ block: "nearest" }` only while the preview is in grid mode.
+3. Call the helper from the grid layout path so both `enterGrid` and `setIndex`
+   changes are covered, while guarding environments where `scrollIntoView` is
+   absent.
+4. Rebuild `packages/peitho-present/dist/preview.js`; `dist/shell.js` should not
+   change.
+
+## Gates
+
+- `cd packages/peitho-present && npm ci && npm run build && npm test && npm run typecheck`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `git diff --check`
+- Verify `packages/peitho-present/dist/shell.js` is unchanged and
+  `packages/peitho-present/dist/preview.js` is rebuilt.

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -231,7 +231,7 @@ function installPreviewKeyboard(win = window, bus = win) {
     }
     if (event.key === "Escape") {
       event.preventDefault();
-      dispatchOverviewRequest(bus, "exit");
+      dispatchOverviewRequest(bus, "toggle");
       return;
     }
     if (event.key === "Enter") {
@@ -593,6 +593,10 @@ var PreviewShellController = class {
       slide.host.hidden = false;
       this.applyHostFrame(slide.host, 0, 0, scale);
     });
+    this.scrollSelectedTileIntoView();
+  }
+  scrollSelectedTileIntoView() {
+    this.slides[this.selectedIndex]?.tile.scrollIntoView?.({ block: "nearest" });
   }
   applyHostFrame(host, left, top, scale) {
     host.style.position = "absolute";

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -92,7 +92,7 @@ export function installPreviewKeyboard(
     }
     if (event.key === "Escape") {
       event.preventDefault();
-      dispatchOverviewRequest(bus, "exit");
+      dispatchOverviewRequest(bus, "toggle");
       return;
     }
     if (event.key === "Enter") {
@@ -494,6 +494,11 @@ class PreviewShellController implements PreviewShell {
       slide.host.hidden = false;
       this.applyHostFrame(slide.host, 0, 0, scale);
     });
+    this.scrollSelectedTileIntoView();
+  }
+
+  private scrollSelectedTileIntoView(): void {
+    this.slides[this.selectedIndex]?.tile.scrollIntoView?.({ block: "nearest" });
   }
 
   private applyHostFrame(host: HTMLElement, left: number, top: number, scale: number): void {

--- a/packages/peitho-present/test/preview.test.ts
+++ b/packages/peitho-present/test/preview.test.ts
@@ -212,7 +212,7 @@ it("preview keyboard emits command requests and ignores chord-modified commands"
     window.dispatchEvent(event);
   }
 
-  expect(requests).toEqual([{ action: "exit" }, { action: "activate" }]);
+  expect(requests).toEqual([{ action: "toggle" }, { action: "activate" }]);
   expect(navigations).toEqual([{ to: "next" }, { to: "up" }, { to: "down" }]);
   expect(bareEscape.defaultPrevented).toBe(true);
   expect(chordEscape.defaultPrevented).toBe(false);
@@ -241,7 +241,7 @@ it("overview requests toggle between single and grid mode", async () => {
   expect(root.dataset.peithoPreviewMode).toBe("single");
 });
 
-it("Escape exits grid mode and is a no-op in single mode", async () => {
+it("exit overview requests exit grid mode and are a no-op in single mode", async () => {
   const bus = new EventTarget();
   const root = document.createElement("main");
   const shell = await mountForTest(root, bus);
@@ -253,6 +253,29 @@ it("Escape exits grid mode and is a no-op in single mode", async () => {
   expect(shell.mode).toBe("grid");
   bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "exit" } }));
   expect(shell.mode).toBe("single");
+});
+
+it("Escape toggles between single and grid mode with the current slide selected", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+  cleanups.push(installPreviewKeyboard(window, bus));
+
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 2 } } }));
+  const enterGrid = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+  window.dispatchEvent(enterGrid);
+
+  expect(enterGrid.defaultPrevented).toBe(true);
+  expect(shell.mode).toBe("grid");
+  expect(shell.currentIndex).toBe(2);
+  expect(shell.selectedIndex).toBe(2);
+
+  const exitGrid = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+  window.dispatchEvent(exitGrid);
+
+  expect(exitGrid.defaultPrevented).toBe(true);
+  expect(shell.mode).toBe("single");
+  expect(shell.currentIndex).toBe(2);
 });
 
 it("Enter activate request enters grid from single mode with the current slide selected", async () => {
@@ -286,6 +309,56 @@ it("grid arrow navigation moves selection and Enter shows the selected slide", a
   expect(shell.currentIndex).toBe(1);
   const hosts = [...root.querySelectorAll<HTMLElement>(".peitho-preview-slide")];
   expect(hosts.map((host) => host.hidden)).toEqual([true, false, true]);
+});
+
+it("grid arrow navigation scrolls the selected tile into view", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "toggle" } }));
+  const targetTile = root.querySelectorAll<HTMLElement>(".peitho-preview-tile")[1];
+  const scrollIntoView = vi.fn();
+  targetTile.scrollIntoView = scrollIntoView;
+
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+
+  expect(shell.mode).toBe("grid");
+  expect(shell.selectedIndex).toBe(1);
+  expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+});
+
+it("entering grid scrolls the current slide tile into view", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 2 } } }));
+  const targetTile = root.querySelectorAll<HTMLElement>(".peitho-preview-tile")[2];
+  const scrollIntoView = vi.fn();
+  targetTile.scrollIntoView = scrollIntoView;
+  expect(scrollIntoView).not.toHaveBeenCalled();
+
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "enter" } }));
+
+  expect(shell.mode).toBe("grid");
+  expect(shell.selectedIndex).toBe(2);
+  expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+});
+
+it("single mode navigation does not scroll preview tiles into view", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+  const targetTile = root.querySelectorAll<HTMLElement>(".peitho-preview-tile")[1];
+  const scrollIntoView = vi.fn();
+  targetTile.scrollIntoView = scrollIntoView;
+
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+
+  expect(shell.mode).toBe("single");
+  expect(shell.currentIndex).toBe(1);
+  expect(scrollIntoView).not.toHaveBeenCalled();
 });
 
 it("grid vertical navigation moves by one computed row and stops at row edges", async () => {


### PR DESCRIPTION
Closes #181

## Summary
- **Scroll follow**: when the selection in grid moves to an off-screen tile, follow with `scrollIntoView({block:"nearest"})` (no movement if already visible). Also applied to the initial selection when entering grid. Environments without scrollIntoView do not crash.
- **Esc bidirectional toggle**: Esc during single now enters grid (matching the reveal.js ESC convention). The keyboard emits "toggle"; the "exit" action remains for shell-internal paths such as tile clicks.

## Test plan
- [x] TDD (Red first): arrow-move fires scrollIntoView on the selected tile / on grid entry / not fired in single / Esc for single→grid and grid→single (174 tests)
- [x] Real-browser E2E (24-slide deck): confirmed scrollTop 0→481 with the selected tile visible under repeated ↓, ↑ scrolls back, Esc round-trips grid⇄single
- [x] All npm gates + dist/preview.js rebuild, cargo fmt/clippy/bindings unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
