### PR TITLE
Docs site: rename "What to inspect" to "What to look at"

### DIFF
--- a/site/content/examples/aspect-ratio-4-3.md
+++ b/site/content/examples/aspect-ratio-4-3.md
@@ -18,7 +18,7 @@ shape.
 Use this example when you need older projector geometry, embedded documentation
 captures, or a square-ish canvas without changing the authoring model.
 
-## What to inspect
+## What to look at
 
 The source has no custom layout or CSS. The frontmatter alone changes the
 canvas behavior, which is the same `aspect_ratio` key documented in

--- a/site/content/examples/code-walkthrough.md
+++ b/site/content/examples/code-walkthrough.md
@@ -20,7 +20,7 @@ The custom layout makes that contract explicit with `accepts="code"` and
 slide omits the code block or adds a second one, the deck stops at build time
 rather than silently reshaping the content.
 
-## What to inspect
+## What to look at
 
 The theme is intentionally terminal-like: code owns the left side, annotation
 text owns the right side, and the `payoff` slide gets a keyed CSS override in

--- a/site/content/examples/feature-tour.md
+++ b/site/content/examples/feature-tour.md
@@ -21,7 +21,7 @@ the code-demo layout accepts multiple fenced code blocks for the Rust and JSON
 contract example. See [Writing Decks](@/guide/writing-decks.md) and
 [Layouts](@/guide/layouts.md) for the underlying rules.
 
-## What to inspect
+## What to look at
 
 Look at the page settings comments around `tour-cover`, `checks`, `cli`, and
 `timing`. They carry keys, sections, times, and the explicit layout choice that

--- a/site/content/examples/image-showcase.md
+++ b/site/content/examples/image-showcase.md
@@ -19,7 +19,7 @@ The image path is deck-relative, and Peitho checks that the referenced local
 asset exists. The convention mapping for image-only paragraphs is covered in
 [Writing Decks](@/guide/writing-decks.md).
 
-## What to inspect
+## What to look at
 
 The CSS frames the diagram in a fixed visual area and uses `object-fit: contain`
 so the asset remains inspectable. The Markdown stays just a heading plus

--- a/site/content/examples/keynote.md
+++ b/site/content/examples/keynote.md
@@ -19,7 +19,7 @@ That makes it a compact example of hybrid dispatch by content shape. The
 Markdown stays close to the talk outline, and the layout files decide how title
 and body slots render; the mechanism is covered in [Layouts](@/guide/layouts.md).
 
-## What to inspect
+## What to look at
 
 The custom CSS gives the deck a centered, serif keynote style with larger cover
 type and measured statement copy. The body text is Japanese, so the CSS also

--- a/site/content/examples/lightning-talk.md
+++ b/site/content/examples/lightning-talk.md
@@ -19,7 +19,7 @@ The custom poster layout accepts only title and body content. There is no code
 slot, which keeps the example focused on talk timing, section metadata, and
 large-type Markdown slides.
 
-## What to inspect
+## What to look at
 
 Compare the `time: 5m` frontmatter with the per-section page settings comments.
 Those values drive the agenda and timer behavior described in

--- a/site/content/examples/minimal.md
+++ b/site/content/examples/minimal.md
@@ -20,7 +20,7 @@ plain paragraphs and lists become body content, fenced Rust code maps to the
 code slot, keyed comments can identify slides, and HTML comments become speaker
 notes.
 
-## What to inspect
+## What to look at
 
 Start here when learning the file shape, then move to
 [Getting Started](@/guide/getting-started.md) and

--- a/site/content/examples/two-column.md
+++ b/site/content/examples/two-column.md
@@ -19,7 +19,7 @@ That explicit routing is still checked against the layout schema. A misspelled
 slot name or unsupported fence shape is a build error, as described in
 [Writing Decks](@/guide/writing-decks.md).
 
-## What to inspect
+## What to look at
 
 The source alternates between prose, subheadings, lists, and inline code inside
 the two explicit slots. The CSS labels the columns as `slot=left` and


### PR DESCRIPTION
Closes #221

Rename the section heading in every example page from "What to inspect" to "What to look at". The intent — pointing a reader at specific things to notice in the linked deck — reads more naturally in plain English than the devtools-adjacent "inspect".

8 files touched; zola build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC