### PR TITLE
Docs site: landing page content

### DIFF
--- a/docs/plans/2026-07-09-docs-site.md
+++ b/docs/plans/2026-07-09-docs-site.md
@@ -270,13 +270,23 @@ All landing copy lives in `site/content/_index.md`, either in the Markdown
 body or in `[extra]` keys. `index.html` only renders data supplied by the
 content file; it must not duplicate the hero, pillar, install, or link copy.
 
+Zola/Tera autoescapes `/` in text nodes as `&#x2F;`; keep the entity-escaped
+checks below so rendered-source assertions match the build output without
+disabling escaping.
+
 **Verification**
 
 ```bash
 rm -rf .zola-landing
 (cd site && zola build --output-dir ../.zola-landing)
 test -f .zola-landing/index.html
-rg -n 'HTML-native presentation tool|Separation of content and design|Git-manageable HTML/CSS layouts|Type-checked slot contracts|brew install mizzy/tap/peitho|/guide/|/examples/' .zola-landing/index.html
+rg -n 'HTML-native presentation tool' .zola-landing/index.html
+rg -n 'Separation of content and design' .zola-landing/index.html
+rg -n 'Git-manageable HTML&#x2F;CSS layouts' .zola-landing/index.html
+rg -n 'Type-checked slot contracts' .zola-landing/index.html
+rg -n 'brew install mizzy&#x2F;tap&#x2F;peitho' .zola-landing/index.html
+rg -n '/guide/' .zola-landing/index.html
+rg -n '/examples/' .zola-landing/index.html
 ```
 
 ## Task 3: write the guide pages from README.md

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,4 +1,41 @@
 +++
 title = "peitho"
 template = "index.html"
+
+[extra.hero]
+lead = "An HTML-native presentation tool that treats Markdown as the source of truth."
+
+[[extra.sections]]
+title = "Pillars"
+
+[[extra.sections.rows]]
+title = "Separation of content and design"
+meta = "Markdown owns the content; HTML and CSS own the layout and theme. Neither leaks into the other."
+
+[[extra.sections.rows]]
+title = "Git-manageable HTML/CSS layouts"
+meta = "Layouts and CSS are normal files that diff and review cleanly. The layout itself is the schema (<slot name accepts arity>)."
+
+[[extra.sections.rows]]
+title = "Type-checked slot contracts"
+meta = "Slot excess and deficiency, type mismatches, broken references, and unassigned content are all build errors with line numbers and help."
+
+[[extra.sections]]
+title = "Install"
+code = "brew install mizzy/tap/peitho"
+
+[[extra.sections]]
+title = "Start"
+
+[[extra.sections.rows]]
+title = "Read the guide"
+path = "@/guide/_index.md"
+
+[[extra.sections.rows]]
+title = "Browse examples"
+path = "@/examples/_index.md"
+
+[[extra.sections.rows]]
+title = "View source"
+url = "https://github.com/mizzy/peitho"
 +++

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1,12 +1,66 @@
 {% extends "base.html" %}
 
-{% block title %}{{ config.title }}{% endblock title %}
-
-{% block main_class %}page{% endblock main_class %}
-
 {% block content %}
+  {% for key, value in section.extra.hero %}
+    {% if key != "lead" %}
+      {# deliberately undefined: referencing it fails the build on a shape violation #}
+      {{ throw_unknown_landing_hero_key }}
+    {% endif %}
+  {% endfor %}
+
   <section class="hero">
     <h1>{{ section.title }}</h1>
+    <p>{{ section.extra.hero.lead }}</p>
     {{ section.content | safe }}
   </section>
+
+  {% for landing_section in section.extra.sections %}
+    {% for key, value in landing_section %}
+      {% if key != "title" and key != "code" and key != "rows" %}
+        {{ throw_unknown_landing_section_key }}
+      {% endif %}
+    {% endfor %}
+
+    <section>
+      <h2>{{ landing_section.title }}</h2>
+
+      {% if landing_section.code and landing_section.rows %}
+        {{ throw_landing_section_has_both_code_and_rows }}
+      {% elif landing_section.code %}
+        <pre><code>{{ landing_section.code }}</code></pre>
+      {% elif landing_section.rows %}
+        <ul class="rows" role="list">
+          {% for row in landing_section.rows %}
+            {% for key, value in row %}
+              {% if key != "title" and key != "meta" and key != "path" and key != "url" %}
+                {{ throw_unknown_landing_row_key }}
+              {% endif %}
+            {% endfor %}
+
+            <li class="row">
+              {% if row.path and row.url %}
+                {{ throw_landing_row_has_both_path_and_url }}
+              {% elif row.path or row.url %}
+                <a class="row-link" href="{% if row.path %}{{ get_url(path=row.path) }}{% else %}{{ row.url }}{% endif %}">
+                  <span class="row-title">{{ row.title }}</span>
+                  {% if row.meta %}
+                    <span class="row-meta">{{ row.meta }}</span>
+                  {% endif %}
+                </a>
+              {% else %}
+                <div class="row-link">
+                  <span class="row-title">{{ row.title }}</span>
+                  {% if row.meta %}
+                    <span class="row-meta">{{ row.meta }}</span>
+                  {% endif %}
+                </div>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        {{ throw_unknown_landing_section_shape }}
+      {% endif %}
+    </section>
+  {% endfor %}
 {% endblock content %}


### PR DESCRIPTION
Closes #202

Task 2 of docs/plans/2026-07-09-docs-site.md: the landing page.

- All copy lives in site/content/_index.md as structured [extra] data (hero lead, three pillars, install one-liner, entry rows); index.html renders data only — no copy in the template
- Pillar wording follows CLAUDE.md's canonical three pillars, including the <slot name accepts arity> literal and the build-errors sentence
- Fail-loud template contract: missing hero lead, unknown keys on hero/sections/rows, a section with neither/both of code and rows, and a row with both path and url all fail zola build via deliberately-undefined Tera variables (each path measured)
- Plan amendment: Task 2 verification split into per-literal rg checks with entity-escaped forms (Tera escapes / to &#x2F;), so the block proves every literal instead of passing on one alternation hit

Review: 5 fresh-eyes rounds; findings fixed and measured each round (escaping discipline, ol→ul semantics, kind-dispatch removal, mandatory hero lead, grammar/canonical pillar copy, dead block overrides, verification fidelity, key whitelists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC