### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.3.0"
+version = "1.3.1"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.3.0 to 1.3.1 (grid scroll padding #187, eliminate ETXTBSY in fake-chrome tests #186).

## Test plan
- [x] cargo test --workspace (x3) / clippy / fmt / bindings drift
- [x] npm ci + build + test (175) + typecheck / no dist drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
