### PR TITLE
ci: auto-deploy the demo site to peitho.gosu.ke on main push

### DIFF
--- a/.github/workflows/demo-preview-cleanup.yml
+++ b/.github/workflows/demo-preview-cleanup.yml
@@ -1,0 +1,106 @@
+name: Cleanup Demo Preview Deployments
+
+on:
+  pull_request:
+    types: [closed]
+
+# deploy-demo.ymlと同じgroupにして、プレビューデプロイ中ならcleanupを待機させ、完了後にその結果も削除する
+# PR番号でgroup化するのは、github.refはマージされたPRのclosedイベントではbaseブランチに解決され、本番デプロイのgroupと衝突してキャンセルされるため(mizzy/decks#32)
+# cancelは非同期で、一覧取得後にデプロイが作られる可能性があるためキャンセルしない
+concurrency:
+  group: deploy-demo-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  cleanup-preview:
+    # fork PRはSecretsを参照できないため、同一リポジトリからのPRのみクリーンアップする
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Delete Cloudflare Pages preview deployments
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: peitho
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          : "${CLOUDFLARE_API_TOKEN:?CLOUDFLARE_API_TOKEN is required}"
+          : "${CLOUDFLARE_ACCOUNT_ID:?CLOUDFLARE_ACCOUNT_ID is required}"
+          : "${PROJECT:?PROJECT is required}"
+          : "${BRANCH:?BRANCH is required}"
+
+          api_base="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${PROJECT}"
+          per_page=25
+          page=1
+          ids=()
+
+          while :; do
+            if ! response="$(curl -sS --retry 3 \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "${api_base}/deployments?env=preview&page=${page}&per_page=${per_page}")"; then
+              echo "Cloudflare API request failed while listing deployments on page ${page}" >&2
+              exit 1
+            fi
+
+            if ! jq -e '.success == true' >/dev/null <<<"${response}"; then
+              echo "Cloudflare API failed while listing deployments on page ${page}" >&2
+              printf '%s\n' "${response}" >&2
+              exit 1
+            fi
+
+            page_output="$(jq -r --arg branch "${BRANCH}" '.result[]? | select(.environment == "preview") | select(.deployment_trigger.metadata.branch == $branch) | .id' <<<"${response}")"
+            if [ -n "${page_output}" ]; then
+              mapfile -t page_ids <<<"${page_output}"
+              ids+=("${page_ids[@]}")
+            fi
+
+            count="$(jq -r '.result | length' <<<"${response}")"
+            if [ "${count}" -eq 0 ]; then
+              break
+            fi
+
+            page=$((page + 1))
+          done
+
+          if [ "${#ids[@]}" -eq 0 ]; then
+            echo "No preview deployments found for branch ${BRANCH}"
+            exit 0
+          fi
+
+          mapfile -t ids < <(printf '%s\n' "${ids[@]}" | awk '!seen[$0]++')
+
+          failed_ids=()
+          for id in "${ids[@]}"; do
+            if ! response="$(curl -sS --retry 3 -X DELETE \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              "${api_base}/deployments/${id}?force=true")"; then
+              echo "Cloudflare API request failed while deleting deployment ${id}" >&2
+              failed_ids+=("${id}")
+              continue
+            fi
+
+            if ! jq -e '.success == true' >/dev/null <<<"${response}"; then
+              if jq -e '[.errors[]? | ((.message // "") | ascii_downcase | contains("deployment not found"))] | any' >/dev/null <<<"${response}"; then
+                echo "Preview deployment ${id} already deleted"
+                continue
+              fi
+
+              echo "Cloudflare API failed while deleting deployment ${id}" >&2
+              printf '%s\n' "${response}" >&2
+              failed_ids+=("${id}")
+              continue
+            fi
+
+            echo "Deleted preview deployment ${id} for branch ${BRANCH}"
+          done
+
+          if [ "${#failed_ids[@]}" -gt 0 ]; then
+            echo "Failed to delete ${#failed_ids[@]} preview deployment(s)" >&2
+            exit 1
+          fi

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,81 @@
+name: Deploy Demo
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # PR runはPR番号でgroup化してdemo-preview-cleanup.ymlと同じgroupにし、それ以外はrefでgroup化する
+  group: deploy-demo-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: demo
+
+      # このリポジトリ自身がpeithoなので、リリースバイナリではなく
+      # ソースからビルドした今のpeithoでデモサイトを組む
+      - name: Build demo site
+        run: make demo-site
+
+      - name: Deploy to Cloudflare Pages
+        if: github.event_name != 'pull_request'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .demo-site --project-name=peitho --branch=main
+
+      # fork PRはSecretsを参照できないため、同一リポジトリからのPRのみプレビューをデプロイする
+      - name: Deploy preview to Cloudflare Pages
+        id: preview
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy .demo-site --project-name=peitho --branch=${{ github.head_ref }}
+
+      - name: Comment preview URL on PR
+        if: steps.preview.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ALIAS_URL: ${{ steps.preview.outputs.pages-deployment-alias-url }}
+          DEPLOYMENT_URL: ${{ steps.preview.outputs.deployment-url }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          marker="<!-- peitho-demo-preview-url -->"
+          body="$(printf '%s\n' \
+            "🔍 **Demo preview**: ${ALIAS_URL:-$DEPLOYMENT_URL}" \
+            "" \
+            "| | URL |" \
+            "|---|---|" \
+            "| Branch alias | ${ALIAS_URL:-–} |" \
+            "| This deploy | ${DEPLOYMENT_URL:-–} |" \
+            "" \
+            "commit: ${HEAD_SHA}" \
+            "${marker}")"
+          comment_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n1)"
+          if [ -n "${comment_id}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="${body}" >/dev/null
+          else
+            gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "${body}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ layouts/ themes/ examples/  Shared layouts, base theme, samples. The default lay
 docs/plans/           Implementation plans for each milestone (history)
 ```
 
+Demo site https://peitho.gosu.ke/ (Cloudflare Pages project `peitho`): `.github/workflows/deploy-demo.yml` builds `make demo-site` from source and deploys on every `main` push; same-repo PRs get a preview deploy + PR comment, cleaned up on close by `demo-preview-cleanup.yml`. Manual fallback: `envchain peitho make deploy-demo`. Adding an example still requires editing the Makefile `demo-site` target and `demo/index.html` by hand (nothing is auto-listed). Design record: `docs/plans/2026-07-09-demo-site-deploy-flow.md`
+
 ## Gates (all must pass before committing)
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An HTML-native presentation tool that treats Markdown as the source of truth.
 
 Peitho is the Greek goddess who presides over the power to move people's hearts with words rather than force — a fitting match for the essence of presentation.
 
-Demo: **[peitho.gosu.ke](https://peitho.gosu.ke/)** (builds and serves `examples/` as-is. Deploy with `envchain peitho make deploy-demo`)
+Demo: **[peitho.gosu.ke](https://peitho.gosu.ke/)** (builds and serves `examples/` as-is. Auto-deployed on push to `main`; `envchain peitho make deploy-demo` for manual deploys)
 
 ## Features
 

--- a/docs/plans/2026-07-09-demo-site-deploy-flow.md
+++ b/docs/plans/2026-07-09-demo-site-deploy-flow.md
@@ -1,0 +1,39 @@
+# デモサイト (peitho.gosu.ke) のデプロイフロー整備
+
+日付: 2026-07-09
+参考: `mizzy/decks` リポジトリのデプロイフロー (`.github/workflows/deploy.yml` / `preview-cleanup.yml`)
+
+## 現状と問題
+
+- https://peitho.gosu.ke/ (Cloudflare Pagesプロジェクト `peitho`) は `envchain peitho make deploy-demo` の手動デプロイのみ
+- examplesやレンダラを変更してもデプロイを忘れるとデモサイトが古いまま残る
+- decks.gosu.ke側は既にGitHub Actionsで自動化済みなので、同じ形に揃える
+
+## 方針
+
+decksのフローを移植する。ただしdecksと違いこのリポジトリはpeitho本体なので、
+リリースバイナリをダウンロードするのではなく**ソースからビルドした今のpeithoでデモサイトを組む**
+(既存の `make demo-site` をそのまま使う。`dist/shell.js` は埋め込み済み・コミット済みなのでnpmビルド不要)。
+
+1. `.github/workflows/deploy-demo.yml`
+   - `main` push / `workflow_dispatch` → `make demo-site` → `wrangler pages deploy .demo-site --project-name=peitho --branch=main`
+   - `pull_request` (同一リポジトリのみ、forkはSecretsを参照できない) → プレビューデプロイ + PRコメント (decksと同じmarker方式で1コメントを更新)
+   - concurrencyはdecks同様 `deploy-demo-<PR番号 or ref>` でgroup化し `cancel-in-progress: true`
+   - Rustビルドは `Swatinem/rust-cache` (shared-key: demo) でキャッシュ
+2. `.github/workflows/demo-preview-cleanup.yml`
+   - PR close時にそのブランチのプレビューデプロイをCloudflare APIで削除 (decksのpreview-cleanup.ymlと同じ。issue mizzy/decks#32のconcurrency知見も踏襲)
+3. GitHub Secrets: `CLOUDFLARE_API_TOKEN` (envchain `peitho` のものを登録) / `CLOUDFLARE_ACCOUNT_ID`
+   - プロジェクト名 `peitho` はMakefileで既に公開情報なのでワークフローに直書き
+4. `make deploy-demo` は手動デプロイ用にそのまま残す
+5. CLAUDE.md にデプロイフローを1行追記
+
+## decksから引き継ぐ罠
+
+- Cloudflare API Tokenには `Account: Cloudflare Pages: Edit` / `Account: Account Settings: Read` / `User: User Details: Read` の3つ全部が必要。欠けると `wrangler pages deploy` が `Authentication error [code: 10000]` で落ちる
+- preview-cleanupのconcurrency groupはPR番号でgroup化する (`github.ref` はマージ済みPRのclosedイベントでbaseブランチに解決され、本番デプロイのgroupと衝突する)
+
+## 検証
+
+- `make demo-site` がworktreeで通ること (デモサイトの組み立て+publish contamination check)
+- workflow YAMLの構文チェック (actionlint があれば)
+- マージ後、Actionsの実走行とpeitho.gosu.keの更新を確認


### PR DESCRIPTION
## Summary

peitho.gosu.ke のデプロイを手動 (`envchain peitho make deploy-demo`) から GitHub Actions に移行する。mizzy/decks のデプロイフローの移植。

- `.github/workflows/deploy-demo.yml`: `main` push / `workflow_dispatch` で `make demo-site` をソースからビルドし、Cloudflare Pages プロジェクト `peitho` へデプロイ。同一リポジトリからの PR にはプレビューデプロイ + URL コメント (marker 方式で1コメントを更新)
- `.github/workflows/demo-preview-cleanup.yml`: PR close 時にそのブランチのプレビューデプロイを Cloudflare API で削除 (concurrency group は PR 番号ベース — decks#32 の知見を踏襲)
- decks と違い、この リポジトリは peitho 本体なのでリリースバイナリではなく PR のソースでビルドする。レンダラ変更の影響をプレビューで確認できる
- Secrets `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` は設定済み
- `make deploy-demo` は手動フォールバックとして残す

Design record: `docs/plans/2026-07-09-demo-site-deploy-flow.md`

## Test plan

- [x] actionlint パス
- [x] `make demo-site` がローカルで通る (8デッキ + index.html を組み立て、publish contamination check パス)
- [ ] この PR 自身の preview デプロイが成功し、コメントに URL が付く
- [ ] マージ後、main push の Deploy Demo が成功し peitho.gosu.ke が更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC