### PR TITLE
Docs site: frozen legacy _redirects

### DIFF
--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -1,0 +1,8 @@
+/minimal/* /demo/minimal/:splat 301
+/lightning-talk/* /demo/lightning-talk/:splat 301
+/code-walkthrough/* /demo/code-walkthrough/:splat 301
+/keynote/* /demo/keynote/:splat 301
+/feature-tour/* /demo/feature-tour/:splat 301
+/two-column/* /demo/two-column/:splat 301
+/image-showcase/* /demo/image-showcase/:splat 301
+/aspect-ratio-4-3/* /demo/aspect-ratio-4-3/:splat 301


### PR DESCRIPTION
Closes #205

Task 5 of docs/plans/2026-07-09-docs-site.md: `site/static/_redirects` — a Cloudflare Pages redirect file that rewrites the eight old root deck URLs (`/feature-tour/`, `/minimal/`, etc., which shipped on peitho.gosu.ke before the docs site existed) to their new `/demo/<name>/` locations.

The list is frozen at these 8 lines. New examples are born under `/demo/` and never appear at the root, so no future redirect is ever needed.

Verified: file has exactly 8 lines, no comments or blank lines, the feature-tour line is byte-identical to the plan; `zola build` copies the file verbatim into `.demo-site/_redirects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
