### PR TITLE
Docs site: examples gallery with drift-proof deck sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ packages/peitho-present/dist/*
 /.demo-site
 /.screenshots
 site/static/giallo.css
+site/static/deck-sources/
+.zola-examples/

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ PRESENT = cargo run -q -p peitho -- present
 PEITHO = cargo run -q -p peitho --
 DEMO_OUT = .demo-site
 DEMO_DECKS = minimal lightning-talk code-walkthrough keynote feature-tour two-column image-showcase aspect-ratio-4-3
+DOCS_SOURCE_DIR = site/static/deck-sources
 WRANGLER ?= npx -y wrangler
 
 .PHONY: help minimal lightning-talk code-walkthrough keynote feature-tour shell \
 	minimal-windowed lightning-talk-windowed code-walkthrough-windowed keynote-windowed \
-	feature-tour-windowed demo-site deploy-demo screenshots
+	feature-tour-windowed docs-sources demo-site deploy-demo screenshots
 
 help:
 	@echo "サンプルの動作確認ターゲット:"
@@ -63,6 +64,15 @@ keynote: shell
 
 feature-tour: shell
 	$(PRESENT) examples/feature-tour/deck.md $(PRESENT_FLAGS)
+
+docs-sources:
+	rm -rf $(DOCS_SOURCE_DIR)
+	mkdir -p $(DOCS_SOURCE_DIR)/minimal
+	cp examples/deck.md $(DOCS_SOURCE_DIR)/minimal/deck.md
+	for d in $(filter-out minimal,$(DEMO_DECKS)); do \
+		mkdir -p $(DOCS_SOURCE_DIR)/$$d; \
+		cp examples/$$d/deck.md $(DOCS_SOURCE_DIR)/$$d/deck.md || exit 1; \
+	done
 
 demo-site:
 	rm -rf $(DEMO_OUT)

--- a/docs/plans/2026-07-09-docs-site.md
+++ b/docs/plans/2026-07-09-docs-site.md
@@ -470,32 +470,31 @@ Each example page uses:
 ```toml
 +++
 title = "Feature Tour"
-weight = 10
+weight = 70
 template = "example-page.html"
 description = "A tour deck that exercises Peitho's own contract and presenter features."
 
 [extra]
-deck = "feature-tour"
 demo_path = "/demo/feature-tour/"
 source_path = "static/deck-sources/feature-tour/deck.md"
 +++
 ```
 
 Use top-level `description` for the card summary, page lead, and page meta
-description. Keep deck metadata in `[extra]`.
+description. Keep link and source metadata in `[extra]`.
 
 Weights and source paths:
 
 | Weight | Page | Deck source copied from | `extra.source_path` |
 |---:|---|---|---|
-| 10 | `feature-tour.md` | `examples/feature-tour/deck.md` | `static/deck-sources/feature-tour/deck.md` |
-| 20 | `keynote.md` | `examples/keynote/deck.md` | `static/deck-sources/keynote/deck.md` |
-| 30 | `code-walkthrough.md` | `examples/code-walkthrough/deck.md` | `static/deck-sources/code-walkthrough/deck.md` |
-| 40 | `lightning-talk.md` | `examples/lightning-talk/deck.md` | `static/deck-sources/lightning-talk/deck.md` |
+| 5 | `minimal.md` | `examples/deck.md` | `static/deck-sources/minimal/deck.md` |
+| 10 | `lightning-talk.md` | `examples/lightning-talk/deck.md` | `static/deck-sources/lightning-talk/deck.md` |
+| 20 | `aspect-ratio-4-3.md` | `examples/aspect-ratio-4-3/deck.md` | `static/deck-sources/aspect-ratio-4-3/deck.md` |
+| 30 | `image-showcase.md` | `examples/image-showcase/deck.md` | `static/deck-sources/image-showcase/deck.md` |
+| 40 | `keynote.md` | `examples/keynote/deck.md` | `static/deck-sources/keynote/deck.md` |
 | 50 | `two-column.md` | `examples/two-column/deck.md` | `static/deck-sources/two-column/deck.md` |
-| 60 | `image-showcase.md` | `examples/image-showcase/deck.md` | `static/deck-sources/image-showcase/deck.md` |
-| 70 | `aspect-ratio-4-3.md` | `examples/aspect-ratio-4-3/deck.md` | `static/deck-sources/aspect-ratio-4-3/deck.md` |
-| 80 | `minimal.md` | `examples/deck.md` | `static/deck-sources/minimal/deck.md` |
+| 60 | `code-walkthrough.md` | `examples/code-walkthrough/deck.md` | `static/deck-sources/code-walkthrough/deck.md` |
+| 70 | `feature-tour.md` | `examples/feature-tour/deck.md` | `static/deck-sources/feature-tour/deck.md` |
 
 Add `docs-sources` and include it in `.PHONY`:
 

--- a/site/content/examples/_index.md
+++ b/site/content/examples/_index.md
@@ -4,3 +4,16 @@ template = "examples.html"
 page_template = "example-page.html"
 sort_by = "weight"
 +++
+
+These examples show Peitho decks at different levels of ceremony, from one
+Markdown file with built-in defaults to custom layouts, custom CSS, presenter
+timing, explicit slot routing, and image handling.
+
+Follow the gallery from smallest to broadest: start with
+[Minimal](@/examples/minimal.md), move through focused examples that isolate one
+contract at a time, and finish with the [Feature Tour](@/examples/feature-tour.md)
+when you want the full breadth in one place.
+
+The examples connect back to Peitho's [pillars](@/_index.md), the deck authoring
+guide in [Writing Decks](@/guide/writing-decks.md), and the layout contract
+details in [Layouts](@/guide/layouts.md).

--- a/site/content/examples/aspect-ratio-4-3.md
+++ b/site/content/examples/aspect-ratio-4-3.md
@@ -1,0 +1,25 @@
++++
+title = "Aspect Ratio 4:3"
+weight = 20
+template = "example-page.html"
+description = "A short deck that switches Peitho from widescreen defaults to a 4:3 logical canvas."
+
+[extra]
+demo_path = "/demo/aspect-ratio-4-3/"
+source_path = "static/deck-sources/aspect-ratio-4-3/deck.md"
++++
+
+## What it demonstrates
+
+Aspect Ratio 4:3 changes one deck-level setting: `aspect_ratio: 4:3`. The deck
+then renders on a 960 by 720 logical canvas instead of the default widescreen
+shape.
+
+Use this example when you need older projector geometry, embedded documentation
+captures, or a square-ish canvas without changing the authoring model.
+
+## What to inspect
+
+The source has no custom layout or CSS. The frontmatter alone changes the
+canvas behavior, which is the same `aspect_ratio` key documented in
+[Frontmatter](@/guide/frontmatter.md).

--- a/site/content/examples/code-walkthrough.md
+++ b/site/content/examples/code-walkthrough.md
@@ -1,0 +1,28 @@
++++
+title = "Code Walkthrough"
+weight = 60
+template = "example-page.html"
+description = "A Rust typestate walkthrough that requires one code block per slide and styles annotation text beside it like a terminal."
+
+[extra]
+demo_path = "/demo/code-walkthrough/"
+source_path = "static/deck-sources/code-walkthrough/deck.md"
++++
+
+## What it demonstrates
+
+Code Walkthrough explains a Rust typestate pipeline through four slides. Each
+slide has one heading, exactly one fenced Rust block, and optional annotation
+bullets.
+
+The custom layout makes that contract explicit with `accepts="code"` and
+`arity="1"` for the code slot, plus a blocks slot for walkthrough text. If a
+slide omits the code block or adds a second one, the deck stops at build time
+rather than silently reshaping the content.
+
+## What to inspect
+
+The theme is intentionally terminal-like: code owns the left side, annotation
+text owns the right side, and the `payoff` slide gets a keyed CSS override in
+`overrides.css`. The slot and override behavior is the same mechanism described
+in [Layouts](@/guide/layouts.md).

--- a/site/content/examples/feature-tour.md
+++ b/site/content/examples/feature-tour.md
@@ -1,0 +1,32 @@
++++
+title = "Feature Tour"
+weight = 70
+template = "example-page.html"
+description = "A broad tour deck that combines custom layouts, presenter timing, notes, list slots, code slots, and keyed CSS."
+
+[extra]
+demo_path = "/demo/feature-tour/"
+source_path = "static/deck-sources/feature-tour/deck.md"
++++
+
+## What it demonstrates
+
+Feature Tour is the broadest example deck. It sets `time: 8m`, divides the talk
+into agenda sections, uses speaker notes, and moves through four custom layouts:
+cover, topic, agenda, and code demo.
+
+The deck also shows why Peitho treats layouts as checked contracts. One slide
+explicitly asks for the `agenda` layout to resolve a list-only ambiguity, while
+the code-demo layout accepts multiple fenced code blocks for the Rust and JSON
+contract example. See [Writing Decks](@/guide/writing-decks.md) and
+[Layouts](@/guide/layouts.md) for the underlying rules.
+
+## What to inspect
+
+Look at the page settings comments around `tour-cover`, `checks`, `cli`, and
+`timing`. They carry keys, sections, times, and the explicit layout choice that
+keeps dispatch predictable.
+
+The adjacent CSS also matters: `overrides.css` targets stable slide keys, while
+the base theme styles the checklist and highlighted code without changing the
+Markdown content.

--- a/site/content/examples/image-showcase.md
+++ b/site/content/examples/image-showcase.md
@@ -1,0 +1,26 @@
++++
+title = "Image Showcase"
+weight = 30
+template = "example-page.html"
+description = "A minimal visual deck that maps one local Markdown image into a required image slot."
+
+[extra]
+demo_path = "/demo/image-showcase/"
+source_path = "static/deck-sources/image-showcase/deck.md"
++++
+
+## What it demonstrates
+
+Image Showcase is intentionally small: one heading and one local Markdown image.
+The `visual` layout provides a required `accepts="image"` slot, so the image is
+typed content rather than an arbitrary HTML embed.
+
+The image path is deck-relative, and Peitho checks that the referenced local
+asset exists. The convention mapping for image-only paragraphs is covered in
+[Writing Decks](@/guide/writing-decks.md).
+
+## What to inspect
+
+The CSS frames the diagram in a fixed visual area and uses `object-fit: contain`
+so the asset remains inspectable. The Markdown stays just a heading plus
+`![Architecture diagram](img/arch.png)`.

--- a/site/content/examples/keynote.md
+++ b/site/content/examples/keynote.md
@@ -1,0 +1,27 @@
++++
+title = "Keynote"
+weight = 40
+template = "example-page.html"
+description = "A centered serif keynote deck where slide shape dispatches title-only covers and body statement slides."
+
+[extra]
+demo_path = "/demo/keynote/"
+source_path = "static/deck-sources/keynote/deck.md"
++++
+
+## What it demonstrates
+
+The Keynote deck uses two layouts with no explicit layout comments. A title-only
+slide matches the cover layout, while slides with a heading and body copy match
+the statement layout.
+
+That makes it a compact example of hybrid dispatch by content shape. The
+Markdown stays close to the talk outline, and the layout files decide how title
+and body slots render; the mechanism is covered in [Layouts](@/guide/layouts.md).
+
+## What to inspect
+
+The custom CSS gives the deck a centered, serif keynote style with larger cover
+type and measured statement copy. The body text is Japanese, so the CSS also
+sets line breaking for that writing system while leaving the Markdown itself
+plain.

--- a/site/content/examples/lightning-talk.md
+++ b/site/content/examples/lightning-talk.md
@@ -1,0 +1,26 @@
++++
+title = "Lightning Talk"
+weight = 10
+template = "example-page.html"
+description = "A five-minute poster-style talk that uses sections, notes, and a title/body layout with no code slot."
+
+[extra]
+demo_path = "/demo/lightning-talk/"
+source_path = "static/deck-sources/lightning-talk/deck.md"
++++
+
+## What it demonstrates
+
+Lightning Talk is a timed five-minute deck with section markers for setup,
+problem, approach, and wrap-up. It also includes speaker notes on the opening
+slide, so it is useful for checking the presenter workflow.
+
+The custom poster layout accepts only title and body content. There is no code
+slot, which keeps the example focused on talk timing, section metadata, and
+large-type Markdown slides.
+
+## What to inspect
+
+Compare the `time: 5m` frontmatter with the per-section page settings comments.
+Those values drive the agenda and timer behavior described in
+[Writing Decks](@/guide/writing-decks.md) and [Frontmatter](@/guide/frontmatter.md).

--- a/site/content/examples/minimal.md
+++ b/site/content/examples/minimal.md
@@ -1,0 +1,28 @@
++++
+title = "Minimal"
+weight = 5
+template = "example-page.html"
+description = "A single-file starter deck that uses built-in defaults for layout, CSS, slide splitting, code, keys, and notes."
+
+[extra]
+demo_path = "/demo/minimal/"
+source_path = "static/deck-sources/minimal/deck.md"
++++
+
+## What it demonstrates
+
+Minimal is the smallest complete deck in the repository. It has no frontmatter,
+custom layout directory, or custom CSS; Peitho uses its built-in defaults and
+splits slides on `---`.
+
+The deck still exercises the core conventions: a heading becomes the title,
+plain paragraphs and lists become body content, fenced Rust code maps to the
+code slot, keyed comments can identify slides, and HTML comments become speaker
+notes.
+
+## What to inspect
+
+Start here when learning the file shape, then move to
+[Getting Started](@/guide/getting-started.md) and
+[Writing Decks](@/guide/writing-decks.md) for the same ideas with commands and
+authoring rules around them.

--- a/site/content/examples/two-column.md
+++ b/site/content/examples/two-column.md
@@ -1,0 +1,26 @@
++++
+title = "Two Column"
+weight = 50
+template = "example-page.html"
+description = "A two-column deck that resolves matching block slots with explicit left and right slot fences."
+
+[extra]
+demo_path = "/demo/two-column/"
+source_path = "static/deck-sources/two-column/deck.md"
++++
+
+## What it demonstrates
+
+Two Column exists for the case convention mapping cannot solve on its own. The
+layout has `left` and `right` slots, and both accept block content, so the deck
+uses `::: {slot=left}` and `::: {slot=right}` fences to route each column.
+
+That explicit routing is still checked against the layout schema. A misspelled
+slot name or unsupported fence shape is a build error, as described in
+[Writing Decks](@/guide/writing-decks.md).
+
+## What to inspect
+
+The source alternates between prose, subheadings, lists, and inline code inside
+the two explicit slots. The CSS labels the columns as `slot=left` and
+`slot=right`, making the slot routing visible in the rendered deck.

--- a/site/templates/example-page.html
+++ b/site/templates/example-page.html
@@ -3,6 +3,23 @@
 {% block title %}{{ page.title }} - {{ config.title }}{% endblock title %}
 
 {% block content %}
+  {% for key, value in page.extra %}
+    {% if key != "demo_path" and key != "source_path" %}
+      {{ throw_unknown_example_extra_key }}
+    {% endif %}
+  {% endfor %}
+
+  {% if not page.extra.demo_path %}
+    {{ throw_missing_example_demo_path }}
+  {% endif %}
+  {% if not page.extra.source_path %}
+    {{ throw_missing_example_source_path }}
+  {% endif %}
+  {% set deck_source = load_data(path=page.extra.source_path, format="plain") %}
+  {% set nl = "
+" %}
+  {% set source_block = "````markdown" ~ nl ~ deck_source ~ nl ~ "````" %}
+
   <article class="doc-page example-page">
     <header class="page-header">
       <h1>{{ page.title }}</h1>
@@ -12,5 +29,11 @@
     </header>
 
     {{ page.content | safe }}
+
+    <p><a href="{{ page.extra.demo_path }}">Open live demo</a></p>
+    <section class="deck-source">
+      <h2>Deck source</h2>
+      {{ source_block | markdown | safe }}
+    </section>
   </article>
 {% endblock content %}


### PR DESCRIPTION
Closes #204

Task 4 of docs/plans/2026-07-09-docs-site.md: eight example pages plus the gallery, ordered from simplest to broadest (Minimal → Feature Tour).

Each page explains what the deck demonstrates, links to the live demo at `/demo/<name>/`, and renders the deck's actual source via Zola's `load_data` from `site/static/deck-sources/`. The `docs-sources` Makefile target populates that directory by copying `examples/<name>/deck.md` verbatim, and `.gitignore` keeps the copies out of the tree — so the source shown on the site is the real deck, and drift is impossible.

`example-page.html` enforces the `[extra]` contract with deliberately-undefined Tera variables (unknown extra key or missing `demo_path`/`source_path` → build fails) — same fail-loud pattern the landing uses.

Review: 5 rounds. Findings and fixes: dead `deck` extra field removed; unnecessary `| safe` on the internal demo link dropped; Makefile for-loop hardened with `|| exit 1`; a "notes" terminology collision in the code-walkthrough page reworded; a Tera `"\n"` bug (the string literal is NOT a newline in Tera — every emitted page had a stray literal `\n` and the fence downgraded to unhighlighted plain, silently killing highlighting) fixed by concatenating with a real newline; gallery order matched to the intro (Minimal first) with the plan Task 4 weights table amended in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
