### PR TITLE
Docs site: design and implementation plan

### DIFF
--- a/docs/plans/2026-07-09-docs-site.md
+++ b/docs/plans/2026-07-09-docs-site.md
@@ -1,0 +1,756 @@
+# Docs site implementation plan
+
+<!-- constrained-by ../specs/2026-07-09-docs-site-design.md -->
+
+Date: 2026-07-09
+
+## Scope
+
+Replace the hand-written `demo/index.html` at https://peitho.gosu.ke/ with a
+Zola documentation site plus the existing eight built example decks under
+`/demo/<name>/`. The design, language, stack, URL scheme, redirect policy,
+and build composition are already approved in
+[`../specs/2026-07-09-docs-site-design.md`](../specs/2026-07-09-docs-site-design.md);
+do not revisit those decisions.
+
+Source material:
+
+- [`../../README.md`](../../README.md): user-facing feature, install, deck,
+  frontmatter, examples, and CLI content.
+- [`../../demo/index.html`](../../demo/index.html): visual identity only:
+  `"Iowan Old Style", Georgia, ui-serif, serif`, `#faf6ee` paper,
+  `#211f1c` ink, `#4c463d` muted text, `#9c8f76` rules,
+  `#ddd3c0` card borders.
+- [`../../Makefile`](../../Makefile): current `DEMO_DECKS`, `demo-site`,
+  `deploy-demo`, and publish contamination check.
+- [`../../.github/workflows/deploy-demo.yml`](../../.github/workflows/deploy-demo.yml):
+  existing deploy flow; add only Zola installation.
+- [`../../CLAUDE.md`](../../CLAUDE.md): demo-site maintenance paragraph.
+
+## Task 1: scaffold Zola and the shared site shell
+
+**Goal**  
+Create a no-theme Zola site in `site/`, with English as the default language,
+syntect-era Zola highlighting enabled, and custom templates/CSS that extend
+the current demo page identity across landing, guide, and examples pages.
+
+**Files**
+
+- `site/config.toml`
+- `site/templates/base.html`
+- `site/templates/index.html`
+- `site/templates/guide.html`
+- `site/templates/guide-page.html`
+- `site/templates/examples.html`
+- `site/templates/example-page.html`
+- `site/content/guide/_index.md`
+- `site/content/examples/_index.md`
+- `site/static/site.css`
+
+**Implementation shape**
+
+Pin the site to the Zola version introduced in Task 6:
+
+```toml
+base_url = "https://peitho.gosu.ke"
+title = "peitho"
+description = "An HTML-native presentation tool that treats Markdown as the source of truth."
+default_language = "en"
+compile_sass = false
+build_search_index = false
+generate_feeds = false
+generate_sitemap = true
+generate_robots_txt = true
+
+[markdown]
+highlight_code = true
+highlight_theme = "base16-ocean-light"
+smart_punctuation = true
+
+[extra]
+github_url = "https://github.com/mizzy/peitho"
+```
+
+Do not set `theme`; absence of the key is the no-theme state. During
+implementation, verify these config keys against the pinned Zola version
+`0.22.1`.
+
+Use Zola multilingual conventions without adding another language yet: English
+pages are plain `content/**/*.md`; a future Japanese pass can add
+`*.ja.md` files and `[languages.ja]`.
+
+`base.html` owns the shared shell:
+
+```html
+<!doctype html>
+<html lang="{{ lang }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+  <meta name="description" content="{{ config.description }}">
+  <link rel="stylesheet" href='{{ get_url(path="site.css") }}'>
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href='{{ get_url(path="@/_index.md") }}'>Peitho</a>
+    <nav aria-label="Primary">
+      <a href='{{ get_url(path="@/guide/_index.md") }}'>Guide</a>
+      <a href='{{ get_url(path="@/examples/_index.md") }}'>Examples</a>
+      <a href="{{ config.extra.github_url }}">GitHub</a>
+    </nav>
+  </header>
+  <main class="{% block main_class %}page{% endblock main_class %}">
+    {% block content %}{% endblock content %}
+  </main>
+  <footer class="site-footer">
+    <a href="{{ config.extra.github_url }}">github.com/mizzy/peitho</a>
+  </footer>
+</body>
+</html>
+```
+
+`index.html` renders the landing page. `guide.html` renders
+`site/content/guide/_index.md` and a linked ordered page list. `guide-page.html`
+renders one guide page plus guide navigation from `get_section(path="guide/_index.md")`.
+`examples.html` renders the gallery from `section.pages`. `example-page.html`
+renders each example page, its `/demo/<name>/` link, and the deck source loaded
+from `page.extra.source_path`.
+
+Create stub sections now so the base navigation resolves before the full guide
+and examples content exists:
+
+```toml
++++
+title = "Guide"
+template = "guide.html"
+page_template = "guide-page.html"
+sort_by = "weight"
++++
+```
+
+```toml
++++
+title = "Examples"
+template = "examples.html"
+page_template = "example-page.html"
+sort_by = "weight"
++++
+```
+
+CSS must carry these exact tokens and patterns:
+
+```css
+:root {
+  --paper: #faf6ee;
+  --ink: #211f1c;
+  --muted: #4c463d;
+  --rule: #9c8f76;
+  --card-border: #ddd3c0;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Iowan Old Style", Georgia, ui-serif, serif;
+}
+.page { max-width: 760px; margin: 0 auto; padding: 48px 24px; }
+.hero h1 { font-size: clamp(44px, 8vw, 72px); font-weight: 600; letter-spacing: 0.04em; }
+.hero h1::after { content: ""; display: block; width: 72px; height: 1px; margin: 28px 0; background: var(--rule); }
+.card-link { display: block; padding: 20px 24px; border: 1px solid var(--card-border); color: inherit; text-decoration: none; }
+.card-link:hover { border-color: var(--ink); }
+```
+
+**Verification**
+
+```bash
+test -f site/config.toml
+test -f site/templates/base.html
+test -f site/templates/index.html
+test -f site/templates/guide.html
+test -f site/templates/guide-page.html
+test -f site/templates/examples.html
+test -f site/templates/example-page.html
+test -f site/content/guide/_index.md
+test -f site/content/examples/_index.md
+test -f site/static/site.css
+rg -n 'default_language = "en"|highlight_code = true|font-family: "Iowan Old Style", Georgia|#faf6ee|#211f1c|#9c8f76|#ddd3c0' site
+! rg -n '^theme =' site/config.toml
+```
+
+## Task 2: write the landing page
+
+**Goal**  
+Create the homepage content and wire it to `index.html`: a hero one-liner,
+three pillars, install one-liner, and links into the guide and examples.
+
+**Files**
+
+- `site/content/_index.md`
+- `site/templates/index.html`
+
+**Implementation shape**
+
+Use this frontmatter:
+
+```toml
++++
+title = "peitho"
+template = "index.html"
++++
+```
+
+Page outline:
+
+- Hero: "An HTML-native presentation tool that treats Markdown as the source
+  of truth."
+- Pillars:
+  - "Separation of content and design": Markdown owns content; HTML/CSS own
+    layout and theme.
+  - "Git-manageable HTML/CSS layouts": layouts and CSS are normal files that
+    diff and review cleanly.
+  - "Type-checked slot contracts": `<slot name accepts arity>` is the schema;
+    missing, extra, mistyped, and unassigned content fail the build with line
+    numbers.
+- Install one-liner:
+
+```sh
+brew install mizzy/tap/peitho
+```
+
+- Entry links:
+  - `/guide/` labeled "Read the guide"
+  - `/examples/` labeled "Browse examples"
+  - `https://github.com/mizzy/peitho` labeled "View source"
+
+All landing copy lives in `site/content/_index.md`, either in the Markdown
+body or in `[extra]` keys. `index.html` only renders data supplied by the
+content file; it must not duplicate the hero, pillar, install, or link copy.
+
+**Verification**
+
+```bash
+rm -rf .zola-landing
+(cd site && zola build --output-dir ../.zola-landing)
+test -f .zola-landing/index.html
+rg -n 'HTML-native presentation tool|Separation of content and design|Git-manageable HTML/CSS layouts|Type-checked slot contracts|brew install mizzy/tap/peitho|/guide/|/examples/' .zola-landing/index.html
+```
+
+## Task 3: write the guide pages from README.md
+
+**Goal**  
+Create task-oriented guide content reconstructed from `README.md`, with
+page-level outlines rather than copied README prose.
+
+**Files**
+
+- `site/content/guide/_index.md`
+- `site/content/guide/getting-started.md`
+- `site/content/guide/writing-decks.md`
+- `site/content/guide/layouts.md`
+- `site/content/guide/frontmatter.md`
+- `site/content/guide/cli.md`
+- `site/templates/guide.html`
+- `site/templates/guide-page.html`
+
+**Implementation shape**
+
+The `site/content/guide/_index.md` stub exists from Task 1. Flesh it out with:
+
+```toml
++++
+title = "Guide"
+template = "guide.html"
+page_template = "guide-page.html"
+sort_by = "weight"
++++
+```
+
+Guide index sections:
+
+- "Start with a deck": link to Getting Started.
+- "Author Markdown": link to Writing Decks.
+- "Design with HTML/CSS": link to Layouts.
+- "Reference": links to Frontmatter and CLI.
+
+Every guide page uses:
+
+```toml
++++
+title = "Page title"
+weight = 10
+template = "guide-page.html"
++++
+```
+
+Use weights `10`, `20`, `30`, `40`, `50` in the page order below.
+
+`getting-started.md` outline:
+
+- "Install": Homebrew first, then prebuilt binaries from GitHub Releases;
+  mention shell completions for Homebrew and no Node/npm runtime dependency.
+- "Create a first deck": a minimal `deck.md` with a title, body, code block,
+  slide separator, and speaker note comment.
+- "Build once": `peitho build` defaults to `deck.md` and writes `dist/`.
+- "Preview while editing": `peitho preview` watches the deck/assets, serves
+  locally, reloads while preserving slide/overview state, and exposes overview
+  controls.
+- "Present": `peitho present` opens slides and presenter view; include
+  `peitho present --presenter-windowed` for debugging.
+
+`writing-decks.md` outline:
+
+- "Deck file shape": optional YAML frontmatter at the top, slides split by
+  `---`, page settings comments before slide content.
+- "Convention mapping": shallowest heading -> `title`, fenced code -> `code`,
+  image-only paragraph -> image slot, all other blocks -> `body`.
+- "Explicit slot syntax": document exactly `::: {slot=name}` and explain that
+  it is for layouts where convention mapping cannot choose between slots.
+- "Speaker notes": non-JSON HTML comments become presenter notes, multiple
+  comments join with a blank line, notes never enter `dist/`.
+- "Page settings comments": JSON comments carry `key`, `layout`, `section`,
+  and `time`.
+- "Agenda sections": `section` and `time` appear together, the first slide must
+  mark a section when any marker exists, and section totals must match deck
+  `time` when deck `time` is set.
+
+`layouts.md` outline:
+
+- "Layout as schema": layouts are plain HTML; the slot tags define the
+  contract.
+- "Slot contract syntax": include this exact shape:
+
+```html
+<slot name="title" accepts="inline" arity="1"></slot>
+<slot name="body" accepts="blocks" arity="0..*"></slot>
+<slot name="code" accepts="code" arity="0..1"></slot>
+```
+
+- "Accepted content and arity": explain `inline`, `blocks`, `code`, `image`,
+  `list`, exact counts, ranges, and line-numbered errors.
+- "Hybrid dispatch": explicit `{"layout":"name"}` first, one layout
+  unconditional, otherwise exactly one structural match; zero or multiple
+  matches fail.
+- "Keyed CSS overrides": `<!-- {"key":"arch-1"} -->`,
+  `[data-slide-key="arch-1"] .slot-code`, and target validation.
+- "Asset placement": frontmatter paths and deck-adjacent `layouts/` and `css/`.
+
+`frontmatter.md` outline:
+
+- "Frontmatter belongs at the top": flat YAML keys only; invalid or misplaced
+  settings are line-numbered build errors.
+- "Keys": cover every supported key: `time`, `aspect_ratio`, `resolution`,
+  `layouts`, `css`, `syntaxes`, `fonts`.
+- "Asset resolution order": explicit frontmatter path, then deck-adjacent
+  `layouts/` / `css/` / `syntaxes/` / `fonts/`, then built-in defaults for
+  layouts/css/syntaxes or no extra assets for fonts.
+- "File and directory behavior": layouts read `*.html`, CSS reads `*.css`,
+  syntaxes read `*.sublime-syntax`, fonts copy files verbatim.
+- "Error behavior": unknown keys, bad values, missing explicit paths, invalid
+  time, and malformed frontmatter stop the build.
+
+`cli.md` outline:
+
+- "Default deck path": commands default to `deck.md` in the current directory.
+- "`peitho build`": write distributable `dist/`, include `--watch`.
+- "`peitho preview`": watch/serve/open/reload daily editing loop.
+- "`peitho present`": full-screen slides plus presenter view; include
+  `--presenter-windowed`.
+- "`peitho export`": `peitho export pdf -o deck.pdf`.
+- "`peitho publish`": inspect then delegate to a user deploy command, with
+  `peitho publish -- aws s3 sync dist/ s3://your-bucket/`.
+- "`peitho completions`": bash, zsh, fish, powershell, elvish.
+
+**Verification**
+
+```bash
+rm -rf .zola-guide
+(cd site && zola build --output-dir ../.zola-guide)
+test -f .zola-guide/guide/index.html
+test -f .zola-guide/guide/getting-started/index.html
+test -f .zola-guide/guide/writing-decks/index.html
+test -f .zola-guide/guide/layouts/index.html
+test -f .zola-guide/guide/frontmatter/index.html
+test -f .zola-guide/guide/cli/index.html
+rg -n '::: \{slot=name\}|speaker notes|Agenda sections|<slot name="title"|time.*aspect_ratio.*resolution|peitho build|peitho preview|peitho present|peitho export|peitho publish|peitho completions' site/content/guide
+```
+
+## Task 4: write the examples gallery and example pages
+
+**Goal**  
+Create `/examples/` plus eight example pages. Each page explains what the deck
+demonstrates, links to `/demo/<name>/`, and renders the real deck source copied
+from `examples/` at build time.
+
+**Files**
+
+- `site/content/examples/_index.md`
+- `site/content/examples/feature-tour.md`
+- `site/content/examples/keynote.md`
+- `site/content/examples/code-walkthrough.md`
+- `site/content/examples/lightning-talk.md`
+- `site/content/examples/two-column.md`
+- `site/content/examples/image-showcase.md`
+- `site/content/examples/aspect-ratio-4-3.md`
+- `site/content/examples/minimal.md`
+- `site/templates/examples.html`
+- `site/templates/example-page.html`
+- `Makefile`
+- `.gitignore`
+
+**Implementation shape**
+
+The `site/content/examples/_index.md` stub exists from Task 1. Flesh it out with:
+
+```toml
++++
+title = "Examples"
+template = "examples.html"
+page_template = "example-page.html"
+sort_by = "weight"
++++
+```
+
+Each example page uses:
+
+```toml
++++
+title = "Feature Tour"
+weight = 10
+template = "example-page.html"
+
+[extra]
+deck = "feature-tour"
+demo_path = "/demo/feature-tour/"
+source_path = "static/deck-sources/feature-tour/deck.md"
+summary = "A tour deck that exercises Peitho's own contract and presenter features."
++++
+```
+
+Weights and source paths:
+
+| Weight | Page | Deck source copied from | `extra.source_path` |
+|---:|---|---|---|
+| 10 | `feature-tour.md` | `examples/feature-tour/deck.md` | `static/deck-sources/feature-tour/deck.md` |
+| 20 | `keynote.md` | `examples/keynote/deck.md` | `static/deck-sources/keynote/deck.md` |
+| 30 | `code-walkthrough.md` | `examples/code-walkthrough/deck.md` | `static/deck-sources/code-walkthrough/deck.md` |
+| 40 | `lightning-talk.md` | `examples/lightning-talk/deck.md` | `static/deck-sources/lightning-talk/deck.md` |
+| 50 | `two-column.md` | `examples/two-column/deck.md` | `static/deck-sources/two-column/deck.md` |
+| 60 | `image-showcase.md` | `examples/image-showcase/deck.md` | `static/deck-sources/image-showcase/deck.md` |
+| 70 | `aspect-ratio-4-3.md` | `examples/aspect-ratio-4-3/deck.md` | `static/deck-sources/aspect-ratio-4-3/deck.md` |
+| 80 | `minimal.md` | `examples/deck.md` | `static/deck-sources/minimal/deck.md` |
+
+Add `docs-sources` and include it in `.PHONY`:
+
+```make
+DOCS_SOURCE_DIR = site/static/deck-sources
+
+docs-sources:
+	rm -rf $(DOCS_SOURCE_DIR)
+	mkdir -p $(DOCS_SOURCE_DIR)/minimal
+	cp examples/deck.md $(DOCS_SOURCE_DIR)/minimal/deck.md
+	for d in $(filter-out minimal,$(DEMO_DECKS)); do \
+		mkdir -p $(DOCS_SOURCE_DIR)/$$d; \
+		cp examples/$$d/deck.md $(DOCS_SOURCE_DIR)/$$d/deck.md; \
+	done
+```
+
+Add this ignore rule so the build-time deck source copies do not stay dirty:
+
+```gitignore
+site/static/deck-sources/
+```
+
+`example-page.html` loads the source copy produced by `make docs-sources`.
+Zola resolves `load_data` paths relative to the site root containing
+`config.toml`, so each path includes the `static/` prefix:
+
+```html
+{% set deck_source = load_data(path=page.extra.source_path, format="plain") %}
+{% set source_block = "````markdown\n" ~ deck_source ~ "\n````" %}
+<p><a class="card-link" href="{{ page.extra.demo_path }}">Open live demo</a></p>
+<section class="deck-source">
+  <h2>Deck source</h2>
+  {{ source_block | markdown | safe }}
+</section>
+```
+
+Write fresh English descriptions from `examples/<name>/` contents, not
+translations of the Japanese text in `demo/index.html`:
+
+- Feature Tour: four layouts, planned time/sections, speaker notes, list slot,
+  multi-language highlighting, and explicit layout selection for ambiguity.
+- Keynote: title-only cover slides and body statement slides dispatched by
+  shape, with a centered serif keynote look.
+- Code Walkthrough: Rust typestate walkthrough, required code slot
+  `arity="1"`, terminal-like two-column styling, keyed CSS override.
+- Lightning Talk: five-minute poster-style talk, planned sections, notes, and
+  a layout that accepts title/body but no code.
+- Two Column: explicit `::: {slot=left}` and `::: {slot=right}` routing for
+  two `accepts="blocks"` slots.
+- Image Showcase: local Markdown image mapped into an `accepts="image"` slot.
+- Aspect Ratio 4:3: `aspect_ratio: 4:3` and 960x720 logical canvas behavior.
+- Minimal: single `examples/deck.md` using built-in default layout/theme, slide
+  splitting, keyed comments, code, and notes.
+
+**Verification**
+
+```bash
+make docs-sources
+(cd site && zola build --output-dir ../.zola-examples)
+test -f .zola-examples/examples/index.html
+test -f .zola-examples/examples/feature-tour/index.html
+test -f .zola-examples/examples/keynote/index.html
+test -f .zola-examples/examples/code-walkthrough/index.html
+test -f .zola-examples/examples/lightning-talk/index.html
+test -f .zola-examples/examples/two-column/index.html
+test -f .zola-examples/examples/image-showcase/index.html
+test -f .zola-examples/examples/aspect-ratio-4-3/index.html
+test -f .zola-examples/examples/minimal/index.html
+cmp -s examples/deck.md site/static/deck-sources/minimal/deck.md
+cmp -s examples/feature-tour/deck.md site/static/deck-sources/feature-tour/deck.md
+rg -n '/demo/feature-tour/|The Peitho Feature Tour|/demo/minimal/|Peitho Architecture' .zola-examples/examples
+```
+
+## Task 5: add frozen legacy redirects
+
+**Goal**  
+Preserve the eight old root deck URLs by adding a Cloudflare Pages `_redirects`
+file. This list is frozen and never grows; new examples are born under
+`/demo/` and need no redirect.
+
+**Files**
+
+- `site/static/_redirects`
+
+**Implementation shape**
+
+The file contains exactly these eight lines, no comments and no blank lines:
+
+```text
+/minimal/* /demo/minimal/:splat 301
+/lightning-talk/* /demo/lightning-talk/:splat 301
+/code-walkthrough/* /demo/code-walkthrough/:splat 301
+/keynote/* /demo/keynote/:splat 301
+/feature-tour/* /demo/feature-tour/:splat 301
+/two-column/* /demo/two-column/:splat 301
+/image-showcase/* /demo/image-showcase/:splat 301
+/aspect-ratio-4-3/* /demo/aspect-ratio-4-3/:splat 301
+```
+
+**Verification**
+
+```bash
+test -f site/static/_redirects
+test "$(wc -l < site/static/_redirects | tr -d ' ')" = "8"
+grep -Fx '/feature-tour/* /demo/feature-tour/:splat 301' site/static/_redirects
+! rg -n '^#|^$' site/static/_redirects
+```
+
+## Task 6: rework Makefile demo-site composition
+
+**Goal**  
+Make `make demo-site` build one static tree by composing Zola docs and Peitho
+decks: Zola writes landing/guide/examples/redirects to `.demo-site`, then
+Peitho writes every deck to `.demo-site/demo/<name>`, then the existing
+publish contamination check runs per deck at the new paths.
+
+**Files**
+
+- `Makefile`
+
+**Implementation shape**
+
+Add the documented Zola pin and the absolute output helper:
+
+```make
+ZOLA_VERSION = 0.22.1
+ZOLA ?= zola
+DEMO_OUT_ABS := $(abspath $(DEMO_OUT))
+```
+
+Rework `demo-site`:
+
+```make
+demo-site: docs-sources
+	rm -rf $(DEMO_OUT)
+	cd site && $(ZOLA) build --output-dir $(DEMO_OUT_ABS)
+	$(PEITHO) build examples/deck.md --out $(DEMO_OUT)/demo/minimal
+	$(PEITHO) build examples/lightning-talk/deck.md --out $(DEMO_OUT)/demo/lightning-talk
+	$(PEITHO) build examples/code-walkthrough/deck.md --out $(DEMO_OUT)/demo/code-walkthrough
+	$(PEITHO) build examples/keynote/deck.md --out $(DEMO_OUT)/demo/keynote
+	$(PEITHO) build examples/feature-tour/deck.md --out $(DEMO_OUT)/demo/feature-tour
+	$(PEITHO) build examples/two-column/deck.md --out $(DEMO_OUT)/demo/two-column
+	$(PEITHO) build examples/image-showcase/deck.md --out $(DEMO_OUT)/demo/image-showcase
+	$(PEITHO) build examples/aspect-ratio-4-3/deck.md --out $(DEMO_OUT)/demo/aspect-ratio-4-3
+	for d in $(DEMO_DECKS); do \
+		$(PEITHO) publish --dist $(DEMO_OUT)/demo/$$d -- true || exit 1; \
+	done
+```
+
+Delete the old `cp demo/index.html $(DEMO_OUT)/index.html` line. Keep
+`deploy-demo` unchanged so it still deploys `$(DEMO_OUT)`.
+
+`ZOLA_VERSION` documents the version used by CI; local `make demo-site` should
+use whatever `zola` is on PATH and must not hard-fail on an exact version
+match.
+
+**Verification**
+
+```bash
+! rg -n 'cp demo/index.html' Makefile
+! rg -n 'zola --version.*grep' Makefile
+make demo-site
+test -f .demo-site/index.html
+test -f .demo-site/_redirects
+test -d .demo-site/demo/minimal
+test -d .demo-site/demo/lightning-talk
+test -d .demo-site/demo/code-walkthrough
+test -d .demo-site/demo/keynote
+test -d .demo-site/demo/feature-tour
+test -d .demo-site/demo/two-column
+test -d .demo-site/demo/image-showcase
+test -d .demo-site/demo/aspect-ratio-4-3
+```
+
+## Task 7: install pinned Zola in deploy-demo workflow
+
+**Goal**  
+Add a single pinned Zola binary install step before `make demo-site`. Leave
+checkout, Rust setup/cache, build command, Cloudflare deploys, and PR comment
+logic unchanged.
+
+**Files**
+
+- `.github/workflows/deploy-demo.yml`
+
+**Implementation shape**
+
+Insert this step after `Swatinem/rust-cache@v2` and before "Build demo site":
+
+```yaml
+      - name: Install Zola
+        env:
+          ZOLA_VERSION: 0.22.1
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/zola.tar.gz
+          tar -xzf /tmp/zola.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/zola /usr/local/bin/zola
+          zola --version
+```
+
+The version literal must match `ZOLA_VERSION` in `Makefile`.
+Confirm the release asset name
+`zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz` against the `0.22.1`
+GitHub release during implementation before merging.
+
+**Verification**
+
+```bash
+rg -n 'Install Zola|ZOLA_VERSION: 0.22.1|zola-v\$\{ZOLA_VERSION\}-x86_64-unknown-linux-gnu.tar.gz|make demo-site' .github/workflows/deploy-demo.yml
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-demo.yml"); puts "yaml ok"'
+```
+
+## Task 8: delete the old hand-written demo index
+
+**Goal**  
+Remove the old Japanese `demo/index.html`; the Zola landing page is now the
+root page.
+
+**Files**
+
+- `demo/index.html`
+- `Makefile`
+
+**Implementation shape**
+
+Delete `demo/index.html`. The old copy line is already removed by Task 6:
+
+```make
+cp demo/index.html $(DEMO_OUT)/index.html
+```
+
+**Verification**
+
+```bash
+test ! -e demo/index.html
+! rg -n 'demo/index.html|cp demo/index.html' Makefile
+```
+
+## Task 9: update demo-site notes in CLAUDE.md
+
+**Goal**  
+Update the repository operating notes so future agents know the docs site
+exists, decks now live under `/demo/`, and the redirect list is frozen.
+
+**Files**
+
+- `CLAUDE.md`
+
+**Implementation shape**
+
+Replace the current demo-site paragraph with these facts:
+
+- `.github/workflows/deploy-demo.yml` still builds `make demo-site` from source
+  and deploys `.demo-site` to Cloudflare Pages project `peitho`.
+- `make demo-site` first builds the Zola site from `site/`, then builds each
+  example deck under `.demo-site/demo/<name>`, then runs the publish
+  contamination check per deck.
+- Adding an example requires editing `DEMO_DECKS` / `demo-site` in `Makefile`
+  and adding `site/content/examples/<name>.md`.
+- Do not add redirects for new examples; `site/static/_redirects` is a frozen
+  eight-line legacy list for decks that used to live at the root.
+- `demo/index.html` no longer exists.
+
+**Verification**
+
+```bash
+rg -n 'site/|/demo/<name>|site/content/examples/<name>.md|_redirects|demo/index.html no longer exists' CLAUDE.md
+! rg -n 'demo/index.html by hand|adding an example still requires editing.*demo/index.html' CLAUDE.md
+```
+
+## Task 10: final verification
+
+**Goal**  
+Prove the docs/static-site change works locally and does not regress standard
+repo gates. There is no cargo/vitest-specific implementation surface in this
+plan, but the standard gates still run at the end.
+
+**Files**
+
+- Generated `.demo-site/`
+- Existing repo test/build surfaces
+
+**Verification**
+
+```bash
+make docs-sources
+(cd site && zola check)
+make demo-site
+test -f .demo-site/index.html
+test -d .demo-site/guide
+test -d .demo-site/examples
+test -f .demo-site/_redirects
+test "$(wc -l < .demo-site/_redirects | tr -d ' ')" = "8"
+grep -Fx '/feature-tour/* /demo/feature-tour/:splat 301' .demo-site/_redirects
+test -d .demo-site/demo/minimal
+test -d .demo-site/demo/lightning-talk
+test -d .demo-site/demo/code-walkthrough
+test -d .demo-site/demo/keynote
+test -d .demo-site/demo/feature-tour
+test -d .demo-site/demo/two-column
+test -d .demo-site/demo/image-showcase
+test -d .demo-site/demo/aspect-ratio-4-3
+cargo test --workspace
+cargo test --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all --check
+git diff --exit-code bindings/
+(cd packages/peitho-present && npm run build && npm test && npm run typecheck)
+git diff --exit-code packages/peitho-present/dist/shell.js
+git diff --exit-code packages/peitho-present/dist/preview.js
+```

