### PR TITLE
docs: watch error resilience — design and implementation plan

### DIFF
--- a/docs/plans/2026-07-08-watch-error-resilience.md
+++ b/docs/plans/2026-07-08-watch-error-resilience.md
@@ -1,0 +1,1143 @@
+# Watch error resilience implementation plan
+
+<!-- constrained-by ../specs/2026-07-08-watch-error-resilience-design.md -->
+
+## Scope
+
+`peitho preview` / `peitho build --watch` の watch ループを、監視中ディレクトリの削除・復活・配下ディレクトリ追加で終了させない。採用設計は [`../specs/2026-07-08-watch-error-resilience-design.md`](../specs/2026-07-08-watch-error-resilience-design.md) の §5(C) に固定する。
+
+`clippy::too_many_arguments` を避けるため、実 watch 集合と watch 関連状態は `WatchState` に束ねる。
+
+```rust
+struct WatchState {
+    input: PathBuf,
+    targets: WatchTargets,
+    watched_dirs: Vec<PathBuf>,
+    last_watch_error_note: Option<String>,
+}
+
+struct WatchRuntime {
+    state: WatchState,
+    debouncer: Debouncer<PollWatcher>,
+    rx: mpsc::Receiver<DebounceEventResult>,
+}
+
+fn handle_watch_paths_with_rebuild<F>(
+    state: &mut WatchState,
+    watcher: &mut dyn WatchController,
+    changed_paths: &[PathBuf],
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+    rebuild: F,
+) -> miette::Result<()>;
+
+fn handle_watch_event_result<F>(
+    result: DebounceEventResult,
+    state: &mut WatchState,
+    watcher: &mut dyn WatchController,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+    rebuild: F,
+) -> miette::Result<()>;
+```
+
+`reconcile_watched_dirs` の論理戻り値は「集合が変化したか」の `bool`。stderr 書き込み失敗は致命傷のままにするため、Rust の型は `miette::Result<bool>` にする。
+
+## Task 1: debouncer-mini の消失イベント形状を計測する
+
+**Goal**  
+設計文書の検証ポイントどおり、登録済みディレクトリ削除時に `Ok(Vec<DebouncedEvent>)` と `Err(notify::Error { paths, .. })` がどう届くかを scratch テストで確認する。成功後に削除して成果物に残さない。
+
+**Files**  
+`crates/peitho/src/main.rs` (一時変更のみ。タスク終了時に元へ戻す)
+
+**Test**
+
+```rust
+#[test]
+fn watch_probe_directory_delete_event_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    let fonts = root.join("fonts");
+    let nested = fonts.join("noto");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("400.woff2"), b"font").unwrap();
+
+    let (tx, rx) = mpsc::channel::<DebounceEventResult>();
+    let notify_config = notify::Config::default().with_poll_interval(Duration::from_millis(50));
+    let debounce_config = DebounceConfig::default()
+        .with_timeout(Duration::from_millis(50))
+        .with_notify_config(notify_config);
+    let mut debouncer = new_debouncer_opt::<_, PollWatcher>(debounce_config, tx).unwrap();
+    debouncer
+        .watcher()
+        .watch(&fonts, RecursiveMode::NonRecursive)
+        .unwrap();
+    debouncer
+        .watcher()
+        .watch(&nested, RecursiveMode::NonRecursive)
+        .unwrap();
+
+    thread::sleep(Duration::from_millis(150));
+    fs::rename(&fonts, root.join("fonts-gone")).unwrap();
+
+    let mut saw_ok_for_fonts = false;
+    let mut saw_err_for_fonts = false;
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while Instant::now() < deadline && !(saw_ok_for_fonts && saw_err_for_fonts) {
+        match rx.recv_timeout(Duration::from_millis(250)) {
+            Ok(Ok(events)) => {
+                eprintln!("probe ok events: {events:?}");
+                saw_ok_for_fonts |= events.iter().any(|event| event.path.starts_with(&fonts));
+            }
+            Ok(Err(err)) => {
+                eprintln!("probe error: {err:?}");
+                saw_err_for_fonts |= err.paths.iter().any(|path| path.starts_with(&fonts));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(err) => panic!("watch channel closed: {err}"),
+        }
+    }
+
+    assert!(saw_ok_for_fonts, "expected at least one remove-like Ok event");
+    assert!(saw_err_for_fonts, "expected at least one notify::Error with fonts path");
+}
+```
+
+**Implementation**
+
+```rust
+// #[cfg(test)] mod tests に一時追加する。
+// probe 後、このテスト全体を削除する。
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_probe_directory_delete_event_shape -- --nocapture
+git diff -- crates/peitho/src/main.rs
+```
+
+Red: assertion が設計文書と違う形で失敗した場合、`--nocapture` の出力を記録して設計前提を見直す。Green: `Ok` と `Err` の両方を観測する。Refactor: scratch テストを削除し、2つ目のコマンドで差分が残っていないことを確認する。
+
+## Task 2: WatchState を導入して WatchRuntime に所有させる
+
+**Goal**  
+初期登録に成功したディレクトリ集合を `WatchState.watched_dirs` に保持し、`WatchRuntime` は `state + debouncer + rx` だけを持つ形にする。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_state_owns_registered_dirs_after_registration() {
+    let fixture = WatchFixture::new("# Intro\n");
+    let mut watcher = RecordingWatchController::default();
+
+    let watched_dirs = register_watch_target_dirs(&fixture.targets, &mut watcher).unwrap();
+    let state = WatchState::new(
+        fixture.options.input.clone(),
+        fixture.targets.clone(),
+        watched_dirs.clone(),
+    );
+
+    assert_eq!(state.input, fixture.options.input);
+    assert_eq!(state.watched_dirs, watched_dirs);
+    assert_eq!(watcher.watched, state.watched_dirs);
+    assert!(state.last_watch_error_note.is_none());
+}
+```
+
+**Implementation**
+
+```rust
+struct WatchState {
+    input: PathBuf,
+    targets: WatchTargets,
+    watched_dirs: Vec<PathBuf>,
+    last_watch_error_note: Option<String>,
+}
+
+impl WatchState {
+    fn new(input: PathBuf, targets: WatchTargets, watched_dirs: Vec<PathBuf>) -> Self {
+        Self {
+            input,
+            targets,
+            watched_dirs,
+            last_watch_error_note: None,
+        }
+    }
+}
+
+struct WatchRuntime {
+    state: WatchState,
+    debouncer: Debouncer<PollWatcher>,
+    rx: mpsc::Receiver<DebounceEventResult>,
+}
+
+fn register_watch_target_dirs(
+    targets: &WatchTargets,
+    watcher: &mut dyn WatchController,
+) -> miette::Result<Vec<PathBuf>> {
+    let dirs = targets.watch_dirs();
+    watch_all_dirs(watcher, &dirs)?;
+    Ok(dirs)
+}
+
+let watched_dirs = {
+    let mut watcher = NotifyWatchController::new(debouncer.watcher());
+    register_watch_target_dirs(&targets, &mut watcher)?
+};
+let state = WatchState::new(input, targets, watched_dirs);
+Ok(WatchRuntime { state, debouncer, rx })
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_state_owns_registered_dirs_after_registration
+```
+
+Red: `WatchState` が未定義で失敗する。Green: `WatchRuntime` が `state` を所有して通す。Refactor: `prepare_watch_loop` 内の初期化順を `targets -> watched_dirs -> state` に整え、同じコマンドを再実行する。
+
+## Task 3: reconcile の差分適用を追加する
+
+**Goal**  
+`watched_dirs - desired_dirs` を `unwatch`、`desired_dirs - watched_dirs` を `watch` し、成功時に `watched_dirs` を `desired_dirs` へ収束させる。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn reconcile_watched_dirs_applies_diff_and_updates_owned_set() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    let old = root.join("old");
+    let keep = root.join("keep");
+    let new = root.join("new");
+    fs::create_dir_all(&old).unwrap();
+    fs::create_dir_all(&keep).unwrap();
+    fs::create_dir_all(&new).unwrap();
+    let mut watched_dirs = vec![old.clone(), keep.clone()];
+    let desired_dirs = vec![keep.clone(), new.clone()];
+    let mut watcher = RecordingWatchController::default();
+    let mut stderr = Vec::new();
+
+    let changed =
+        reconcile_watched_dirs(&mut watcher, &mut watched_dirs, &desired_dirs, &mut stderr)
+            .unwrap();
+
+    assert!(changed);
+    assert_eq!(watcher.unwatched, vec![old]);
+    assert_eq!(watcher.watched, vec![new]);
+    assert_eq!(watched_dirs, desired_dirs);
+    assert!(stderr.is_empty());
+}
+```
+
+**Implementation**
+
+```rust
+fn contains_watch_path(paths: &[PathBuf], path: &Path) -> bool {
+    paths.iter().any(|existing| same_watch_path(existing, path))
+}
+
+fn watch_sets_differ(left: &[PathBuf], right: &[PathBuf]) -> bool {
+    left.len() != right.len() || left.iter().any(|path| !contains_watch_path(right, path))
+}
+
+fn reconcile_watched_dirs(
+    watcher: &mut dyn WatchController,
+    watched_dirs: &mut Vec<PathBuf>,
+    desired_dirs: &[PathBuf],
+    stderr: &mut dyn Write,
+) -> miette::Result<bool> {
+    let previous_dirs = watched_dirs.clone();
+    let changed = watch_sets_differ(&previous_dirs, desired_dirs);
+
+    for old in &previous_dirs {
+        if !contains_watch_path(desired_dirs, old) {
+            watcher.unwatch_dir(old)?;
+        }
+    }
+    for new in desired_dirs {
+        if !contains_watch_path(&previous_dirs, new) {
+            watcher.watch_dir(new)?;
+        }
+    }
+
+    *watched_dirs = desired_dirs.to_vec();
+    Ok(changed)
+}
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho reconcile_watched_dirs_applies_diff_and_updates_owned_set
+```
+
+Red: `reconcile_watched_dirs` が未定義で失敗する。Green: 差分適用で通す。Refactor: `contains_watch_path` の呼び出し重複を整え、同じコマンドを再実行する。
+
+## Task 4: reconcile の watch/unwatch 失敗を非致命ノートにする
+
+**Goal**  
+`watch_not_found` と `PathNotFound` の登録変更失敗を stderr ノートにして継続し、成功・失敗にかかわらず所有集合を `desired_dirs` に収束させる。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn reconcile_watched_dirs_notes_failures_and_converges() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    let stale = root.join("stale");
+    let desired = root.join("desired");
+    let mut watched_dirs = vec![stale.clone()];
+    let desired_dirs = vec![desired.clone()];
+    let mut watcher = RecordingWatchController {
+        fail_unwatch: vec![stale.clone()],
+        fail_watch: vec![desired.clone()],
+        ..RecordingWatchController::default()
+    };
+    let mut stderr = Vec::new();
+
+    let changed =
+        reconcile_watched_dirs(&mut watcher, &mut watched_dirs, &desired_dirs, &mut stderr)
+            .unwrap();
+
+    assert!(changed);
+    assert_eq!(watcher.unwatched, vec![stale]);
+    assert_eq!(watcher.watched, vec![desired]);
+    assert_eq!(watched_dirs, desired_dirs);
+    let stderr = String::from_utf8(stderr).unwrap();
+    assert!(stderr.contains("note: failed to stop watching"), "actual stderr: {stderr}");
+    assert!(stderr.contains("note: failed to watch"), "actual stderr: {stderr}");
+    assert!(!stderr.contains("restart --watch"), "actual stderr: {stderr}");
+}
+```
+
+**Implementation**
+
+```rust
+#[derive(Default)]
+struct RecordingWatchController {
+    watched: Vec<PathBuf>,
+    unwatched: Vec<PathBuf>,
+    fail_watch: Vec<PathBuf>,
+    fail_unwatch: Vec<PathBuf>,
+}
+
+impl WatchController for RecordingWatchController {
+    fn watch_dir(&mut self, dir: &Path) -> miette::Result<()> {
+        self.watched.push(dir.to_path_buf());
+        if contains_watch_path(&self.fail_watch, dir) {
+            return Err(miette::miette!("injected watch failure for {}", dir.display()));
+        }
+        Ok(())
+    }
+
+    fn unwatch_dir(&mut self, dir: &Path) -> miette::Result<()> {
+        self.unwatched.push(dir.to_path_buf());
+        if contains_watch_path(&self.fail_unwatch, dir) {
+            return Err(miette::miette!("injected unwatch failure for {}", dir.display()));
+        }
+        Ok(())
+    }
+}
+
+if let Err(err) = watcher.unwatch_dir(old) {
+    writeln!(stderr, "note: failed to stop watching {}: {err}", old.display())
+        .into_diagnostic()?;
+}
+if let Err(err) = watcher.watch_dir(new) {
+    writeln!(stderr, "note: failed to watch {}: {err}", new.display()).into_diagnostic()?;
+}
+stderr.flush().into_diagnostic()?;
+*watched_dirs = desired_dirs.to_vec();
+Ok(changed)
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho reconcile_watched_dirs_notes_failures_and_converges
+```
+
+Red: Task 3 の実装は watcher エラーを `?` で返すため失敗する。Green: stderr ノート化で通す。Refactor: failure note の文言生成を watch/unwatch で読みやすく分け、同じコマンドを再実行する。
+
+## Task 5: deck 変更時の更新を WatchState ベースに置き換える
+
+**Goal**  
+`refresh_watch_targets_after_deck_change` が `WatchState.watched_dirs` を実集合として使い、`update_watched_dirs` を削除する。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn deck_refresh_uses_owned_watched_dirs_when_filesystem_state_drifted() {
+    let fixture = WatchFixture::new("# Intro\n");
+    let old_layouts = fixture._dir.path().join("layouts");
+    let alternate_layouts = fixture._dir.path().join("other-layouts");
+    fs::create_dir_all(&alternate_layouts).unwrap();
+    fs::write(alternate_layouts.join("title-body-code.html"), TEST_LAYOUT_HTML).unwrap();
+    let mut state = WatchState::new(
+        fixture.options.input.clone(),
+        fixture.targets.clone(),
+        fixture.targets.watch_dirs(),
+    );
+    fs::remove_dir_all(&old_layouts).unwrap();
+    fs::write(
+        &state.input,
+        "---\nlayouts: ./other-layouts\n---\n# Intro\n",
+    )
+    .unwrap();
+    let mut watcher = RecordingWatchController::default();
+    let mut stderr = Vec::new();
+
+    refresh_watch_targets_after_deck_change(&mut state, &mut watcher, &mut stderr).unwrap();
+
+    assert!(watcher.unwatched.iter().any(|path| path == &old_layouts));
+    assert!(watcher.watched.iter().any(|path| path == &alternate_layouts));
+    assert_eq!(state.watched_dirs, state.targets.watch_dirs());
+    let stderr = String::from_utf8(stderr).unwrap();
+    assert!(stderr.contains("note: watching new asset paths from frontmatter:"));
+}
+```
+
+**Implementation**
+
+```rust
+fn refresh_watch_targets_after_deck_change(
+    state: &mut WatchState,
+    watcher: &mut dyn WatchController,
+    stderr: &mut dyn Write,
+) -> miette::Result<()> {
+    let current_assets = match resolve_deck_assets(&state.input) {
+        Ok(assets) => assets,
+        Err(_) => return Ok(()),
+    };
+    if state.targets.assets == current_assets {
+        return Ok(());
+    }
+
+    let next_targets = WatchTargets::new(state.input.clone(), current_assets);
+    let desired_dirs = next_targets.watch_dirs();
+    reconcile_watched_dirs(watcher, &mut state.watched_dirs, &desired_dirs, stderr)?;
+    state.targets = next_targets;
+    writeln!(
+        stderr,
+        "note: watching new asset paths from frontmatter: {}",
+        describe_resolved_assets(&state.targets.assets)
+    )
+    .into_diagnostic()?;
+    stderr.flush().into_diagnostic()?;
+    Ok(())
+}
+
+// update_watched_dirs は削除する。
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho deck_refresh_uses_owned_watched_dirs_when_filesystem_state_drifted
+```
+
+Red: 旧シグネチャと旧差分計算ではコンパイルまたは期待 unwatch で失敗する。Green: `WatchState` を渡して通す。Refactor: `next_targets` と `desired_dirs` の生成順を読みやすく保ち、同じコマンドを再実行する。
+
+## Task 6: 通常イベント handler を WatchState 化して新しい fonts サブディレクトリを追従する
+
+**Goal**  
+`handle_watch_paths_with_rebuild` と `handle_watch_event_result` の通常イベント経路を `&mut WatchState` へ移行し、全呼び出し元を同じタスク内で更新する。relevant な通常イベントでリビルドした後、`state.targets.watch_dirs()` を desired として reconcile する。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+fn watch_state_with_fonts() -> (tempfile::TempDir, WatchState, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = fs::canonicalize(dir.path()).unwrap();
+    let deck = root.join("deck.md");
+    let fonts = root.join("fonts");
+    fs::create_dir_all(&fonts).unwrap();
+    fs::write(&deck, "---\nfonts: ./fonts\n---\n# Intro\n").unwrap();
+    let targets = resolve_watch_targets(&deck).unwrap();
+    let watched_dirs = targets.watch_dirs();
+    (dir, WatchState::new(deck, targets, watched_dirs), fonts)
+}
+
+#[test]
+fn watch_path_handler_reconciles_after_new_fonts_subdir() {
+    let (_dir, mut state, fonts) = watch_state_with_fonts();
+    let nested = fonts.join("noto");
+    fs::create_dir_all(&nested).unwrap();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut rebuilds = 0;
+
+    handle_watch_paths_with_rebuild(
+        &mut state,
+        &mut watcher,
+        std::slice::from_ref(&nested),
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| {
+            rebuilds += 1;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rebuilds, 1);
+    assert!(watcher.watched.iter().any(|path| path == &nested));
+    assert_eq!(state.watched_dirs, state.targets.watch_dirs());
+    assert!(stderr.is_empty());
+}
+```
+
+**Implementation**
+
+```rust
+fn handle_watch_paths_with_rebuild<F>(
+    state: &mut WatchState,
+    watcher: &mut dyn WatchController,
+    changed_paths: &[PathBuf],
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+    mut rebuild: F,
+) -> miette::Result<()>
+where
+    F: FnMut(&mut dyn Write, &mut dyn Write) -> miette::Result<()>,
+{
+    let relevant = changed_paths
+        .iter()
+        .any(|changed| state.targets.is_relevant_change(changed));
+
+    if relevant {
+        if changed_paths
+            .iter()
+            .any(|changed| same_watch_path(&state.input, changed))
+        {
+            refresh_watch_targets_after_deck_change(state, watcher, stderr)?;
+        }
+        rebuild(stdout, stderr)?;
+        let desired_dirs = state.targets.watch_dirs();
+        reconcile_watched_dirs(watcher, &mut state.watched_dirs, &desired_dirs, stderr)?;
+    }
+
+    Ok(())
+}
+
+fn handle_watch_event_result<F>(
+    result: DebounceEventResult,
+    state: &mut WatchState,
+    watcher: &mut dyn WatchController,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+    rebuild: F,
+) -> miette::Result<()>
+where
+    F: FnMut(&mut dyn Write, &mut dyn Write) -> miette::Result<()>,
+{
+    let events = result.map_err(|err| {
+        miette::miette!("watch error: {err}")
+    })?;
+    state.last_watch_error_note = None;
+    let paths = events.into_iter().map(|event| event.path).collect::<Vec<_>>();
+    handle_watch_paths_with_rebuild(state, watcher, &paths, stdout, stderr, rebuild)
+}
+
+// 同じ差分で全呼び出し元を更新する。
+handle_watch_paths_with_rebuild(&mut state, &mut watcher, changed_paths, stdout, stderr, rebuild)?;
+handle_watch_event_result(result, &mut runtime.state, &mut watcher, stdout, stderr, &mut rebuild)?;
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_path_handler_reconciles_after_new_fonts_subdir
+```
+
+Red: 旧 handler は `WatchState` を受け取らず、新サブディレクトリを watch しない。Green: `WatchState` signature とリビルド後 reconcile で通す。Refactor: `handle_watch_paths_with_rebuild` と `handle_watch_event_result` の引数数が6以下であることを確認し、同じコマンドを再実行する。
+
+## Task 7: 通常イベントで消えた fonts サブディレクトリを unwatch する
+
+**Goal**  
+remove の通常イベントだけが先に届く順序でも、リビルド後 reconcile によって消えたサブディレクトリを `state.watched_dirs` から外す。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_path_handler_reconciles_after_removed_fonts_subdir() {
+    let (_dir, mut state, fonts) = watch_state_with_fonts();
+    let nested = fonts.join("noto");
+    fs::create_dir_all(&nested).unwrap();
+    state.watched_dirs = state.targets.watch_dirs();
+    fs::remove_dir_all(&nested).unwrap();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut rebuilds = 0;
+
+    handle_watch_paths_with_rebuild(
+        &mut state,
+        &mut watcher,
+        std::slice::from_ref(&nested),
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| {
+            rebuilds += 1;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rebuilds, 1);
+    assert!(watcher.unwatched.iter().any(|path| path == &nested));
+    assert!(!state.watched_dirs.iter().any(|path| path == &nested));
+}
+```
+
+**Implementation**
+
+```rust
+let desired_dirs = state.targets.watch_dirs();
+reconcile_watched_dirs(watcher, &mut state.watched_dirs, &desired_dirs, stderr)?;
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_path_handler_reconciles_after_removed_fonts_subdir
+```
+
+Red: stale subdir が `state.watched_dirs` に残る実装なら失敗する。Green: remove イベント後の reconcile で通す。Refactor: add/remove のテストを隣接させ、同じコマンドを再実行する。
+
+## Task 8: watch エラーを非致命化して reconcile する
+
+**Goal**  
+`DebounceEventResult::Err` を `Err` として返さず、stderr ノート、desired 再計算、reconcile を実行して watch ループを継続させる。このタスクでは `write_watch_error_note` を作らず、素の `writeln!` と `flush` で書く。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_event_handler_notes_error_reconciles_and_continues() {
+    let (_dir, mut state, fonts) = watch_state_with_fonts();
+    fs::remove_dir_all(&fonts).unwrap();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut rebuilds = 0;
+    let result: DebounceEventResult =
+        Err(notify::Error::path_not_found().add_path(fonts.clone()));
+
+    handle_watch_event_result(
+        result,
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| {
+            rebuilds += 1;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rebuilds, 1);
+    assert!(watcher.unwatched.iter().any(|path| path == &fonts));
+    assert!(!state.watched_dirs.iter().any(|path| path == &fonts));
+    let stderr = String::from_utf8(stderr).unwrap();
+    assert!(stderr.contains("note: watch error:"), "actual stderr: {stderr}");
+    assert!(!stderr.contains("restart the command"), "actual stderr: {stderr}");
+}
+
+#[test]
+fn watch_event_handler_returns_ok_when_watcher_reports_error() {
+    let (_dir, mut state, _fonts) = watch_state_with_fonts();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    handle_watch_event_result(
+        Err(notify::Error::generic("backend stopped")),
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| Ok(()),
+    )
+    .unwrap();
+
+    assert!(stdout.is_empty());
+    let stderr = String::from_utf8(stderr).unwrap();
+    assert!(stderr.contains("note: watch error: backend stopped"));
+}
+```
+
+既存の `watch_event_handler_returns_error_when_watcher_reports_error`
+(`crates/peitho/src/main.rs` の 2709 行付近)はこのタスク内で削除し、
+上の `watch_event_handler_returns_ok_when_watcher_reports_error` に置き換える。
+旧テストは `handle_watch_event_result(...).unwrap_err()` と `stderr.is_empty()` を
+期待しており、watch エラー非致命化後は必ず失敗するため残さない。
+
+**Implementation**
+
+```rust
+Err(err) => {
+    let relevant_error = err
+        .paths
+        .iter()
+        .any(|path| state.targets.is_relevant_change(path));
+    let note = format!(
+        "note: watch error: {err}\nhelp: removed missing paths from the watch set; they will be watched again after they reappear or the deck frontmatter changes"
+    );
+    writeln!(stderr, "{note}").into_diagnostic()?;
+    stderr.flush().into_diagnostic()?;
+    state.last_watch_error_note = Some(note);
+    let desired_dirs = state.targets.watch_dirs();
+    let changed = reconcile_watched_dirs(watcher, &mut state.watched_dirs, &desired_dirs, stderr)?;
+    if changed && relevant_error {
+        rebuild(stdout, stderr)?;
+    }
+    return Ok(());
+}
+```
+
+同じタスク内で `watch_paths_loop` の呼び出しも `handle_watch_event_result(result, &mut runtime.state, ...)` に更新して、タスク終了時点でコンパイルを通す。
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_event_handler_notes_error_reconciles_and_continues
+cargo test -p peitho watch_event_handler_returns_ok_when_watcher_reports_error
+```
+
+Red: 旧 handler は `Err` を返す。Green: エラー枝を消費して通す。Refactor: Err branch の早期 return を小さく保ち、2つの cargo test コマンドを再実行する。
+
+## Task 9: watch エラーのリビルドを「集合変化あり + relevant」に限定する
+
+**Goal**  
+権限エラーが同じ集合のまま繰り返す場合に、200ms ごとのリビルドループを起こさない。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_event_handler_does_not_rebuild_when_error_does_not_change_watch_set() {
+    let (_dir, mut state, _fonts) = watch_state_with_fonts();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut rebuilds = 0;
+    let result: DebounceEventResult = Err(
+        notify::Error::generic("permission denied while scanning")
+            .add_path(state.input.clone()),
+    );
+
+    handle_watch_event_result(
+        result,
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| {
+            rebuilds += 1;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rebuilds, 0);
+    assert_eq!(state.watched_dirs, state.targets.watch_dirs());
+    assert!(watcher.watched.is_empty());
+    assert!(watcher.unwatched.is_empty());
+}
+```
+
+**Implementation**
+
+```rust
+let relevant_error = err
+    .paths
+    .iter()
+    .any(|path| state.targets.is_relevant_change(path));
+let desired_dirs = state.targets.watch_dirs();
+let changed = reconcile_watched_dirs(watcher, &mut state.watched_dirs, &desired_dirs, stderr)?;
+if changed && relevant_error {
+    rebuild(stdout, stderr)?;
+}
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_event_handler_does_not_rebuild_when_error_does_not_change_watch_set
+```
+
+Red: 無条件 rebuild なら失敗する。Green: `changed && relevant_error` で通す。Refactor: rebuild 条件のローカル変数名を `should_rebuild` にするか判断し、同じコマンドを再実行する。
+
+## Task 10: irrelevant な watch エラーではリビルドしない
+
+**Goal**  
+集合が変化しても `err.paths` が `WatchTargets::is_relevant_change` に該当しない場合は、reconcile だけ実行してリビルドしない。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_event_handler_does_not_rebuild_when_error_path_is_irrelevant() {
+    let (_dir, mut state, fonts) = watch_state_with_fonts();
+    let stale = fonts.parent().unwrap().join("stale-watch-root");
+    state.watched_dirs.push(stale.clone());
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut rebuilds = 0;
+    let result: DebounceEventResult =
+        Err(notify::Error::path_not_found().add_path(stale.clone()));
+
+    handle_watch_event_result(
+        result,
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| {
+            rebuilds += 1;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rebuilds, 0);
+    assert!(watcher.unwatched.iter().any(|path| path == &stale));
+    assert!(!state.watched_dirs.iter().any(|path| path == &stale));
+}
+```
+
+**Implementation**
+
+```rust
+let relevant_error = err
+    .paths
+    .iter()
+    .any(|path| state.targets.is_relevant_change(path));
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_event_handler_does_not_rebuild_when_error_path_is_irrelevant
+```
+
+Red: 集合変化だけで rebuild すると失敗する。Green: relevant 条件を加えて通す。Refactor: stale path の fixture 構築を最小化し、同じコマンドを再実行する。
+
+## Task 11: 同一文言 watch エラーノートの連続出力を抑制する
+
+**Goal**  
+同じ watch エラーが連続して届く場合、2回目以降の同一ノートを出さない。通常イベントを挟んだ後は再度出せるようにする。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_event_handler_suppresses_consecutive_duplicate_error_notes() {
+    let (_dir, mut state, _fonts) = watch_state_with_fonts();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    for _ in 0..2 {
+        handle_watch_event_result(
+            Err(notify::Error::generic("backend noisy")),
+            &mut state,
+            &mut watcher,
+            &mut stdout,
+            &mut stderr,
+            |_stdout, _stderr| Ok(()),
+        )
+        .unwrap();
+    }
+
+    handle_watch_event_result(
+        Ok(vec![notify_debouncer_mini::DebouncedEvent::new(
+            state.input.clone(),
+            notify_debouncer_mini::DebouncedEventKind::Any,
+        )]),
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| Ok(()),
+    )
+    .unwrap();
+
+    handle_watch_event_result(
+        Err(notify::Error::generic("backend noisy")),
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| Ok(()),
+    )
+    .unwrap();
+
+    let stderr = String::from_utf8(stderr).unwrap();
+    assert_eq!(stderr.matches("note: watch error: backend noisy").count(), 2);
+}
+```
+
+**Implementation**
+
+```rust
+fn write_watch_error_note(
+    err: &notify::Error,
+    stderr: &mut dyn Write,
+    last_watch_error_note: &mut Option<String>,
+) -> miette::Result<()> {
+    let note = format!(
+        "note: watch error: {err}\nhelp: removed missing paths from the watch set; they will be watched again after they reappear or the deck frontmatter changes"
+    );
+    if last_watch_error_note.as_deref() == Some(note.as_str()) {
+        return Ok(());
+    }
+    writeln!(stderr, "{note}").into_diagnostic()?;
+    stderr.flush().into_diagnostic()?;
+    *last_watch_error_note = Some(note);
+    Ok(())
+}
+
+// Err branch
+write_watch_error_note(&err, stderr, &mut state.last_watch_error_note)?;
+
+// Ok branch
+state.last_watch_error_note = None;
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_event_handler_suppresses_consecutive_duplicate_error_notes
+```
+
+Red: 毎回 note を出す実装では count が 3 になる。Green: 連続重複だけ抑制して通す。Refactor: note 文字列の生成を `write_watch_error_note` 内に閉じ、同じコマンドを再実行する。
+
+## Task 12: watch ループ結線と too_many_arguments を局所確認する
+
+**Goal**  
+`watch_paths_loop` が `runtime.state` を handler に渡し、watch handler 群が clippy の引数数閾値を超えないことを確認する。シグネチャ変更済みの既存 watch テスト呼び出しはこの時点で一括確認する。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+#[test]
+fn watch_loop_function_accepts_runtime_with_watch_state() {
+    let _loop_fn =
+        watch_paths_loop::<fn(&mut dyn Write, &mut dyn Write) -> miette::Result<()>>;
+    let _paths_handler =
+        handle_watch_paths_with_rebuild::<fn(&mut dyn Write, &mut dyn Write) -> miette::Result<()>>;
+    let _event_handler =
+        handle_watch_event_result::<fn(&mut dyn Write, &mut dyn Write) -> miette::Result<()>>;
+}
+```
+
+**Implementation**
+
+```rust
+fn watch_paths_loop<F>(mut runtime: WatchRuntime, mut rebuild: F) -> miette::Result<()>
+where
+    F: FnMut(&mut dyn Write, &mut dyn Write) -> miette::Result<()>,
+{
+    while let Ok(result) = runtime.rx.recv() {
+        let mut watcher = NotifyWatchController::new(runtime.debouncer.watcher());
+        handle_watch_event_result(
+            result,
+            &mut runtime.state,
+            &mut watcher,
+            &mut std::io::stdout(),
+            &mut std::io::stderr(),
+            &mut rebuild,
+        )?;
+    }
+    Ok(())
+}
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_loop_function_accepts_runtime_with_watch_state
+cargo clippy -p peitho --all-targets -- -D warnings
+```
+
+Red: loop が旧フィールドや旧 handler signature を参照していればコンパイルで失敗する。Green: `WatchState` 結線で通す。Refactor: 既存 watch テスト群の arrange 部に `WatchState` 初期化を寄せ、2つのコマンドを再実行する。
+
+## Task 13: stdout/stderr 書き込み失敗は致命傷のままにする
+
+**Goal**  
+watcher ランタイムエラーは非致命化するが、診断を書けない端末 I/O 失敗は `miette::Result::Err` として返す。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```rust
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+        Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "closed"))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "closed"))
+    }
+}
+
+#[test]
+fn watch_event_handler_keeps_stderr_write_failure_fatal() {
+    let (_dir, mut state, _fonts) = watch_state_with_fonts();
+    let mut watcher = RecordingWatchController::default();
+    let mut stdout = Vec::new();
+    let mut stderr = FailingWriter;
+
+    let err = handle_watch_event_result(
+        Err(notify::Error::generic("backend stopped")),
+        &mut state,
+        &mut watcher,
+        &mut stdout,
+        &mut stderr,
+        |_stdout, _stderr| Ok(()),
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("closed"), "actual error: {err}");
+}
+```
+
+**Implementation**
+
+```rust
+writeln!(stderr, "{note}").into_diagnostic()?;
+stderr.flush().into_diagnostic()?;
+```
+
+**Verification**
+
+```bash
+cargo test -p peitho watch_event_handler_keeps_stderr_write_failure_fatal
+```
+
+Red: stderr 失敗を無視する実装なら失敗する。Green: `into_diagnostic()?` で通す。Refactor: `FailingWriter` を test module の末尾に置き、同じコマンドを再実行する。
+
+## Task 14: 最終ゲートと手動 E2E を実行する
+
+**Goal**  
+単体テスト、ワークスペース全体、lint、format、契約ドリフト、実プロセスの preview 復帰を確認する。
+
+**Files**  
+`crates/peitho/src/main.rs`
+
+**Test**
+
+```bash
+cargo test -p peitho watch_state_owns_registered_dirs_after_registration
+cargo test -p peitho reconcile_watched_dirs_applies_diff_and_updates_owned_set
+cargo test -p peitho reconcile_watched_dirs_notes_failures_and_converges
+cargo test -p peitho deck_refresh_uses_owned_watched_dirs_when_filesystem_state_drifted
+cargo test -p peitho watch_path_handler_reconciles_after_new_fonts_subdir
+cargo test -p peitho watch_path_handler_reconciles_after_removed_fonts_subdir
+cargo test -p peitho watch_event_handler_notes_error_reconciles_and_continues
+cargo test -p peitho watch_event_handler_returns_ok_when_watcher_reports_error
+cargo test -p peitho watch_event_handler_does_not_rebuild_when_error_does_not_change_watch_set
+cargo test -p peitho watch_event_handler_does_not_rebuild_when_error_path_is_irrelevant
+cargo test -p peitho watch_event_handler_suppresses_consecutive_duplicate_error_notes
+cargo test -p peitho watch_loop_function_accepts_runtime_with_watch_state
+cargo test -p peitho watch_event_handler_keeps_stderr_write_failure_fatal
+```
+
+**Implementation**
+
+```bash
+cargo test --workspace
+cargo test --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all --check
+git diff --exit-code bindings/
+```
+
+**Verification**
+
+Manual E2E:
+
+```bash
+tmpdir=$(mktemp -d)
+printf '%s\n' "$tmpdir" > /tmp/peitho-watch-e2e-dir
+cat > "$tmpdir/deck.md" <<'EOF'
+---
+fonts: ./fonts
+---
+# Intro
+EOF
+mkdir -p "$tmpdir/fonts/noto"
+printf 'font-bytes' > "$tmpdir/fonts/noto/test.woff2"
+cargo run -p peitho -- preview "$tmpdir/deck.md" --port 4321 --no-open
+```
+
+別シェルで実行する。
+
+```bash
+tmpdir=$(cat /tmp/peitho-watch-e2e-dir)
+mv "$tmpdir/fonts" "$tmpdir/fonts-gone"
+curl -sf http://127.0.0.1:4321/ >/dev/null
+mv "$tmpdir/fonts-gone" "$tmpdir/fonts"
+touch "$tmpdir/fonts/noto/test.woff2"
+curl -sf http://127.0.0.1:4321/ >/dev/null
+```
+
+確認する観測結果:
+
+- rename 後も `cargo run -p peitho -- preview ...` のプロセスが生存している。
+- stderr に `note: watch error:` が出るが `restart the command` は出ない。
+- `fonts` 消失中は stderr に `build failed:` が出て、preview は直前の成功世代を配信し続ける。
+- 実行中のリビルド失敗ではエラーページへ差し替わらない。エラーページは初回ビルド失敗時のみの既存仕様として残る。
+- rename 戻しと `touch` 後に rebuild が走り、preview が成功世代へ復帰する。
+- `cargo run -p peitho -- build "$tmpdir/deck.md" --watch` でも同じ rename / rename 戻しでプロセスが終了しない。

--- a/docs/specs/2026-07-08-watch-error-resilience-design.md
+++ b/docs/specs/2026-07-08-watch-error-resilience-design.md
@@ -1,0 +1,188 @@
+# Watch error resilience — preview/buildのwatchループを監視対象のトラブルで死なせない
+
+- 日付: 2026-07-08
+- 状態: 設計確定(実装前)
+- 関連: `crates/peitho/src/main.rs` の watch 系(`watch_paths_loop` / `handle_watch_event_result` / `refresh_watch_targets_after_deck_change` / `spawn_preview_watch`)
+
+## 1. 問題
+
+`peitho preview` 実行中に、frontmatter `fonts:` が参照するディレクトリ
+(`../../fonts/noto-sans`)がリネーム・削除されると、次の出力とともに
+プロセスごと落ち、サーバーの再起動が必要になる。
+
+```
+rebuilt 18 slide(s) into .peitho/preview-cache
+preview watch error: watch error: IO error for operation on ./../../fonts/noto-sans: No such file or directory (os error 2) about ["./../../fonts/noto-sans"]
+help: restart the command after checking file watcher permissions
+exit 1
+```
+
+ビルドエラーは「stderrに出す+エラーページを出す+サーバーは生き続ける」
+設計なのに、watcherのランタイムエラーだけが即死する非一貫性がある。
+
+## 2. 計測で確認した事実(notify 8.2.0 / notify-debouncer-mini 0.7.0)
+
+- `PollWatcher::watch()` は存在しないパスに対して **Err を返さない**。
+  `WatchData::new` が `fs::metadata` 失敗時にエラー**イベント**を発行して
+  登録をスキップする(`poll.rs` の `watch_inner` / `WatchData::new`)。
+  つまり登録失敗はコールサイトの `Result` ではなく、イベントチャネルの
+  `DebounceEventResult::Err` として非同期に届く。
+- 登録済みルートが消えた場合、ポーリングごとの `rescan` で WalkDir が
+  ルート欠損エラーを出し、**ポーリング間隔(200ms)ごとにエラーイベントが
+  発行され続ける**。PollWatcher は自分では watches からルートを削除しない。
+  → 単純な「ログして継続」ではエラーノートが無限にスパムする。
+- ルート配下の既知エントリは `rescan` の disappeared 検出で **remove の
+  通常イベント(Ok)としても届く**。つまりディレクトリ消失の多くのケースで、
+  リビルドのトリガーは通常イベント経路からも得られる。
+- `DebounceEventResult = Result<Vec<DebouncedEvent>, notify::Error>`、
+  `notify::Error` は `paths: Vec<PathBuf>` を持つ(エラー対象パスが取れる)。
+
+## 3. 壊れている不変条件(根本原因)
+
+1. **watchループの生存性**: `handle_watch_event_result`(main.rs:542)が
+   `DebounceEventResult::Err` を `?` で致命傷として伝播し、preview 側は
+   `spawn_preview_watch`(main.rs:1532)が `std::process::exit(1)` で
+   プロセスごと殺す。`build --watch` も同じ `watch_paths_loop` を通るので
+   同様に終了する。
+2. **監視集合の所有権**: 「いま実際にwatch登録されているディレクトリ集合」を
+   誰も保持しておらず、`WatchTargets::watch_dirs()` が**その時点の
+   ファイルシステム状態から毎回再計算**される。集合がドリフトすると
+   (例: 監視中のディレクトリが消えると `is_dir()` が false になり親を返す)、
+   `refresh_watch_targets_after_deck_change` → `update_watched_dirs` の
+   差分計算が実際の登録状態と食い違い、`unwatch` の `watch_not_found` が
+   致命傷として伝播する**潜在バグ**が deck 変更経路にもある。
+3. **監視集合の収束契機**: 監視集合の更新が deck ファイル変更時にしか
+   行われない。fonts ツリー内に新しいサブディレクトリができた場合や、
+   消えたディレクトリが復活した場合に監視集合が古いまま追従しない
+   (非再帰watchなので配下の変更を取りこぼす)。これも同じ根本原因
+   (集合が所有されておらず、収束処理が1経路にしかない)の別症状。
+
+## 4. アプローチ比較
+
+### A. エラーをログして継続するだけ(却下)
+
+- Pros: 最小差分。
+- Cons: PollWatcher が消えたルートに 200ms ごとにエラーを出し続けるため
+  ノートがスパムする。監視集合のドリフト(§3-2, §3-3)は直らない。
+  症状への絆創膏。
+
+### B. watchエラー時に debouncer ごと作り直して全再登録(次点)
+
+- Pros: 状態追跡不要でセマンティクスが単純。`watch_dirs()` が
+  ファイルシステム状態を反映するので、消えたルートは自然に親watchへ
+  切り替わる。
+- Cons: `WatchRuntime` の rx/debouncer をループ内で差し替える再構築が
+  必要になり、ループ構造の変更が大きい。§3-2 の deck 変更経路の潜在バグは
+  「差分更新をやめて全再構築に統一」しない限り残る。全再構築に統一すると
+  イベントチャネルの張り替えが頻発する。
+
+### C. 実watch集合を所有状態にして、単一の reconcile に収束させる(採用)
+
+- Pros: 根本原因(§3の3点すべて)を1つの上流シームで直す。
+  「実際に登録済みの集合」と「望ましい集合(targets+現FS状態から導出)」の
+  差分適用が唯一の変更経路になり、watchエラー時・deck変更時・通常変更時の
+  3契機がすべて同じ関数に集まる。将来の呼び出し元がフィルタを
+  覚える必要がない。
+- Cons: `WatchRuntime` に状態が1つ増える。差分適用のテストが必要。
+- Complexity: 中。
+
+## 5. 採用設計(C)
+
+### 復元する不変条件
+
+- **watchループは、起動に成功したら watcher/ファイルシステム由来の
+  ランタイムエラーで終了しない。** エラーは診断ノートであり、
+  ビルドエラーと同格の扱い。
+- **実watch集合は `WatchRuntime` が所有する状態であり、すべての登録変更は
+  単一の reconcile 関数を通る。** ファイルシステムからの再計算で
+  「いま何をwatchしているか」を推測しない。
+
+### 変更点
+
+1. `WatchRuntime` に `watched_dirs: Vec<PathBuf>`(実際に登録した集合)を
+   追加。初期登録時に確定させる。
+2. 新関数 `reconcile_watched_dirs(watcher, watched: &mut Vec<PathBuf>,
+   desired: &[PathBuf], stderr)`:
+   - `watched - desired` を unwatch、`desired - watched` を watch。
+   - unwatch/watch の失敗(`watch_not_found` 等)は stderr ノートにして
+     継続(致命傷にしない)。成功・失敗にかかわらず `watched` を
+     desired に収束させる(PollWatcher は存在しないパスの watch を
+     イベント経由でしか失敗報告しないため、コールサイトの Result に
+     依存しない)。
+   - 戻り値は「集合が変化したか」(bool)。
+3. `handle_watch_event_result` のエラー枝を非致命化:
+   - `watch error: {err}` を stderr にノート(help 文言は「消えたパスは
+     監視から外し、復活または deck 変更時に再監視する」旨に変更。
+     「restart the command」は削除)。
+   - `targets.watch_dirs()`(現FS状態から再導出した desired)に対して
+     reconcile。消えたルートは desired から自然に消えるので
+     unwatch され、ポーリングスパムが止まる。消えたルートの親が
+     desired に入るので、**復活はその親の通常イベントとして観測できる**。
+   - reconcile で集合が変化し、かつ `err.paths` のいずれかが
+     `is_relevant_change` に該当する場合のみ、リビルドを1回トリガー
+     (frontmatter が明示参照するアセット欠損ならリビルドは失敗し、
+     preview は既存挙動どおり stderr に `build failed:` を出して
+     直前の成功世代を配信し続ける。実行中のエラーページ差し替えは
+     初回ビルド失敗時のみの既存仕様で、本修正では変えない)。
+     集合が変化しない持続的エラー(権限エラー等)ではリビルドしない
+     (200ms ごとのリビルドループを防ぐゲート)。
+   - 同一文言のエラーノートが連続する場合は2回目以降を抑制する
+     (直前ノートの文字列を保持して比較)。権限エラー等の持続的
+     スパムをログ洪水にしないため。
+4. 通常イベント経路(`handle_watch_paths_with_rebuild`)でも、relevant な
+   変更でリビルドした後に reconcile を実行する。これで
+   「消えたディレクトリの復活」「fonts ツリー内の新サブディレクトリ」に
+   監視集合が追従する(§3-3 の修正)。
+5. `refresh_watch_targets_after_deck_change` は差分計算に
+   `targets.watch_dirs()` の再計算値(=ドリフトした推測)ではなく
+   所有された `watched_dirs` を使う(§3-2 の潜在バグ修正)。
+   既存の `update_watched_dirs` は reconcile に置き換えて削除。
+6. `spawn_preview_watch` の `process::exit(1)` 経路は残すが、そこに
+   到達するのは stdout/stderr 書き込み失敗などwatch継続が無意味な
+   場合のみになる(watcher由来のエラーは 3 で消費され、Err として
+   返らない)。`build --watch` の `watch_paths_loop` も同じ関数を
+   通るため同時に直る。
+
+### 到達しうるエラー経路の整理(サイレントドロップ禁止の確認)
+
+| 事象 | 挙動 |
+| --- | --- |
+| 監視中ディレクトリが消えた | ノート1回 + unwatch + 親watch継続。relevantならリビルド(明示frontmatterならビルド失敗ノート、preview は直前の成功世代を配信し続ける) |
+| 消えたディレクトリが復活 | 親watchの通常イベント → リビルド + reconcile でツリー再監視 |
+| fonts ツリー内に新サブディレクトリ | 通常イベント → リビルド + reconcile で追加監視 |
+| 権限エラー等の持続的watchエラー | ノート(連続同一文言は抑制)+ reconcile no-op + リビルドなし。ループ継続 |
+| deck 変更でアセットパス変更 | 従来どおり再解決 + reconcile(所有集合ベースなので watch_not_found で死なない) |
+| 起動時に watcher 自体が作れない | 従来どおり起動失敗(致命傷のまま。サーバー起動前なので正しい) |
+| stdout/stderr 書き込み失敗 | 従来どおり致命傷(端末喪失。継続する意味がない) |
+
+### テスト方針
+
+既存の `WatchController` フェイクを使った単体テストに加える:
+
+- watchエラーイベント(消えたルートを paths に含む)→ ノート出力、
+  unwatch 呼び出し、関数は Ok を返す(ループ継続)。
+- reconcile: watched/desired の差分どおりに watch/unwatch が呼ばれ、
+  失敗しても Ok で収束する。
+- エラー後に集合変化なし(権限エラー相当)→ リビルドが呼ばれない。
+- エラー後に集合変化あり+relevant → リビルドが1回呼ばれる。
+- 同一文言エラーノートの連続 → 2回目は出力されない。
+- deck 変更時の refresh がドリフトした実集合を使って死なないこと
+  (旧実装では watch_not_found が致命傷になるケース)。
+- E2E(手動・実ブラウザ): preview 起動 → fonts ディレクトリを
+  リネーム → サーバー生存・watchエラーノート出力・`build failed:` ノート
+  (明示frontmatter時。配信は直前の成功世代のまま)→ リネームを戻す →
+  次のビルドが成功し preview が復帰。
+
+### 検証ポイント(実装時に計測で確認)
+
+- ディレクトリ消失時に remove の通常イベントと Err がどの順序・粒度で
+  届くか(debouncer-mini がエラーを別メッセージとして flush する挙動)。
+  設計はどちらの順序でも成立するが、テストの期待値を書く際に確認する。
+
+## 6. 採用しなかった選択肢の記録
+
+- 「preview だけ直して build --watch は据え置き」: 同じ根本原因の
+  別症状なので不可(CLAUDE.md のルートコーズ原則)。
+- 「エラー時に process::exit をやめて watch スレッドだけ静かに終える」:
+  preview が黙って更新されなくなるサイレント劣化であり、
+  サイレントドロップ禁止の柱に反する。


### PR DESCRIPTION
## Background

During `peitho preview`, if a watched fonts directory is removed the server dies with the following output and has to be restarted:

```
preview watch error: watch error: IO error for operation on ./../../fonts/noto-sans: No such file or directory (os error 2) about ["./../../fonts/noto-sans"]
help: restart the command after checking file watcher permissions
exit 1
```

Build errors are designed to "print to stderr and keep the server alive", but watcher runtime errors alone die instantly — an inconsistency. `build --watch` goes through the same loop, so it is equally guilty.

## Root causes (confirmed by measurement)

- notify 8.2.0's PollWatcher keeps emitting error events every poll cycle (200 ms) once a registered root goes away. Also, `watch()` on a nonexistent path does not return Err — the error is delivered asynchronously as an event
- `handle_watch_event_result` propagates this error as fatal, and the preview side uses `process::exit(1)` to kill the whole process
- On top of that, nobody owns "the set of paths actually registered with the watcher"; it is inferred by re-computing `watch_dirs()` from the filesystem, so the deck-change path also carries a latent `watch_not_found` instant-death bug, and watching does not follow the reappearance of a removed directory or the arrival of a new subdirectory

## Adopted design

Own the real watch set as `WatchState` and converge every registration change into a single `reconcile_watched_dirs`. Watch errors are demoted to non-fatal notes (consecutive identical messages are suppressed), removed roots are unwatched to stop the spam, and reappearance is picked up via the parent watch. See the design doc for details.

## What this includes

- `docs/specs/2026-07-08-watch-error-resilience-design.md` — design (measured facts, approach comparison, error-path table)
- `docs/plans/2026-07-08-watch-error-resilience.md` — implementation plan (14 tasks, TDD)

The implementation lands in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC

