### PR TITLE
fix: give the preview grid scroll-follow breathing room at the edges

### DIFF
--- a/docs/plans/2026-07-08-issue-185-preview-grid-scroll-padding.md
+++ b/docs/plans/2026-07-08-issue-185-preview-grid-scroll-padding.md
@@ -1,0 +1,30 @@
+# Issue 185: preview grid scroll padding
+
+## Problem
+
+In `peitho preview` grid mode, selected tiles can be scrolled exactly against
+the top or bottom edge of the scroll viewport. The selected tile remains
+visible, but there is no breathing room to show adjacent rows.
+
+## Plan
+
+1. Add red Vitest coverage in `packages/peitho-present/test/preview.test.ts`
+   that grid mode sets `scroll-padding-top` and `scroll-padding-bottom` on the
+   preview root.
+2. Extend that coverage to switch back to single mode and verify the scroll
+   padding is removed.
+3. Set the grid scroll padding in `applyGridLayout` to match `GRID_PADDING`
+   (`24px`) so existing `scrollIntoView({ block: "nearest" })` behavior can use
+   the same edge inset as the grid padding.
+4. Clear only those scroll-padding properties in `applySingleLayout`.
+5. Rebuild `packages/peitho-present/dist/preview.js`; `dist/shell.js` should not
+   change.
+
+## Gates
+
+- `cd packages/peitho-present && npm ci && npm run build && npm test && npm run typecheck`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `git diff --check`
+- Verify `packages/peitho-present/dist/shell.js` is unchanged and
+  `packages/peitho-present/dist/preview.js` is rebuilt.

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -546,6 +546,8 @@ var PreviewShellController = class {
     this.root.style.padding = "0";
     this.root.style.gap = "0";
     this.root.style.gridTemplateColumns = "";
+    this.root.style.removeProperty("scroll-padding-top");
+    this.root.style.removeProperty("scroll-padding-bottom");
     this.slides.forEach((slide, index) => {
       const active = index === this.currentIndex;
       slide.tile.hidden = !active;
@@ -573,6 +575,8 @@ var PreviewShellController = class {
     this.root.style.justifyContent = "center";
     this.root.style.overflow = "auto";
     this.root.style.padding = `${GRID_PADDING}px`;
+    this.root.style.setProperty("scroll-padding-top", `${GRID_PADDING}px`);
+    this.root.style.setProperty("scroll-padding-bottom", `${GRID_PADDING}px`);
     this.root.style.boxSizing = "border-box";
     this.slides.forEach((slide, index) => {
       const selected = index === this.selectedIndex;

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -441,6 +441,8 @@ class PreviewShellController implements PreviewShell {
     this.root.style.padding = "0";
     this.root.style.gap = "0";
     this.root.style.gridTemplateColumns = "";
+    this.root.style.removeProperty("scroll-padding-top");
+    this.root.style.removeProperty("scroll-padding-bottom");
 
     this.slides.forEach((slide, index) => {
       const active = index === this.currentIndex;
@@ -471,6 +473,8 @@ class PreviewShellController implements PreviewShell {
     this.root.style.justifyContent = "center";
     this.root.style.overflow = "auto";
     this.root.style.padding = `${GRID_PADDING}px`;
+    this.root.style.setProperty("scroll-padding-top", `${GRID_PADDING}px`);
+    this.root.style.setProperty("scroll-padding-bottom", `${GRID_PADDING}px`);
     this.root.style.boxSizing = "border-box";
 
     this.slides.forEach((slide, index) => {

--- a/packages/peitho-present/test/preview.test.ts
+++ b/packages/peitho-present/test/preview.test.ts
@@ -328,6 +328,24 @@ it("grid arrow navigation scrolls the selected tile into view", async () => {
   expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
 });
 
+it("grid mode sets scroll padding and single mode clears it", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "toggle" } }));
+
+  expect(shell.mode).toBe("grid");
+  expect(root.style.scrollPaddingTop).toBe("24px");
+  expect(root.style.scrollPaddingBottom).toBe("24px");
+
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "toggle" } }));
+
+  expect(shell.mode).toBe("single");
+  expect(root.style.scrollPaddingTop).toBe("");
+  expect(root.style.scrollPaddingBottom).toBe("");
+});
+
 it("entering grid scrolls the current slide tile into view", async () => {
   const bus = new EventTarget();
   const root = document.createElement("main");


### PR DESCRIPTION
Closes #185

## Summary
- Grid scroll follow was leaving edge tiles glued to the viewport edge. Fix by setting `scroll-padding-top/bottom: 24px` (matching the grid's own padding) on the container. `scrollIntoView({block:"nearest"})` honors scroll-padding, so this is a CSS-property-only change.
- The property is cleared in single mode.

## Test plan
- [x] TDD (Red first): scroll-padding set for grid / cleared for single (175 tests)
- [x] Real-browser E2E (24-slide deck): after moving to the top/bottom edge tile, measured 24px margin between the tile edge and the viewport edge
- [x] All npm gates + dist/preview.js rebuild, shell.js unchanged, cargo fmt/clippy unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