--- a/docs/specs/2026-07-09-docs-site-design.md
+++ b/docs/specs/2026-07-09-docs-site-design.md
@@ -1,0 +1,183 @@
+# Docs site for peitho.gosu.ke
+
+Date: 2026-07-09
+Status: approved by the author (stack, language, structure, and URL scheme confirmed in conversation)
+
+## Goal
+
+Turn https://peitho.gosu.ke/ from a bare list of demo decks into a full
+documentation site: a landing page that explains what peitho is, a guide that
+teaches how to use it, and an examples section that showcases the existing
+demo decks. Comparable in richness to the documentation sites of similar
+tools, while keeping peitho's own identity.
+
+## Chosen approach: Zola with custom templates
+
+Static site generator: [Zola](https://www.getzola.org/). Rationale, driven by
+peitho's own requirements rather than by what similar tools use:
+
+- **Full control over design.** The site inherits the hand-crafted visual
+  identity of the current `demo/index.html` (serif typography, warm paper
+  background, thin rules). Zola templates are plain HTML + CSS (Tera), so the
+  existing page style extends naturally to the whole site. This also matches
+  peitho's own pillars: HTML-native, git-manageable HTML/CSS.
+- **Rust toolchain.** Zola is a single Rust binary; CI installs one tool. No
+  new package ecosystem is introduced for the site.
+- **syntect built in.** Zola highlights code with syntect — the same
+  highlighter peitho itself uses — so code samples on the docs site and
+  peitho's own output stay consistent.
+- **Right-sized.** The site is 15–25 pages. Heavier docs frameworks
+  (VitePress, Starlight) earn their weight through default themes and
+  built-in search; we are replacing the theme anyway, and search can be added
+  later with Pagefind (fully static, non-invasive) if the page count grows.
+
+Rejected alternatives:
+
+- **VitePress / Astro Starlight**: default-theme value is lost the moment we
+  keep our own design; deep theme customization means working in Vue/Astro
+  components rather than plain HTML/CSS.
+- **Hand-rolled static HTML** (status quo): no shared layout, no Markdown
+  pipeline; every page duplicates boilerplate and drifts.
+
+## Key decisions
+
+### Language: English first, Japanese-ready
+
+The site is English-only at launch, consistent with the project's
+English-only rule. The content tree uses Zola's multilingual conventions from
+day one (`default_language = "en"`; pages are `content/**/pagename.md`), so
+Japanese can be added later non-destructively by dropping
+`pagename.ja.md` files next to the English ones and enabling
+`[languages.ja]` in `config.toml` — English URLs do not change.
+
+### Content structure: three pillars
+
+1. **Landing page** (`/`) — hero (one-line statement of what peitho is), the
+   three pillars (separation of content and design; git-manageable HTML/CSS
+   layouts; type-checked slot contracts), install one-liner, and entry points
+   into the guide and examples. Carries over the current `demo/index.html`
+   aesthetic.
+2. **Guide** (`/guide/…`) — task-oriented documentation, reconstructed from
+   README.md and existing design records:
+   - Getting Started — install (Homebrew / prebuilt binaries), first deck,
+     `preview`, `present`
+   - Writing Decks — slide splitting, convention mapping, explicit slot
+     syntax (`::: {slot=name}`), speaker notes, page settings comments,
+     agenda sections
+   - Layouts — the layout-as-schema idea, `<slot name accepts arity>`,
+     multiple layouts and hybrid dispatch, keyed CSS overrides
+   - Frontmatter — reference for every supported key (`time`,
+     `aspect_ratio`, `resolution`, `layouts`, `css`, `syntaxes`, `fonts`),
+     asset resolution order, error behavior
+   - CLI — `build`, `preview`, `present`, `export`, `publish`,
+     `completions`; flags and the daily editing loop
+3. **Examples** (`/examples/…`) — one page per demo deck (8 today): what the
+   deck demonstrates, a link to the live demo under `/demo/<name>/`, and the
+   deck's `deck.md` source (or the instructive excerpt) with highlighting.
+
+The guide documents *usage*; internal design records stay in `docs/` in the
+repository and are not part of the site.
+
+### URL scheme: decks move under /demo/
+
+Built decks move from the site root (`/feature-tour/`) to
+`/demo/<name>/`. The root namespace belongs to the docs site (`/guide/…`,
+`/examples/…`), which removes any chance of collision between future doc
+pages and deck names.
+
+Old URLs keep working via a Cloudflare Pages `_redirects` file with one rule
+per deck (e.g. `/feature-tour/* /demo/feature-tour/:splat 301`). A wildcard
+single rule is not possible because the old deck paths live at the root, so
+the redirect list is explicit — one line per existing deck, maintained
+alongside the deck list in the Makefile.
+
+### Build composition: one static tree, same deploy flow
+
+`make demo-site` remains the single entry point and now composes two builds
+into `.demo-site/`:
+
+1. `zola build` in `site/` → output to `.demo-site/` (landing, guide,
+   examples, `_redirects`)
+2. `peitho build examples/<name>/deck.md --out .demo-site/demo/<name>` for
+   each deck, followed by the existing `peitho publish` contamination check
+
+The deploy workflow (`.github/workflows/deploy-demo.yml`) gains one step:
+install Zola (single binary, version pinned in the workflow). Everything else
+— Cloudflare Pages project, main-push deploy, PR preview deploys and
+cleanup — stays as designed in
+`docs/plans/2026-07-09-demo-site-deploy-flow.md`.
+
+`demo/index.html` is deleted; the landing page replaces it. The Japanese text
+in that file (a leftover from the English-only migration, PR #199) disappears
+with it.
+
+## File structure
+
+```
+site/
+  config.toml          # default_language = "en", syntect highlighting on
+  content/
+    _index.md          # landing page content
+    guide/
+      _index.md        # guide index / sidebar root
+      getting-started.md
+      writing-decks.md
+      layouts.md
+      frontmatter.md
+      cli.md
+    examples/
+      _index.md        # examples index (the gallery, successor of today's list)
+      feature-tour.md
+      keynote.md
+      code-walkthrough.md
+      lightning-talk.md
+      two-column.md
+      image-showcase.md
+      aspect-ratio-4-3.md
+      minimal.md
+  templates/
+    base.html          # shared shell: header nav, footer, styles
+    index.html         # landing
+    guide.html / guide-page.html
+    examples.html / example-page.html
+  static/
+    _redirects         # old root deck URLs → /demo/<name>/
+    (css, any images)
+```
+
+Notes:
+
+- Templates and CSS are hand-written and carry the current visual identity;
+  no third-party Zola theme is used.
+- Deck sources shown on example pages are included from `examples/` at build
+  time (Zola `load_data` or a documented copy step) rather than pasted, so
+  they cannot drift from the real decks. The exact mechanism is an
+  implementation-plan decision; the invariant is: **example sources on the
+  site must come from `examples/`, not be maintained by hand.**
+
+## Edge cases and constraints
+
+- **Deck/doc URL collisions**: prevented structurally by the `/demo/` prefix.
+- **Redirects must not be forgotten when adding a deck**: adding an example
+  already requires touching the Makefile deck list; the `_redirects` file
+  only lists *pre-move* decks (the 8 that shipped at root), so it is a
+  frozen, never-growing list. New decks are born under `/demo/` and need no
+  redirect.
+- **English-only rule**: all site content, templates, and this design doc are
+  English. Future Japanese content is an explicit, additive step.
+- **Publish contamination check**: unchanged — it runs per-deck against
+  `.demo-site/demo/<name>` exactly as it runs today against
+  `.demo-site/<name>`.
+- **Zola version pinning**: the workflow pins an exact Zola version to keep
+  CI reproducible; local builds document the same version in the Makefile.
+- **No auto-listing regression**: adding an example still requires manual
+  edits (Makefile target + a new `site/content/examples/<name>.md`). This
+  matches the current documented behavior; auto-listing is out of scope.
+
+## Out of scope
+
+- Full-text search (add Pagefind later if needed)
+- Japanese translation (structure is ready; content is not written now)
+- Auto-discovery of example decks
+- Publishing real (non-example) decks to peitho.gosu.ke (tracked separately
+  in CLAUDE.md "Undecided")


### PR DESCRIPTION
## Summary

Design document and implementation plan for turning https://peitho.gosu.ke/ from a bare demo-deck list into a full documentation site (landing page, guide, examples gallery), per the author-approved decisions:

- **Stack**: Zola with custom Tera templates — full design control carrying over the current visual identity, Rust toolchain, syntect highlighting consistent with peitho itself
- **Language**: English first; Zola multilingual conventions keep a later `/ja/` addition non-destructive
- **Structure**: landing / guide (getting started, writing decks, layouts, frontmatter, CLI) / examples (8 decks with live demos and drift-proof sources)
- **URLs**: decks move to `/demo/<name>/`; old root URLs get a frozen 8-line `_redirects` list
- **Build & deploy**: `make demo-site` composes `zola build` + deck builds into `.demo-site/`; the Cloudflare Pages flow gains only a pinned Zola install step

## Contents

- `docs/specs/2026-07-09-docs-site-design.md` — the design record
- `docs/plans/2026-07-09-docs-site.md` — 10 tasks, each independently verifiable

Implementation follows in separate PRs, one issue per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC