### PR TITLE
Docs site: Makefile demo-site + workflow Zola install

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -28,10 +28,29 @@ jobs:
         with:
           shared-key: demo
 
+      - name: Install Zola
+        env:
+          ZOLA_VERSION: 0.22.1
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/zola.tar.gz
+          tar -xzf /tmp/zola.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/zola /usr/local/bin/zola
+          zola --version
+
       # このリポジトリ自身がpeithoなので、リリースバイナリではなく
       # ソースからビルドした今のpeithoでデモサイトを組む
       - name: Build demo site
-        run: make demo-site
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            alias=$(echo "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-28 | sed 's/^-*//; s/-*$//')
+            make demo-site ZOLA_BASE_URL="https://${alias}.peitho-4yr.pages.dev"
+          else
+            make demo-site
+          fi
 
       - name: Deploy to Cloudflare Pages
         if: github.event_name != 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,11 @@
 PRESENT_FLAGS ?=
 PRESENT = cargo run -q -p peitho -- present
 PEITHO = cargo run -q -p peitho --
+ZOLA_VERSION = 0.22.1
+ZOLA ?= zola
+ZOLA_BASE_URL ?=
 DEMO_OUT = .demo-site
+DEMO_OUT_ABS := $(abspath $(DEMO_OUT))
 DEMO_DECKS = minimal lightning-talk code-walkthrough keynote feature-tour two-column image-showcase aspect-ratio-4-3
 DOCS_SOURCE_DIR = site/static/deck-sources
 WRANGLER ?= npx -y wrangler
@@ -25,7 +29,7 @@ help:
 	@echo "その他の追加フラグ:   make keynote PRESENT_FLAGS=\"--port 8000\""
 	@echo ""
 	@echo "デモサイト:"
-	@echo "  make demo-site    examplesを$(DEMO_OUT)/に組み立てて検査"
+	@echo "  make demo-site    build the docs site plus every demo deck into $(DEMO_OUT)/"
 	@echo "  make deploy-demo  Cloudflare Pagesへデプロイ（要wrangler認証）"
 	@echo ""
 	@echo "README用スクリーンショット:"
@@ -74,21 +78,26 @@ docs-sources:
 		cp examples/$$d/deck.md $(DOCS_SOURCE_DIR)/$$d/deck.md || exit 1; \
 	done
 
-demo-site:
+demo-site: docs-sources
 	rm -rf $(DEMO_OUT)
-	mkdir -p $(DEMO_OUT)
-	$(PEITHO) build examples/deck.md --out $(DEMO_OUT)/minimal
-	$(PEITHO) build examples/lightning-talk/deck.md --out $(DEMO_OUT)/lightning-talk
-	$(PEITHO) build examples/code-walkthrough/deck.md --out $(DEMO_OUT)/code-walkthrough
-	$(PEITHO) build examples/keynote/deck.md --out $(DEMO_OUT)/keynote
-	$(PEITHO) build examples/feature-tour/deck.md --out $(DEMO_OUT)/feature-tour
-	$(PEITHO) build examples/two-column/deck.md --out $(DEMO_OUT)/two-column
-	$(PEITHO) build examples/image-showcase/deck.md --out $(DEMO_OUT)/image-showcase
-	$(PEITHO) build examples/aspect-ratio-4-3/deck.md --out $(DEMO_OUT)/aspect-ratio-4-3
+	zola_log=$$(mktemp); \
+	(cd site && $(ZOLA) build --output-dir $(DEMO_OUT_ABS) $(if $(ZOLA_BASE_URL),--base-url $(ZOLA_BASE_URL))) >$$zola_log 2>&1; \
+	zola_status=$$?; \
+	cat $$zola_log; \
+	if [ $$zola_status -ne 0 ]; then rm -f $$zola_log; exit $$zola_status; fi; \
+	if grep -Fq 'page(s) ignored' $$zola_log; then rm -f $$zola_log; exit 1; fi; \
+	rm -f $$zola_log
+	$(PEITHO) build examples/deck.md --out $(DEMO_OUT)/demo/minimal
+	$(PEITHO) build examples/lightning-talk/deck.md --out $(DEMO_OUT)/demo/lightning-talk
+	$(PEITHO) build examples/code-walkthrough/deck.md --out $(DEMO_OUT)/demo/code-walkthrough
+	$(PEITHO) build examples/keynote/deck.md --out $(DEMO_OUT)/demo/keynote
+	$(PEITHO) build examples/feature-tour/deck.md --out $(DEMO_OUT)/demo/feature-tour
+	$(PEITHO) build examples/two-column/deck.md --out $(DEMO_OUT)/demo/two-column
+	$(PEITHO) build examples/image-showcase/deck.md --out $(DEMO_OUT)/demo/image-showcase
+	$(PEITHO) build examples/aspect-ratio-4-3/deck.md --out $(DEMO_OUT)/demo/aspect-ratio-4-3
 	for d in $(DEMO_DECKS); do \
-		$(PEITHO) publish --dist $(DEMO_OUT)/$$d -- true || exit 1; \
+		$(PEITHO) publish --dist $(DEMO_OUT)/demo/$$d -- true || exit 1; \
 	done
-	cp demo/index.html $(DEMO_OUT)/index.html
 
 deploy-demo: demo-site
 	$(WRANGLER) pages deploy $(DEMO_OUT) --project-name peitho --branch main

--- a/docs/plans/2026-07-09-docs-site.md
+++ b/docs/plans/2026-07-09-docs-site.md
@@ -638,7 +638,7 @@ demo-site: docs-sources
 	zola_status=$$?; \
 	cat $$zola_log; \
 	if [ $$zola_status -ne 0 ]; then rm -f $$zola_log; exit $$zola_status; fi; \
-	if grep -i 'ignored' $$zola_log; then rm -f $$zola_log; exit 1; fi; \
+	if grep -Fq 'page(s) ignored' $$zola_log; then rm -f $$zola_log; exit 1; fi; \
 	rm -f $$zola_log
 	$(PEITHO) build examples/deck.md --out $(DEMO_OUT)/demo/minimal
 	$(PEITHO) build examples/lightning-talk/deck.md --out $(DEMO_OUT)/demo/lightning-talk
@@ -665,6 +665,10 @@ Absolute URLs from `base_url` are correct for the production deploy, but
 preview deploys must override the Zola base URL at this build seam so
 `get_url()` stylesheet and navigation links exercise the preview target rather
 than escaping to `https://peitho.gosu.ke`.
+
+The ignored-page gate intentionally matches `page(s) ignored`, measured against
+Zola 0.22.1, instead of a broad `ignored` substring to avoid future false
+positives from unrelated warnings.
 
 **Verification**
 


### PR DESCRIPTION
Closes #206
Closes #207

Tasks 6 and 7 combined: `make demo-site` now composes the docs site + every deck, and the deploy-demo workflow installs Zola so it can actually run.

## Task 6 — Makefile

- `demo-site` depends on `docs-sources` (Task 4) so `site/static/deck-sources/` is populated before Zola reads it via `load_data`
- Runs `zola build` for the documentation site (landing / guide / examples / `_redirects` / 404) into `.demo-site/`
- Builds each of the 8 example decks into `.demo-site/demo/<name>/`
- Publish contamination check runs per deck at the new paths
- Old `cp demo/index.html` line is gone; the site's root is now Zola's index (Task 8 removes the file)
- `ZOLA_BASE_URL` opt-in override so preview builds point at the preview host
- Zola output is inspected for `page(s) ignored` (Zola 0.22.1's exact marker); if it appears the build fails — no silent drop of weightless pages in `sort_by="weight"` sections

## Task 7 — deploy-demo workflow

- New step installs Zola 0.22.1 from the GitHub Releases tarball
- The Build step is rewritten to compute the Cloudflare branch alias for pull_request events (lowercase → non-alphanumeric to `-` → truncate to 28 chars → strip surrounding hyphens) and pass `ZOLA_BASE_URL="https://<alias>.peitho-4yr.pages.dev"` to `make demo-site`
- Main-push production builds unchanged
- Cloudflare deploy, PR comment, and cleanup unchanged

Task 6 landed first and hit CI with a missing `zola`; Task 7 in the same PR fixes it. Fold-in is intentional so `main` never has a state where `make demo-site` requires a tool CI doesn't install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
