### PR TITLE
chore: bump version to 1.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.3.2"
+version = "1.3.3"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
Version bump for the v1.3.3 release.

Changes since v1.3.2:
- #195 fix: register @font-face at document scope so present/preview load webfonts
- #196 fix: keep the watch loop alive through watcher runtime errors
- #192 docs: watch error resilience — design and implementation plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175NiSpcnjyrNykWc6xqzvB
