### PR TITLE
fix: register @font-face at document scope so present/preview load webfonts

### DIFF
--- a/docs/plans/2026-07-08-present-preview-fontface-scope.md
+++ b/docs/plans/2026-07-08-present-preview-fontface-scope.md
@@ -1,0 +1,60 @@
+# Issue 194: present/previewのwebフォントをdocumentスコープへ出す
+
+## Problem
+
+`peitho present`/`peitho preview`は`peitho.css`をfetchし、各スライドのShadow DOM内へ`<style>`として注入している。スライド用CSSの隔離としては正しいが、ブラウザはShadow DOM内の`@font-face`をdocumentフォントとして登録しないため、`fonts:`でコピーされたfontsourceのwebフォントがpresent/previewだけOSフォールバックになる。
+
+サイトビューアとPDFは`<head>`の`<link rel="stylesheet" href="peitho.css">`でdocumentスコープにCSSを読むため、同じ`peitho.css`でもwebフォントが効く。差分はフォント宣言のスコープだけ。
+
+## Scope
+
+- 変更対象は`packages/peitho-present/src/`のTypeScriptだけ。Rust側は変更しない。
+- `packages/peitho-present/dist/shell.js`と`packages/peitho-present/dist/preview.js`は埋め込み成果物なので、実装後に`npm run build`で再生成してコミットする。
+- Shadow DOM側の`peitho.css`注入は現状維持する。documentへ出すのはフォント関連ルールだけで、`peitho.css`全体は出さない。
+
+## Plan
+
+1. Red:新規`packages/peitho-present/test/fontscope.test.ts`を追加し、`extractFontScopeCss`相当の抽出関数に失敗する単体テストを書く。
+   - `extracts leading imports after charset comments and whitespace`
+   - `does not promote imports after ordinary rules`
+   - `extracts top level font face blocks from anywhere`
+   - `skips comments and strings while scanning font face blocks`
+   - `omits non font rules`
+2. Green:新規`packages/peitho-present/src/fontscope.ts`を追加する。
+   - 先頭prefixだけを走査し、空白、コメント、`@charset`文を読み飛ばしてから、有効な連続`@import`文だけを抽出する。
+   - 通常ルールが出た後の`@import`はCSS仕様上も無効なので抽出しない。途中の無効な`@import`をdocumentスコープで有効化しない。
+   - ファイル全体を小さな字句走査で読み、コメントと文字列リテラルをスキップしながらトップレベルの`@font-face{...}`ブロックだけを抽出する。
+   - `@media`などのネスト内の`@font-face`は追わない。今回の制約としてトップレベルだけを扱う。
+   - 抽出結果が空ならdocumentへstyleを追加しない。
+3. Red:`packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts`にpresentシェルのdocumentフォントスコープテストを追加する。
+   - `injects document scoped font css once for present shells`
+   - `removes document scoped font css when the last present shell is destroyed`
+   - 既存の`injects peitho css into each shadow root before fragment html`は残し、Shadow DOM注入が変わらないことも守る。
+4. Green:`packages/peitho-present/src/shell.ts`で`peitho.css`取得後に`installDocumentFontScope(document, css)`相当を呼び、返されたcleanupを`destroy()`で実行する。
+   - documentごとに`style[data-peitho-font-scope]`を1つだけ作る。
+   - 複数スライド、複数`mountPresentShell`、presenterのcurrent/preview同時shellでも1つに保つ。
+   - 複数同時マウントで先にdestroyされたshellが残りのshellを壊さないよう、`fontscope.ts`側でDocument単位の参照数を持ち、最後のcleanupで注入したstyleを除去する。
+   - 既に外部から`style[data-peitho-font-scope]`がある場合は再注入せず、その既存styleはdestroyで削除しない。
+5. Red:`packages/peitho-present/test/preview.test.ts`にpreviewシェルのdocumentフォントスコープテストを追加する。
+   - `injects document scoped font css once for preview shells`
+   - `removes document scoped font css when the last preview shell is destroyed`
+   - 複数スライドと複数`mountPreviewShell`でもstyleが1つだけであることを見る。
+6. Green:`packages/peitho-present/src/preview.ts`にも同じ`installDocumentFontScope(document, css)`を入れ、既存の`destroy()`でcleanupする。previewには既にmount後のクリーンアップ経路が`destroy()`としてあるため、そこに合わせる。
+7. 仕上げとして、present/previewのfetch失敗時に不要な空styleが残らないことを確認する。`peitho.css`取得に失敗した場合は抽出前なので注入されない。CSS取得後の後続失敗でも、返されたshellの`destroy()`で掃除される。
+
+## URL解決
+
+document直下の`<style data-peitho-font-scope>`内に置いた`@import url("fonts/noto-sans-jp/index.css")`や`@font-face src:url("fonts/...")`はdocument base URLで解決される。presentのHTMLとpreviewのindex、`peitho.css`はいずれも同じ出力ルートに置かれるため、`peitho.css`内での相対URL解決と結果は同じになる。
+
+## Non-goals
+
+- `peitho.css`全体をdocumentへ`<link>`または`<style>`で入れない。シェルのホスト要素自身が`.peitho-slide`などを持つため、スライド用スタイルがシェルページへ二重適用される。
+- Shadow DOM側の`@import`は消さない。ロードされてもfontsourceの`index.css`は`@font-face`だけなので、documentスコープ側の適用が本命で、Shadow DOM側は無害。
+- 実ブラウザE2EはCodexのsandboxでは実行しない。webフォントの実適用確認はOpus側で`peitho present`/`peitho preview`を開いて実施する。
+
+## Gates
+
+- `cd packages/peitho-present && npm ci && npm run build && npm test && npm run typecheck`
+- `git diff --check`
+- `git diff --exit-code -- crates bindings`でRust側とbindingが変わっていないことを確認する。
+- `packages/peitho-present/dist/shell.js`と`packages/peitho-present/dist/preview.js`が`npm run build`後の再生成物としてコミット対象に入っていることを確認する。

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -40,6 +40,176 @@ function hasNonCollapsedSelection(win) {
   return selection !== null && !selection.isCollapsed;
 }
 
+// src/fontscope.ts
+var FONT_SCOPE_ATTRIBUTE = "data-peitho-font-scope";
+var FONT_SCOPE_SELECTOR = `style[${FONT_SCOPE_ATTRIBUTE}]`;
+var fontScopeStates = /* @__PURE__ */ new WeakMap();
+function extractFontScopeCss(css) {
+  return [...extractLeadingImports(css), ...extractTopLevelFontFaces(css)].join("\n");
+}
+function installDocumentFontScope(doc, css) {
+  const fontCss = extractFontScopeCss(css);
+  if (fontCss.trim() === "") return () => {
+  };
+  const tracked = fontScopeStates.get(doc);
+  if (tracked) {
+    tracked.references += 1;
+    return cleanupDocumentFontScope(doc, tracked.style);
+  }
+  const existing = doc.head.querySelector(FONT_SCOPE_SELECTOR);
+  if (existing) return () => {
+  };
+  const style = doc.createElement("style");
+  style.setAttribute(FONT_SCOPE_ATTRIBUTE, "");
+  style.textContent = fontCss;
+  doc.head.appendChild(style);
+  fontScopeStates.set(doc, { style, references: 1 });
+  return cleanupDocumentFontScope(doc, style);
+}
+function cleanupDocumentFontScope(doc, style) {
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    const state = fontScopeStates.get(doc);
+    if (!state || state.style !== style) return;
+    state.references -= 1;
+    if (state.references > 0) return;
+    state.style.remove();
+    fontScopeStates.delete(doc);
+  };
+}
+function extractLeadingImports(css) {
+  const imports = [];
+  let index = skipWhitespaceAndComments(css, 0);
+  while (startsWithAtRule(css, index, "@charset")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    index = skipWhitespaceAndComments(css, end);
+  }
+  while (startsWithAtRule(css, index, "@import")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    imports.push(css.slice(index, end).trim());
+    index = skipWhitespaceAndComments(css, end);
+  }
+  return imports;
+}
+function extractTopLevelFontFaces(css) {
+  const blocks = [];
+  let depth = 0;
+  let index = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (depth === 0 && startsWithAtRule(css, index, "@font-face")) {
+      const end = consumeBlock(css, index);
+      if (end === null) return blocks;
+      blocks.push(css.slice(index, end).trim());
+      index = end;
+      continue;
+    }
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+  return blocks;
+}
+function consumeStatement(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === ";") return index + 1;
+    index += 1;
+  }
+  return null;
+}
+function consumeBlock(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === "{") break;
+    index += 1;
+  }
+  if (index >= css.length) return null;
+  let depth = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    index += 1;
+  }
+  return null;
+}
+function skipWhitespaceAndComments(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const char = css[index];
+    if (isCssWhitespace(char)) {
+      index += 1;
+      continue;
+    }
+    if (css.startsWith("/*", index)) {
+      index = skipComment(css, index);
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+function skipCommentOrString(css, index) {
+  if (css.startsWith("/*", index)) return skipComment(css, index);
+  const char = css[index];
+  if (char === '"' || char === "'") return skipString(css, index);
+  return index;
+}
+function skipComment(css, index) {
+  const end = css.indexOf("*/", index + 2);
+  return end < 0 ? css.length : end + 2;
+}
+function skipString(css, index) {
+  const quote = css[index];
+  index += 1;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) return index + 1;
+    index += 1;
+  }
+  return index;
+}
+function startsWithAtRule(css, index, rule) {
+  if (css.slice(index, index + rule.length).toLowerCase() !== rule) return false;
+  const next = css[index + rule.length];
+  return next === void 0 || !/[a-zA-Z0-9_-]/.test(next);
+}
+function isCssWhitespace(char) {
+  return char === " " || char === "\n" || char === "\r" || char === "	" || char === "\f";
+}
+
 // src/keyboard.ts
 var navigationKeyMap = /* @__PURE__ */ new Map([
   ["ArrowRight", "next"],
@@ -296,6 +466,7 @@ var PreviewShellController = class {
   restoredState;
   slides = [];
   tileClickGuardCleanups = [];
+  fontScopeCleanup = null;
   dimensions = { width: 1280, height: 720 };
   onNavigate = (event) => {
     if (!this.isLoaded()) return;
@@ -350,6 +521,7 @@ var PreviewShellController = class {
       const cssAspect = manifest.aspectRatio.replace(":", " / ");
       this.setCanvasRootProperties(this.dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
+      this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
       const pending = await Promise.all(
         manifest.slides.map(async (slide) => {
           const html = await this.fetchText(slide.src);
@@ -398,6 +570,8 @@ var PreviewShellController = class {
     this.bus.removeEventListener("peitho:overviewrequest", this.onOverviewRequest);
     this.win.removeEventListener("resize", this.onResize);
     while (this.tileClickGuardCleanups.length > 0) this.tileClickGuardCleanups.pop()?.();
+    this.fontScopeCleanup?.();
+    this.fontScopeCleanup = null;
     this.clearCanvasRootProperties();
   }
   async fetchJson(url) {

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -562,6 +562,176 @@ function toggleFullscreen(doc = document) {
   void doc.documentElement.requestFullscreen?.();
 }
 
+// src/fontscope.ts
+var FONT_SCOPE_ATTRIBUTE = "data-peitho-font-scope";
+var FONT_SCOPE_SELECTOR = `style[${FONT_SCOPE_ATTRIBUTE}]`;
+var fontScopeStates = /* @__PURE__ */ new WeakMap();
+function extractFontScopeCss(css) {
+  return [...extractLeadingImports(css), ...extractTopLevelFontFaces(css)].join("\n");
+}
+function installDocumentFontScope(doc, css) {
+  const fontCss = extractFontScopeCss(css);
+  if (fontCss.trim() === "") return () => {
+  };
+  const tracked = fontScopeStates.get(doc);
+  if (tracked) {
+    tracked.references += 1;
+    return cleanupDocumentFontScope(doc, tracked.style);
+  }
+  const existing = doc.head.querySelector(FONT_SCOPE_SELECTOR);
+  if (existing) return () => {
+  };
+  const style = doc.createElement("style");
+  style.setAttribute(FONT_SCOPE_ATTRIBUTE, "");
+  style.textContent = fontCss;
+  doc.head.appendChild(style);
+  fontScopeStates.set(doc, { style, references: 1 });
+  return cleanupDocumentFontScope(doc, style);
+}
+function cleanupDocumentFontScope(doc, style) {
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    const state = fontScopeStates.get(doc);
+    if (!state || state.style !== style) return;
+    state.references -= 1;
+    if (state.references > 0) return;
+    state.style.remove();
+    fontScopeStates.delete(doc);
+  };
+}
+function extractLeadingImports(css) {
+  const imports = [];
+  let index = skipWhitespaceAndComments(css, 0);
+  while (startsWithAtRule(css, index, "@charset")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    index = skipWhitespaceAndComments(css, end);
+  }
+  while (startsWithAtRule(css, index, "@import")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    imports.push(css.slice(index, end).trim());
+    index = skipWhitespaceAndComments(css, end);
+  }
+  return imports;
+}
+function extractTopLevelFontFaces(css) {
+  const blocks = [];
+  let depth = 0;
+  let index = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (depth === 0 && startsWithAtRule(css, index, "@font-face")) {
+      const end = consumeBlock(css, index);
+      if (end === null) return blocks;
+      blocks.push(css.slice(index, end).trim());
+      index = end;
+      continue;
+    }
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+  return blocks;
+}
+function consumeStatement(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === ";") return index + 1;
+    index += 1;
+  }
+  return null;
+}
+function consumeBlock(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === "{") break;
+    index += 1;
+  }
+  if (index >= css.length) return null;
+  let depth = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    index += 1;
+  }
+  return null;
+}
+function skipWhitespaceAndComments(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const char = css[index];
+    if (isCssWhitespace(char)) {
+      index += 1;
+      continue;
+    }
+    if (css.startsWith("/*", index)) {
+      index = skipComment(css, index);
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+function skipCommentOrString(css, index) {
+  if (css.startsWith("/*", index)) return skipComment(css, index);
+  const char = css[index];
+  if (char === '"' || char === "'") return skipString(css, index);
+  return index;
+}
+function skipComment(css, index) {
+  const end = css.indexOf("*/", index + 2);
+  return end < 0 ? css.length : end + 2;
+}
+function skipString(css, index) {
+  const quote = css[index];
+  index += 1;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) return index + 1;
+    index += 1;
+  }
+  return index;
+}
+function startsWithAtRule(css, index, rule) {
+  if (css.slice(index, index + rule.length).toLowerCase() !== rule) return false;
+  const next = css[index + rule.length];
+  return next === void 0 || !/[a-zA-Z0-9_-]/.test(next);
+}
+function isCssWhitespace(char) {
+  return char === " " || char === "\n" || char === "\r" || char === "	" || char === "\f";
+}
+
 // src/shell.ts
 async function mountPresentShell(options) {
   const shell = new PresentShellController(options);
@@ -581,6 +751,7 @@ var PresentShellController = class {
   now;
   viewport;
   canvasCleanups = [];
+  fontScopeCleanup = null;
   startedAtValue = null;
   pausedAtValue = null;
   pausedTotalMs = 0;
@@ -632,6 +803,7 @@ var PresentShellController = class {
       const cssAspect = manifest.aspectRatio.replace(":", " / ");
       this.setCanvasRootProperties(dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
+      this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
       const pending = [];
       for (const slide of manifest.slides) {
         const html = await this.fetchText(slide.src);
@@ -669,6 +841,8 @@ var PresentShellController = class {
   }
   destroy() {
     this.endPresentation();
+    this.fontScopeCleanup?.();
+    this.fontScopeCleanup = null;
     while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
     this.clearCanvasRootProperties();
     this.bus.removeEventListener("peitho:navigate", this.onNavigate);

--- a/packages/peitho-present/src/fontscope.ts
+++ b/packages/peitho-present/src/fontscope.ts
@@ -1,0 +1,199 @@
+const FONT_SCOPE_ATTRIBUTE = "data-peitho-font-scope";
+const FONT_SCOPE_SELECTOR = `style[${FONT_SCOPE_ATTRIBUTE}]`;
+
+type FontScopeState = {
+  style: HTMLStyleElement;
+  references: number;
+};
+
+const fontScopeStates = new WeakMap<Document, FontScopeState>();
+
+export function extractFontScopeCss(css: string): string {
+  return [...extractLeadingImports(css), ...extractTopLevelFontFaces(css)].join("\n");
+}
+
+export function installDocumentFontScope(doc: Document, css: string): () => void {
+  const fontCss = extractFontScopeCss(css);
+  if (fontCss.trim() === "") return () => {};
+
+  const tracked = fontScopeStates.get(doc);
+  if (tracked) {
+    tracked.references += 1;
+    return cleanupDocumentFontScope(doc, tracked.style);
+  }
+
+  const existing = doc.head.querySelector<HTMLStyleElement>(FONT_SCOPE_SELECTOR);
+  if (existing) return () => {};
+
+  const style = doc.createElement("style");
+  style.setAttribute(FONT_SCOPE_ATTRIBUTE, "");
+  style.textContent = fontCss;
+  doc.head.appendChild(style);
+  fontScopeStates.set(doc, { style, references: 1 });
+  return cleanupDocumentFontScope(doc, style);
+}
+
+function cleanupDocumentFontScope(doc: Document, style: HTMLStyleElement): () => void {
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+
+    const state = fontScopeStates.get(doc);
+    if (!state || state.style !== style) return;
+    state.references -= 1;
+    if (state.references > 0) return;
+
+    state.style.remove();
+    fontScopeStates.delete(doc);
+  };
+}
+
+function extractLeadingImports(css: string): string[] {
+  const imports: string[] = [];
+  let index = skipWhitespaceAndComments(css, 0);
+  while (startsWithAtRule(css, index, "@charset")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    index = skipWhitespaceAndComments(css, end);
+  }
+
+  while (startsWithAtRule(css, index, "@import")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    imports.push(css.slice(index, end).trim());
+    index = skipWhitespaceAndComments(css, end);
+  }
+
+  return imports;
+}
+
+function extractTopLevelFontFaces(css: string): string[] {
+  const blocks: string[] = [];
+  let depth = 0;
+  let index = 0;
+
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+
+    if (depth === 0 && startsWithAtRule(css, index, "@font-face")) {
+      const end = consumeBlock(css, index);
+      if (end === null) return blocks;
+      blocks.push(css.slice(index, end).trim());
+      index = end;
+      continue;
+    }
+
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+
+  return blocks;
+}
+
+function consumeStatement(css: string, start: number): number | null {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === ";") return index + 1;
+    index += 1;
+  }
+  return null;
+}
+
+function consumeBlock(css: string, start: number): number | null {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === "{") break;
+    index += 1;
+  }
+  if (index >= css.length) return null;
+
+  let depth = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    index += 1;
+  }
+
+  return null;
+}
+
+function skipWhitespaceAndComments(css: string, start: number): number {
+  let index = start;
+  while (index < css.length) {
+    const char = css[index];
+    if (isCssWhitespace(char)) {
+      index += 1;
+      continue;
+    }
+    if (css.startsWith("/*", index)) {
+      index = skipComment(css, index);
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function skipCommentOrString(css: string, index: number): number {
+  if (css.startsWith("/*", index)) return skipComment(css, index);
+  const char = css[index];
+  if (char === '"' || char === "'") return skipString(css, index);
+  return index;
+}
+
+function skipComment(css: string, index: number): number {
+  const end = css.indexOf("*/", index + 2);
+  return end < 0 ? css.length : end + 2;
+}
+
+function skipString(css: string, index: number): number {
+  const quote = css[index];
+  index += 1;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) return index + 1;
+    index += 1;
+  }
+  return index;
+}
+
+function startsWithAtRule(css: string, index: number, rule: string): boolean {
+  if (css.slice(index, index + rule.length).toLowerCase() !== rule) return false;
+  const next = css[index + rule.length];
+  return next === undefined || !/[a-zA-Z0-9_-]/.test(next);
+}
+
+function isCssWhitespace(char: string): boolean {
+  return char === " " || char === "\n" || char === "\r" || char === "\t" || char === "\f";
+}

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -2,6 +2,7 @@ import type { Manifest } from "../../../bindings/Manifest";
 import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { calculateCanvasFit, type CanvasViewport } from "./canvas";
 import { createClickNavigationGuard } from "./clickNavigationGuard";
+import { installDocumentFontScope } from "./fontscope";
 import { hasChordModifier } from "./keyboard";
 import type { NavigateTarget, SlideChangeDetail } from "./shell";
 import {
@@ -165,6 +166,7 @@ class PreviewShellController implements PreviewShell {
   private readonly restoredState: PreviewState | null;
   private readonly slides: PreviewSlideView[] = [];
   private readonly tileClickGuardCleanups: Array<() => void> = [];
+  private fontScopeCleanup: (() => void) | null = null;
   private dimensions: CanvasDimensions = { width: 1280, height: 720 };
   private readonly onNavigate = (event: Event): void => {
     if (!this.isLoaded()) return;
@@ -221,6 +223,7 @@ class PreviewShellController implements PreviewShell {
       const cssAspect = manifest.aspectRatio.replace(":", " / ");
       this.setCanvasRootProperties(this.dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
+      this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
       const pending = await Promise.all(
         manifest.slides.map(async (slide) => {
           const html = await this.fetchText(slide.src);
@@ -273,6 +276,8 @@ class PreviewShellController implements PreviewShell {
     this.bus.removeEventListener("peitho:overviewrequest", this.onOverviewRequest);
     this.win.removeEventListener("resize", this.onResize);
     while (this.tileClickGuardCleanups.length > 0) this.tileClickGuardCleanups.pop()?.();
+    this.fontScopeCleanup?.();
+    this.fontScopeCleanup = null;
     this.clearCanvasRootProperties();
   }
 

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -1,6 +1,7 @@
 import type { Manifest } from "../../../bindings/Manifest";
 import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { installCanvasScaler, type CanvasViewport } from "./canvas";
+import { installDocumentFontScope } from "./fontscope";
 
 export type NavigateTarget =
   | "next"
@@ -73,6 +74,7 @@ class PresentShellController implements PresentShell {
   private readonly now: () => number;
   private readonly viewport?: () => CanvasViewport;
   private readonly canvasCleanups: Array<() => void> = [];
+  private fontScopeCleanup: (() => void) | null = null;
   private startedAtValue: number | null = null;
   private pausedAtValue: number | null = null;
   private pausedTotalMs = 0;
@@ -126,6 +128,7 @@ class PresentShellController implements PresentShell {
       const cssAspect = manifest.aspectRatio.replace(":", " / ");
       this.setCanvasRootProperties(dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
+      this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
       const pending: SlideView[] = [];
       for (const slide of manifest.slides) {
         const html = await this.fetchText(slide.src);
@@ -168,6 +171,8 @@ class PresentShellController implements PresentShell {
 
   destroy(): void {
     this.endPresentation();
+    this.fontScopeCleanup?.();
+    this.fontScopeCleanup = null;
     while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
     this.clearCanvasRootProperties();
     this.bus.removeEventListener("peitho:navigate", this.onNavigate);

--- a/packages/peitho-present/test/fontscope.test.ts
+++ b/packages/peitho-present/test/fontscope.test.ts
@@ -1,0 +1,88 @@
+import { expect, it } from "vitest";
+import { extractFontScopeCss } from "../src/fontscope";
+
+it("extracts leading imports after charset comments and whitespace", () => {
+  const css = `
+/* deck fonts */
+@charset "UTF-8";
+
+@import url("fonts/noto-sans-jp/index.css");
+@import url("fonts/inter/index.css") screen;
+.peitho-slide { color: red; }
+`;
+
+  expect(extractFontScopeCss(css)).toBe(
+    [
+      '@import url("fonts/noto-sans-jp/index.css");',
+      '@import url("fonts/inter/index.css") screen;'
+    ].join("\n")
+  );
+});
+
+it("does not promote imports after ordinary rules", () => {
+  const css = `
+@import url("fonts/prefix.css");
+.peitho-slide { color: red; }
+@import url("fonts/late.css");
+@font-face { font-family: "Late"; src: url("fonts/late.woff2"); }
+`;
+
+  expect(extractFontScopeCss(css)).toBe(
+    [
+      '@import url("fonts/prefix.css");',
+      '@font-face { font-family: "Late"; src: url("fonts/late.woff2"); }'
+    ].join("\n")
+  );
+});
+
+it("extracts top level font face blocks from anywhere", () => {
+  const css = `
+.slot-title { color: red; }
+@font-face { font-family: "Heading"; src: url("fonts/heading.woff2"); }
+.slot-body { color: blue; }
+@font-face {
+  font-family: "Body";
+  src: url("fonts/body.woff2");
+}
+`;
+
+  expect(extractFontScopeCss(css)).toBe(
+    [
+      '@font-face { font-family: "Heading"; src: url("fonts/heading.woff2"); }',
+      '@font-face {\n  font-family: "Body";\n  src: url("fonts/body.woff2");\n}'
+    ].join("\n")
+  );
+});
+
+it("skips comments and strings while scanning font face blocks", () => {
+  const css = `
+.fake::before { content: "@font-face { nope }"; }
+/* @font-face { font-family: "Comment"; } */
+@font-face {
+  font-family: "Brace } Face";
+  src: url("fonts/{brace}.woff2");
+  unicode-range: U+0-5FF; /* } */
+}
+`;
+
+  expect(extractFontScopeCss(css)).toBe(
+    [
+      "@font-face {",
+      '  font-family: "Brace } Face";',
+      '  src: url("fonts/{brace}.woff2");',
+      "  unicode-range: U+0-5FF; /* } */",
+      "}"
+    ].join("\n")
+  );
+});
+
+it("omits non font rules", () => {
+  const css = `
+@media screen {
+  @font-face { font-family: "Nested"; src: url("fonts/nested.woff2"); }
+}
+.peitho-slide { font-family: "Nested"; }
+`;
+
+  expect(extractFontScopeCss(css)).toBe("");
+});

--- a/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
+++ b/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
@@ -38,6 +38,12 @@ const manifest = {
   ]
 };
 const cssText = ".slot-title { color: rebeccapurple; }";
+const fontCssText = `
+@import url("fonts/noto-sans-jp/index.css");
+.peitho-slide { color: red; }
+@import url("fonts/late.css");
+@font-face { font-family: "Noto Sans JP"; src: url("fonts/noto.woff2"); }
+`;
 
 const mountedShells: PresentShell[] = [];
 const windowListenerCleanups: Array<() => void> = [];
@@ -65,10 +71,10 @@ function listenWindow(type: string, listener: EventListener): void {
   windowListenerCleanups.push(() => window.removeEventListener(type, listener));
 }
 
-function standardFetch(responseManifest = manifest): typeof fetch {
+function standardFetch(responseManifest = manifest, css = cssText): typeof fetch {
   return vi.fn(async (url: string) => {
     if (url === "manifest.json") return okJson(responseManifest);
-    if (url === "peitho.css") return okText(cssText);
+    if (url === "peitho.css") return okText(css);
     if (url === "slides/000-intro.html") return okText("<section><h1>Intro</h1></section>");
     if (url === "slides/001-arch-1.html") return okText("<section><pre>code</pre></section>");
     return {
@@ -164,6 +170,46 @@ it("injects peitho css into each shadow root before fragment html", async () => 
     expect(firstChild).toBe(style);
     expect(style?.textContent).toContain(cssText);
   }
+});
+
+it("injects document scoped font css once for present shells", async () => {
+  const firstRoot = document.createElement("main");
+  const secondRoot = document.createElement("main");
+
+  await mountForTest({ root: firstRoot, fetcher: standardFetch(manifest, fontCssText), window });
+  await mountForTest({ root: secondRoot, fetcher: standardFetch(manifest, fontCssText), window });
+
+  const styles = document.head.querySelectorAll<HTMLStyleElement>(
+    "style[data-peitho-font-scope]"
+  );
+  expect(styles).toHaveLength(1);
+  expect(styles[0].textContent).toBe(
+    [
+      '@import url("fonts/noto-sans-jp/index.css");',
+      '@font-face { font-family: "Noto Sans JP"; src: url("fonts/noto.woff2"); }'
+    ].join("\n")
+  );
+});
+
+it("removes document scoped font css when the last present shell is destroyed", async () => {
+  const firstRoot = document.createElement("main");
+  const secondRoot = document.createElement("main");
+  const first = await mountForTest({
+    root: firstRoot,
+    fetcher: standardFetch(manifest, fontCssText),
+    window
+  });
+  const second = await mountForTest({
+    root: secondRoot,
+    fetcher: standardFetch(manifest, fontCssText),
+    window
+  });
+
+  expect(document.head.querySelectorAll("style[data-peitho-font-scope]")).toHaveLength(1);
+  first.destroy();
+  expect(document.head.querySelectorAll("style[data-peitho-font-scope]")).toHaveLength(1);
+  second.destroy();
+  expect(document.head.querySelectorAll("style[data-peitho-font-scope]")).toHaveLength(0);
 });
 
 it("puts shell handles on hosts and hides non-current slides", async () => {

--- a/packages/peitho-present/test/preview.test.ts
+++ b/packages/peitho-present/test/preview.test.ts
@@ -52,6 +52,12 @@ const manifest = {
 };
 
 const cssText = ".slot-title { color: red; }";
+const fontCssText = `
+@import url("fonts/noto-sans-jp/index.css");
+.peitho-preview-slide { color: red; }
+@import url("fonts/late.css");
+@font-face { font-family: "Noto Sans JP"; src: url("fonts/noto.woff2"); }
+`;
 
 function manifestWithSlideCount(slideCount: number): typeof manifest {
   return {
@@ -67,11 +73,11 @@ function manifestWithSlideCount(slideCount: number): typeof manifest {
   };
 }
 
-function fetchForManifest(deck: typeof manifest): typeof fetch {
+function fetchForManifest(deck: typeof manifest, css = cssText): typeof fetch {
   return vi.fn(async (url: string) => {
     if (url === "/sync") return okJson({ seq: 0, message: null, generation: 0 });
     if (url === "manifest.json") return okJson(deck);
-    if (url === "peitho.css") return okText(cssText);
+    if (url === "peitho.css") return okText(css);
     if (url.startsWith("slides/")) return okText(`<section><h1>${url}</h1></section>`);
     return { ok: false, status: 404, text: async () => "not found" } as Response;
   }) as typeof fetch;
@@ -224,6 +230,63 @@ it("preview keyboard emits command requests and ignores chord-modified commands"
   expect(chordUp.defaultPrevented).toBe(false);
   expect(bareDown.defaultPrevented).toBe(false);
   expect(chordDown.defaultPrevented).toBe(false);
+});
+
+it("injects document scoped font css once for preview shells", async () => {
+  const firstRoot = document.createElement("main");
+  const secondRoot = document.createElement("main");
+  const first = await mountPreviewShell({
+    root: firstRoot,
+    fetcher: fetchForManifest(manifest, fontCssText),
+    window,
+    storage: sessionStorage,
+    viewport: () => ({ width: 1280, height: 720 })
+  });
+  const second = await mountPreviewShell({
+    root: secondRoot,
+    fetcher: fetchForManifest(manifest, fontCssText),
+    window,
+    storage: sessionStorage,
+    viewport: () => ({ width: 1280, height: 720 })
+  });
+  shells.push(first, second);
+
+  const styles = document.head.querySelectorAll<HTMLStyleElement>(
+    "style[data-peitho-font-scope]"
+  );
+  expect(styles).toHaveLength(1);
+  expect(styles[0].textContent).toBe(
+    [
+      '@import url("fonts/noto-sans-jp/index.css");',
+      '@font-face { font-family: "Noto Sans JP"; src: url("fonts/noto.woff2"); }'
+    ].join("\n")
+  );
+});
+
+it("removes document scoped font css when the last preview shell is destroyed", async () => {
+  const firstRoot = document.createElement("main");
+  const secondRoot = document.createElement("main");
+  const first = await mountPreviewShell({
+    root: firstRoot,
+    fetcher: fetchForManifest(manifest, fontCssText),
+    window,
+    storage: sessionStorage,
+    viewport: () => ({ width: 1280, height: 720 })
+  });
+  const second = await mountPreviewShell({
+    root: secondRoot,
+    fetcher: fetchForManifest(manifest, fontCssText),
+    window,
+    storage: sessionStorage,
+    viewport: () => ({ width: 1280, height: 720 })
+  });
+  shells.push(first, second);
+
+  expect(document.head.querySelectorAll("style[data-peitho-font-scope]")).toHaveLength(1);
+  first.destroy();
+  expect(document.head.querySelectorAll("style[data-peitho-font-scope]")).toHaveLength(1);
+  second.destroy();
+  expect(document.head.querySelectorAll("style[data-peitho-font-scope]")).toHaveLength(0);
 });
 
 it("overview requests toggle between single and grid mode", async () => {


### PR DESCRIPTION
Closes #194

## Problem

The slide fonts look different between `peitho present`/`peitho preview` and the published site / PDF. When a deck wires up web fonts via the `fonts:` frontmatter key plus an `@import` in `css/00-fonts.css`, the site and PDF apply the web fonts correctly, but present/preview render with the OS fallback.

## Cause

The site viewer and the PDF load CSS at document scope via `<link rel="stylesheet" href="peitho.css">` in `<head>`, but the present/preview shell fetches `peitho.css` and injects it as a `<style>` inside each slide's **Shadow DOM**. Browsers do not register `@font-face` declared inside a Shadow DOM (document scope only), so no web fonts were ever loaded. The `fonts/` copy itself was correct in every mode; only the scope of the font declarations was broken.

## Fix

A new `src/fontscope.ts` extracts just the font-related rules from the fetched `peitho.css` and injects them once into the document `<head>` as `<style data-peitho-font-scope>`.

- The extraction targets are the "leading run of valid `@import` statements" (a later, already-invalid `@import` is not promoted) and "top-level `@font-face` blocks". Comments and string literals are skipped via lexical scanning
- The full `peitho.css` is not emitted at the document (the host element itself carries `.peitho-slide`, so it would apply twice — the very reason Shadow DOM was adopted). Shadow-DOM-side injection is unchanged
- A document-scoped refcount keeps the style tag as a single tag even with the presenter's two shells (main + preview); the last `destroy()` removes it
- The same handling is wired into both the present and preview shells

## Verification

- vitest: 185 tests (added 5 for fontscope extraction and 2 each for present/preview), typecheck, `npm run build` regenerated dist
- cargo test --workspace ×3, clippy -D warnings, fmt --check, no bindings drift (no Rust-side changes)
- Real-browser E2E: launched the worktree-built peitho with `preview` / `present --no-open` and confirmed in Chrome that `style[data-peitho-font-scope]` was injected, 383 faces were registered in `document.fonts` with `Noto Sans JP Variable` etc. reaching loaded state, and Japanese slides rendered in Noto Sans JP / Noto Serif JP (before the fix they fell back to Hiragino Sans)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175NiSpcnjyrNykWc6xqzvB
