### PR TITLE
Docs site: guide pages reconstructed from README

### DIFF
--- a/docs/plans/2026-07-09-docs-site.md
+++ b/docs/plans/2026-07-09-docs-site.md
@@ -379,8 +379,9 @@ Use weights `10`, `20`, `30`, `40`, `50` in the page order below.
 <slot name="code" accepts="code" arity="0..1"></slot>
 ```
 
-- "Accepted content and arity": explain `inline`, `blocks`, `code`, `image`,
-  `list`, exact counts, ranges, and line-numbered errors.
+- "Accepted content and arity": explain `inline`, `blocks`, `text`, `code`,
+  `image`, `list` (six variants, per domain.rs), the four supported arity
+  literals `1`, `0..1`, `1..*`, `0..*`, and line-numbered errors.
 - "Hybrid dispatch": explicit `{"layout":"name"}` first, one layout
   unconditional, otherwise exactly one structural match; zero or multiple
   matches fail.

--- a/site/content/guide/_index.md
+++ b/site/content/guide/_index.md
@@ -3,4 +3,34 @@ title = "Guide"
 template = "guide.html"
 page_template = "guide-page.html"
 sort_by = "weight"
+description = "Learn Peitho by moving from a first deck to authoring, layouts, frontmatter, and CLI workflows."
 +++
+
+Peitho keeps presentation content in Markdown and presentation design in HTML
+and CSS. Use this guide when you want to write a deck, choose or design
+layouts, configure deck-level settings, and run the command-line workflows.
+
+## Start with a deck
+
+[Getting Started](@/guide/getting-started.md) walks through installation, a
+small `deck.md`, one build, the live preview loop, and presenting with the
+presenter view.
+
+## Author Markdown
+
+[Writing Decks](@/guide/writing-decks.md) explains the Markdown file shape:
+frontmatter, slide separators, convention mapping, explicit slots, speaker
+notes, page settings, and agenda sections.
+
+## Design with HTML/CSS
+
+[Layouts](@/guide/layouts.md) covers layouts as schemas, slot contracts,
+hybrid layout dispatch, keyed CSS overrides, and where layout and CSS assets
+belong.
+
+## Reference
+
+[Frontmatter](@/guide/frontmatter.md) lists the supported deck settings and
+asset resolution rules. [CLI](@/guide/cli.md) lists the default deck path and
+the `build`, `preview`, `present`, `export`, `publish`, and `completions`
+commands.

--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -1,0 +1,84 @@
++++
+title = "CLI"
+weight = 50
+template = "guide-page.html"
+description = "Run Peitho commands for building, previewing, presenting, exporting, publishing, and shell completions."
++++
+
+## Default deck path
+
+Commands default to `deck.md` in the current directory, so the deck argument can
+be omitted when the file follows the convention.
+
+Use an explicit path when the deck has another name:
+
+```sh
+peitho build slides.md
+```
+
+## `peitho build`
+
+Build writes the distributable `dist/` directory with slide fragments,
+`manifest.json`, `index.html`, and `peitho.css`.
+
+```sh
+peitho build
+```
+
+Rebuild on every save for an external server or pipeline:
+
+```sh
+peitho build --watch
+```
+
+## `peitho preview`
+
+Preview is the daily editing loop: watch, serve, open, and reload on every
+successful rebuild.
+
+```sh
+peitho preview
+```
+
+It watches the same deck and asset roots as `build --watch`, serves locally,
+and reloads while preserving the current slide and overview state.
+
+## `peitho present`
+
+Present generates a volatile cache, starts a local server, launches the browser,
+and places full-screen slides plus the presenter view across displays.
+
+```sh
+peitho present
+```
+
+Use windowed presenter mode while debugging:
+
+```sh
+peitho present --presenter-windowed
+```
+
+## `peitho export`
+
+Export a PDF:
+
+```sh
+peitho export pdf -o deck.pdf
+```
+
+## `peitho publish`
+
+Publish inspects the built output, then delegates deployment to a command you
+already use.
+
+```sh
+peitho publish -- aws s3 sync dist/ s3://your-bucket/
+```
+
+## `peitho completions`
+
+Generate shell completion scripts for bash, zsh, fish, powershell, or elvish.
+
+```sh
+peitho completions zsh
+```

--- a/site/content/guide/frontmatter.md
+++ b/site/content/guide/frontmatter.md
@@ -1,0 +1,71 @@
++++
+title = "Frontmatter"
+weight = 40
+template = "guide-page.html"
+description = "Use deck frontmatter for time, canvas, PDF, layout, CSS, syntax, and font settings."
++++
+
+## Frontmatter belongs at the top
+
+Deck-level settings live in YAML frontmatter at the top of the deck. The body
+is restricted to flat `key:` lines, with trailing stylistic blank lines allowed.
+Settings anywhere but the top are not accepted as deck settings.
+
+Invalid or misplaced settings are line-numbered build errors with help. A
+leading `---` without valid frontmatter, malformed YAML, and Markdown swallowed
+by a missing closing `---` all stop the build.
+
+## Keys
+
+Supported keys are `time`, `aspect_ratio`, `resolution`, `layouts`, `css`,
+`syntaxes`, and `fonts`.
+
+| Key | Purpose |
+| --- | --- |
+| `time` | Planned presentation time: `15m`, `90s`, `1h30m`, or a bare integer in minutes. |
+| `aspect_ratio` | Slide canvas aspect ratio: `16:9` (default) or `4:3`. |
+| `resolution` | PDF-only physical page size in `WxH` CSS pixels. |
+| `layouts` | Layout HTML file or directory. |
+| `css` | Theme CSS file or directory. |
+| `syntaxes` | Custom syntect syntax file or directory. |
+| `fonts` | Font asset file or directory. |
+
+Examples in the repository include:
+
+```yaml
+time: 8m
+```
+
+```yaml
+aspect_ratio: 16:9
+resolution: 1920x1080
+```
+
+## Asset resolution order
+
+For asset keys, Peitho resolves assets in this order:
+
+1. Explicit frontmatter path.
+2. Deck-adjacent auto-detect: `layouts/`, `css/`, `syntaxes/`, or `fonts/`
+   next to the deck.
+3. Built-in defaults for layouts, CSS, and syntaxes; no extra asset for fonts.
+
+An explicit path that does not exist is a line-numbered build error, not a
+silent fallback to auto-detect or built-ins.
+
+## File and directory behavior
+
+Each asset key may point at a file or a directory. Directories are read in
+deterministic filename order.
+
+Layouts read `*.html`. CSS reads `*.css`. Syntaxes read
+`*.sublime-syntax` and augment the built-in syntax set. Fonts copy files
+verbatim without an extension filter, so `.woff2`, `.ttf`, and `@font-face` CSS
+files can live side by side.
+
+## Error behavior
+
+Unknown keys, bad values, missing explicit paths, invalid `time`, and malformed
+frontmatter stop the build with line-numbered errors and help. Time validation
+requires nonzero values, rejects overflow, and keeps values within JavaScript's
+safe integer range before they reach the manifest.

--- a/site/content/guide/getting-started.md
+++ b/site/content/guide/getting-started.md
@@ -1,0 +1,97 @@
++++
+title = "Getting Started"
+weight = 10
+template = "guide-page.html"
+description = "Install Peitho, write a first deck, build it, preview it, and present it."
++++
+
+## Install
+
+Install with Homebrew on macOS or Linux:
+
+```sh
+brew install mizzy/tap/peitho
+```
+
+Homebrew installs shell completions for bash, zsh, and fish automatically.
+
+For a prebuilt binary, download the tarball for your target from GitHub
+Releases, verify the checksum, unpack it, and move the single `peitho` binary
+onto your `PATH`. Layouts, the base theme, and the presentation shell are
+embedded, so Node.js and npm are not runtime dependencies.
+
+## Create a first deck
+
+Create `deck.md` in an empty directory. This example is adapted from
+`examples/deck.md`: it has a title, body text, a fenced code block, a slide
+separator, and a speaker note written as an HTML comment.
+
+````markdown
+# Peitho Architecture
+
+Markdown is the source of truth, while HTML and CSS own layout.
+
+```rust
+enum Phase { Parsed, Mapped, Checked, Rendered }
+```
+
+<!--
+Open with the two-line pitch: separation of content and design,
+then move to the pipeline.
+-->
+
+---
+
+# Convention Mapping
+
+- Shallowest heading maps to title
+- Code blocks map to code
+- Remaining blocks map to body
+````
+
+## Build once
+
+Run a build from the directory that contains `deck.md`:
+
+```sh
+peitho build
+```
+
+The deck argument defaults to `deck.md`, so `peitho build` is the same as
+`peitho build deck.md`. A build writes the distributable `dist/` directory with
+slide fragments, `manifest.json`, `index.html`, and `peitho.css`.
+
+## Preview while editing
+
+Use preview for the daily editing loop:
+
+```sh
+peitho preview
+```
+
+Preview watches the deck and its assets, serves the deck locally, and reloads
+the browser after each successful rebuild while preserving the current slide
+and overview mode. In preview, `o`, Enter, or Esc toggles single-slide and tile
+overview modes; arrows move through slides and overview tiles, and clicking a
+tile opens it.
+
+## Present
+
+Use present when you are ready to speak:
+
+```sh
+peitho present
+```
+
+`peitho present` opens the slides full-screen and opens a presenter view with
+current and next slides, speaker notes, and a timer. The agenda and planned-time
+scale appear when the deck declares sections and time; see
+[Writing Decks](@/guide/writing-decks.md) and
+[Frontmatter](@/guide/frontmatter.md) for those settings. For debugging, open
+the presenter in a normal window instead of full-screen:
+
+```sh
+peitho present --presenter-windowed
+```
+
+Next, learn the deck syntax in [Writing Decks](@/guide/writing-decks.md).

--- a/site/content/guide/layouts.md
+++ b/site/content/guide/layouts.md
@@ -1,0 +1,85 @@
++++
+title = "Layouts"
+weight = 30
+template = "guide-page.html"
+description = "Design Peitho slides with HTML slot contracts, CSS overrides, and predictable layout selection."
++++
+
+## Layout as schema
+
+Layouts are plain HTML. The `<slot>` tags inside the layout define the schema:
+slot name, accepted content type, and arity live in the layout itself rather
+than in a separate contract file.
+
+Peitho checks Markdown content against that schema. Slot excess, slot
+deficiency, type mismatches, broken references, and unassigned content are
+build errors with line numbers and help.
+
+## Slot contract syntax
+
+A layout can declare slots like this:
+
+```html
+<slot name="title" accepts="inline" arity="1"></slot>
+<slot name="body" accepts="blocks" arity="0..*"></slot>
+<slot name="code" accepts="code" arity="0..1"></slot>
+```
+
+The same shape appears in the built-in `title-body-code` layout.
+
+## Accepted content and arity
+
+`accepts` describes the kind of Markdown content the slot can receive. The six
+supported variants are `inline`, `blocks`, `text`, `code`, `image`, and `list`.
+
+`arity` describes how many items the slot can receive. The four supported
+arity literals are exactly `1`, `0..1`, `1..*`, and `0..*`. Any other literal,
+such as `2` or `0..3`, is an `unknown arity value` build error. If a slide
+gives a slot too much content, too little content, or the wrong kind of
+content, the build fails with a line-numbered error instead of dropping the
+content.
+
+## Hybrid dispatch
+
+When multiple layouts are available, Peitho chooses a layout in this order:
+
+1. An explicit page setting such as `<!-- {"layout":"name"} -->`.
+2. The single available layout, unconditionally.
+3. Exactly one structural match between the slide's content and a layout's slot
+   contract.
+
+An unknown explicit layout name is a build error. With structural dispatch,
+zero matches and multiple matches are also build errors; Peitho does not pick a
+layout silently.
+
+## Keyed CSS overrides
+
+Give a slide a stable key in its page settings comment:
+
+```markdown
+<!-- {"key":"arch-1"} -->
+# Peitho Architecture
+```
+
+Then target it from CSS:
+
+```css
+[data-slide-key="arch-1"] .slot-code {
+  grid-column: 2 / 3;
+  width: 60%;
+}
+```
+
+The key survives title edits. Peitho validates keyed selectors against the
+slots of that slide's layout, and a keyed override that points at a missing
+slide key stops the build.
+
+## Asset placement
+
+Put custom layout HTML and CSS next to the deck, or point at them from
+[frontmatter](@/guide/frontmatter.md).
+
+For layouts and CSS, asset resolution is: explicit frontmatter path, then a
+deck-adjacent `layouts/` or `css/` directory, then the built-in default. A
+frontmatter path can point at a file or a directory; layout directories read
+`*.html`, and CSS directories read `*.css`.

--- a/site/content/guide/writing-decks.md
+++ b/site/content/guide/writing-decks.md
@@ -1,0 +1,113 @@
++++
+title = "Writing Decks"
+weight = 20
+template = "guide-page.html"
+description = "Write Markdown decks with slide separators, page settings, explicit slots, notes, and agenda sections."
++++
+
+## Deck file shape
+
+A deck is one Markdown file. A deck may start with YAML frontmatter. Slides are
+split by `---`. A page settings comment belongs before the slide content when
+the slide needs a stable key, an explicit layout, or an agenda marker.
+
+This shape is adapted from `examples/feature-tour/deck.md`:
+
+````markdown
+---
+time: 5m
+---
+
+<!-- {"key":"tour-cover","section":"Basics","time":"2m"} -->
+# The Peitho Feature Tour
+
+<!-- Welcome! This deck is plain Markdown. -->
+
+---
+
+<!-- {"key":"checks","section":"Contracts","time":"3m"} -->
+# Everything the build catches
+
+- A slot with too much or too little content
+- Content the layout has no slot for
+- A keyed CSS override pointing at a key that no longer exists
+````
+
+## Convention mapping
+
+Convention mapping turns Markdown into slots without extra notation:
+
+- The shallowest heading maps to `title`.
+- Fenced code blocks map to `code`.
+- An image-only paragraph maps to the image slot.
+- All other blocks map to `body`.
+
+Markdown images are deck-relative local files. They must use supported local
+image extensions (`png`, `jpg`, `jpeg`, `gif`, `webp`) and must map to a layout
+with exactly one unambiguous `accepts="image"` slot.
+
+## Explicit slot syntax
+
+Use `::: {slot=name}` when convention mapping cannot choose between slots. This
+comes up in layouts with two columns or multiple `accepts="blocks"` slots.
+
+This example is adapted from `examples/two-column/deck.md`:
+
+````markdown
+# Compare approaches
+
+::: {slot=left}
+
+Convention mapping sends headings to `title`, code to `code`, and the rest to
+`body`.
+
+:::
+
+::: {slot=right}
+
+Use `::: {slot=name}` when a two-column layout has `left` and `right` slots
+with the same accepted content.
+
+:::
+````
+
+The slot name must exist in the chosen layout, and the explicit content still
+has to satisfy that slot's accepted content type and arity.
+
+## Speaker notes
+
+Non-JSON HTML comments anywhere in a slide become presenter speaker notes. Empty
+comments are ignored, and multiple comments on the same slide are joined with a
+blank line.
+
+Speaker notes ride into the presenter data, but notes never enter `dist/`.
+`peitho present` reads `notes.json`; distributed slides do not contain notes,
+and the publish contamination check enforces that boundary. Presenter notes are
+rendered as plaintext.
+
+## Page settings comments
+
+JSON HTML comments carry page settings. The supported settings are `key`,
+`layout`, `section`, and `time`.
+
+```markdown
+<!-- {"key":"checks","layout":"agenda","section":"Contracts","time":"3m"} -->
+```
+
+`key` gives the slide a stable target for CSS. `layout` requests a named
+layout. `section` and `time` mark agenda sections. A slide accepts at most one
+page settings comment, so combine the settings in one JSON object when a slide
+needs more than one.
+
+## Agenda sections
+
+Agenda sections use `section` and `time` together:
+
+```markdown
+<!-- {"section":"Basics","time":"2m"} -->
+```
+
+The marked slide starts a section that runs until the next marker. If any
+section marker exists, the first slide must carry one. When deck frontmatter
+sets `time`, the section totals must equal that deck time; when deck `time` is
+absent, the section total becomes the deck's planned time.


### PR DESCRIPTION
Closes #203

Task 3 of docs/plans/2026-07-09-docs-site.md: five task-oriented guide pages plus the guide index, reconstructed from README.md and CLAUDE.md invariants.

- Getting Started: install (Homebrew / prebuilt), first deck, build, preview, present
- Writing Decks: file shape, convention mapping, explicit slot syntax, speaker notes, page settings, agenda sections
- Layouts: layout-as-schema, slot contract syntax, accepted content/arity (all six accepts variants and all four arity literals), hybrid dispatch, keyed CSS overrides, asset placement
- Frontmatter: all seven keys with the closed sets (`16:9`/`4:3`, valid `time` forms), asset resolution order, per-key extension behavior, error behavior
- CLI: build/preview/present/export/publish/completions and the default deck path

Every deck snippet in the guide builds as-is against the embedded default layout (measured with the repo's own peitho). Prose read end-to-end for pedagogy and rendering — 5 review rounds, all findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC