### PR TITLE
Docs site: add a left sidebar to the Guide and Examples

### DIFF
--- a/site/static/site.css
+++ b/site/static/site.css
@@ -75,6 +75,11 @@ a:hover {
   color: var(--dim);
 }
 
+.site-header nav a[aria-current] {
+  color: var(--fg);
+  font-weight: 600;
+}
+
 .page {
   margin-top: 60px;
 }
@@ -205,24 +210,50 @@ ol {
   line-height: 1.5;
 }
 
-.section-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 16px;
-  margin-top: 48px;
-  padding-top: 20px;
+.docs {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  column-gap: 56px;
+  max-width: 1120px;
+  margin: 60px auto 0;
+  padding: 0 32px 80px;
+}
+
+.sidebar {
+  position: sticky;
+  top: 40px;
+  align-self: start;
+  padding-top: 16px;
   border-top: 1px solid var(--rule);
-  color: var(--dim);
-  font-size: 13px;
 }
 
-.section-nav a {
-  color: var(--dim);
+.sidebar-list {
+  display: grid;
+  gap: 2px;
 }
 
-.section-nav a[aria-current="page"] {
-  color: var(--fg);
+.sidebar-list a {
+  display: block;
+  padding: 6px 0 6px 12px;
+  border-left: 2px solid transparent;
+  color: var(--dim);
+  font-size: 14px;
+  line-height: 1.45;
   text-decoration: none;
+}
+
+.sidebar-list a:hover {
+  color: var(--fg);
+}
+
+.sidebar-list a[aria-current="page"] {
+  border-left-color: var(--fg);
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.doc-body {
+  min-width: 0;
 }
 
 code {
@@ -328,10 +359,24 @@ hr {
   background: var(--rule);
 }
 
+@media (max-width: 900px) {
+  .docs {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 32px;
+  }
+
+  .sidebar {
+    position: static;
+    padding-top: 0;
+    border-top: 0;
+  }
+}
+
 @media (max-width: 700px) {
   .wrapper,
   .site-header,
   .page,
+  .docs,
   .site-footer {
     padding-left: 20px;
     padding-right: 20px;

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -11,8 +11,8 @@
   <header class="site-header">
     <a class="brand" href='{{ get_url(path="@/_index.md") }}'>Peitho</a>
     <nav aria-label="Primary">
-      <a href='{{ get_url(path="@/guide/_index.md") }}'>Guide</a>
-      <a href='{{ get_url(path="@/examples/_index.md") }}'>Examples</a>
+      <a{% block nav_guide_attrs %}{% endblock nav_guide_attrs %} href='{{ get_url(path="@/guide/_index.md") }}'>Guide</a>
+      <a{% block nav_examples_attrs %}{% endblock nav_examples_attrs %} href='{{ get_url(path="@/examples/_index.md") }}'>Examples</a>
       <a href="{{ config.extra.github_url }}">GitHub</a>
     </nav>
   </header>

--- a/site/templates/docs.html
+++ b/site/templates/docs.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block main_class %}docs{% endblock main_class %}
+
+{% block content %}
+  {% block sidebar %}{% endblock sidebar %}
+  {% block docs_content %}{% endblock docs_content %}
+{% endblock content %}

--- a/site/templates/example-page.html
+++ b/site/templates/example-page.html
@@ -1,8 +1,23 @@
-{% extends "base.html" %}
+{% extends "docs.html" %}
 
 {% block title %}{{ page.title }} - {{ config.title }}{% endblock title %}
 
-{% block content %}
+{% block nav_examples_attrs %} aria-current="true"{% endblock nav_examples_attrs %}
+
+{% block sidebar %}
+  {% set examples = get_section(path="examples/_index.md") %}
+  {% if examples.pages %}
+    <aside class="sidebar">
+      <nav class="sidebar-list" aria-label="{{ examples.title }} pages">
+        {% for example_page in examples.pages %}
+          <a{% if example_page.permalink == page.permalink %} aria-current="page"{% endif %} href="{{ example_page.permalink }}">{{ example_page.title }}</a>
+        {% endfor %}
+      </nav>
+    </aside>
+  {% endif %}
+{% endblock sidebar %}
+
+{% block docs_content %}
   {% for key, value in page.extra %}
     {% if key != "demo_path" and key != "source_path" %}
       {{ throw_unknown_example_extra_key }}
@@ -20,7 +35,7 @@
 " %}
   {% set source_block = "````markdown" ~ nl ~ deck_source ~ nl ~ "````" %}
 
-  <article class="doc-page example-page">
+  <article class="doc-page doc-body example-page">
     <header class="page-header">
       <h1>{{ page.title }}</h1>
       {% if page.description %}
@@ -36,4 +51,4 @@
       {{ source_block | markdown | safe }}
     </section>
   </article>
-{% endblock content %}
+{% endblock docs_content %}

--- a/site/templates/examples.html
+++ b/site/templates/examples.html
@@ -1,25 +1,26 @@
-{% extends "base.html" %}
+{% extends "docs.html" %}
 
 {% block title %}{{ section.title }} - {{ config.title }}{% endblock title %}
 
-{% block content %}
-  <header class="page-header">
-    <h1>{{ section.title }}</h1>
-    {{ section.content | safe }}
-  </header>
+{% block nav_examples_attrs %} aria-current="page"{% endblock nav_examples_attrs %}
 
+{% block sidebar %}
   {% if section.pages %}
-    <ol class="rows" role="list">
-      {% for page in section.pages %}
-        <li class="row">
-          <a class="row-link" href="{{ page.permalink }}">
-            <span class="row-title">{{ page.title }}</span>
-            {% if page.description %}
-              <span class="row-meta">{{ page.description }}</span>
-            {% endif %}
-          </a>
-        </li>
-      {% endfor %}
-    </ol>
+    <aside class="sidebar">
+      <nav class="sidebar-list" aria-label="{{ section.title }} pages">
+        {% for sidebar_page in section.pages %}
+          <a href="{{ sidebar_page.permalink }}">{{ sidebar_page.title }}</a>
+        {% endfor %}
+      </nav>
+    </aside>
   {% endif %}
-{% endblock content %}
+{% endblock sidebar %}
+
+{% block docs_content %}
+  <section class="doc-body">
+    <header class="page-header">
+      <h1>{{ section.title }}</h1>
+      {{ section.content | safe }}
+    </header>
+  </section>
+{% endblock docs_content %}

--- a/site/templates/guide-page.html
+++ b/site/templates/guide-page.html
@@ -1,9 +1,24 @@
-{% extends "base.html" %}
+{% extends "docs.html" %}
 
 {% block title %}{{ page.title }} - {{ config.title }}{% endblock title %}
 
-{% block content %}
-  <article class="doc-page">
+{% block nav_guide_attrs %} aria-current="true"{% endblock nav_guide_attrs %}
+
+{% block sidebar %}
+  {% set guide = get_section(path="guide/_index.md") %}
+  {% if guide.pages %}
+    <aside class="sidebar">
+      <nav class="sidebar-list" aria-label="{{ guide.title }} pages">
+        {% for guide_page in guide.pages %}
+          <a{% if guide_page.permalink == page.permalink %} aria-current="page"{% endif %} href="{{ guide_page.permalink }}">{{ guide_page.title }}</a>
+        {% endfor %}
+      </nav>
+    </aside>
+  {% endif %}
+{% endblock sidebar %}
+
+{% block docs_content %}
+  <article class="doc-page doc-body">
     <header class="page-header">
       <h1>{{ page.title }}</h1>
       {% if page.description %}
@@ -13,13 +28,4 @@
 
     {{ page.content | safe }}
   </article>
-
-  {% set guide = get_section(path="guide/_index.md") %}
-  {% if guide.pages %}
-    <nav class="section-nav" aria-label="Guide pages">
-      {% for guide_page in guide.pages %}
-        <a {% if guide_page.permalink == page.permalink %}aria-current="page"{% endif %} href="{{ guide_page.permalink }}">{{ guide_page.title }}</a>
-      {% endfor %}
-    </nav>
-  {% endif %}
-{% endblock content %}
+{% endblock docs_content %}

--- a/site/templates/guide.html
+++ b/site/templates/guide.html
@@ -1,25 +1,26 @@
-{% extends "base.html" %}
+{% extends "docs.html" %}
 
 {% block title %}{{ section.title }} - {{ config.title }}{% endblock title %}
 
-{% block content %}
-  <header class="page-header">
-    <h1>{{ section.title }}</h1>
-    {{ section.content | safe }}
-  </header>
+{% block nav_guide_attrs %} aria-current="page"{% endblock nav_guide_attrs %}
 
+{% block sidebar %}
   {% if section.pages %}
-    <ol class="rows" role="list">
-      {% for page in section.pages %}
-        <li class="row">
-          <a class="row-link" href="{{ page.permalink }}">
-            <span class="row-title">{{ page.title }}</span>
-            {% if page.description %}
-              <span class="row-meta">{{ page.description }}</span>
-            {% endif %}
-          </a>
-        </li>
-      {% endfor %}
-    </ol>
+    <aside class="sidebar">
+      <nav class="sidebar-list" aria-label="{{ section.title }} pages">
+        {% for sidebar_page in section.pages %}
+          <a href="{{ sidebar_page.permalink }}">{{ sidebar_page.title }}</a>
+        {% endfor %}
+      </nav>
+    </aside>
   {% endif %}
-{% endblock content %}
+{% endblock sidebar %}
+
+{% block docs_content %}
+  <section class="doc-body">
+    <header class="page-header">
+      <h1>{{ section.title }}</h1>
+      {{ section.content | safe }}
+    </header>
+  </section>
+{% endblock docs_content %}


### PR DESCRIPTION
Closes #219

Guide and Examples pages get a persistent left sidebar; landing and 404 stay one-column.

## Shell

- New `site/templates/docs.html` composes with `base.html` and exposes `sidebar` / `docs_content` blocks
- `guide.html`, `guide-page.html`, `examples.html`, `example-page.html` extend `docs.html`
- Docs container: `max-width: 1120px`, grid `220px minmax(0, 1fr)` with `56px` column gap
- `.doc-body` uses the full ~780px content column (no line-length cap; the article breathes with the page)
- Mobile ≤ 900px: single-column stack; sidebar renders above the article (no `<details>` collapse — modern browsers' Shadow DOM slot styles make a closed `<details>`' children invisible from author CSS; a plain always-visible nav list is the working design)

## Wayfinding

- Sidebar highlights the current entry with black text + 2px left bar (`aria-current="page"`)
- Top nav highlights the active section in black bold (`aria-current="page"` on section index, `aria-current="true"` on child pages — matches the ARIA vocabulary correctly for both cases)
- Section-index bodies (`/guide/`, `/examples/`) drop the redundant page-list card grid — the sidebar carries that information; the body keeps the intro prose from `_index.md`

## Review

Two rounds of adversarial review; five findings applied (dead `.section-nav` CSS purged, duplicate `aria-label` on `<aside>` dropped in favor of the inner `<nav>`, `aria-current` split per template type, stray mobile top rule suppressed, active-nav visual style added). Preview: https://issue-219-sidebar-preview.peitho-4yr.pages.dev/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
