### PR TITLE
Docs site: translate example decks to English

### DIFF
--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -849,11 +849,21 @@ fn two_column_example_preserves_blocks_slot_paragraph_after_heading() {
         .success()
         .stdout(predicate::str::contains("built 3 slide(s)"));
 
-    let html = fs::read_to_string(out.path().join("slides/001-vs.html")).unwrap();
-    assert!(html.contains("<h2>慣習マッピング</h2>"));
-    assert!(html.contains("見出しは<code>title</code>、コードは<code>code</code>、それ以外はまとめて<code>body</code>。"));
-    assert!(html.contains("<h2>明示指定</h2>"));
-    assert!(html.contains("複数の<code>blocks</code> slotを持つレイアウト"));
+    let html = fs::read_to_string(
+        out.path()
+            .join("slides/001-compare-convention-vs-explicit.html"),
+    )
+    .unwrap();
+    assert!(html.contains("<h2>Convention mapping</h2>"));
+    assert!(html.contains(
+        "Headings go to <code>title</code>, code goes to <code>code</code>, \
+         everything else goes to <code>body</code>."
+    ));
+    assert!(html.contains("<h2>Explicit selection</h2>"));
+    assert!(html.contains(
+        "Use it when a layout has multiple <code>blocks</code> slots and \
+         convention cannot resolve the ambiguity."
+    ));
 }
 
 #[test]

--- a/examples/keynote/deck.md
+++ b/examples/keynote/deck.md
@@ -3,24 +3,24 @@
 
 ---
 <!-- {"key":"what"} -->
-# Markdownがsource of truth
+# Markdown as the source of truth
 
-Markdownをsource of truthにする、HTMLネイティブなプレゼンテーションツール。タイトルだけのスライドはcoverレイアウトに、本文のあるスライドはstatementレイアウトに、内容の形から自動で振り分けられる。
+An HTML-native presentation tool that treats Markdown as the source of truth. Title-only slides dispatch to the cover layout, slides with body content dispatch to the statement layout — the shape of the content chooses.
 
 ---
 <!-- {"key":"separation"} -->
-# コンテンツとデザインを分ける
+# Separate content and design
 
-内容はMarkdownに、見た目はレイアウトとCSSに。書いている間、装飾のことは考えない。
+Content in Markdown, look and feel in layouts and CSS. While you write, you never think about decoration.
 
 ---
 <!-- {"key":"contract"} -->
-# レイアウトはスキーマ
+# The layout is the schema
 
-スロットの過不足も、型の不整合も、参照切れも、ビルドが行番号付きで止める。黙って落ちるものは何もない。
+Slot excess and deficiency, type mismatches, broken references — the build stops with line numbers. Nothing is dropped silently.
 
 ---
 <!-- {"key":"closing"} -->
-# 書くことに、戻る
+# Back to writing
 
-デザインは一度だけ。それ以外の時間は、すべて内容のために。
+Design once. Every other minute goes to the content.

--- a/examples/lightning-talk/deck.md
+++ b/examples/lightning-talk/deck.md
@@ -3,38 +3,38 @@ time: 5m
 ---
 
 <!-- {"key":"cover","section":"Setup","time":"1m"} -->
-# スライドはMarkdownで書きたい
+# I want to write slides in Markdown
 
-5分でわかる、発表資料をコードとして扱う話。
+Five minutes on treating decks as code.
 
-<!-- 自己紹介は10秒で切り上げる。「スライド作りで消耗した経験、ありますよね」と会場に問いかけてから本題へ。 -->
+<!-- Keep the self-intro to ten seconds. Ask the room "you've all burned time on slide design, right?" then move on. -->
 
 ---
 <!-- {"key":"problem","section":"Problem","time":"1m"} -->
-# デザインをいじりだすと準備が終わらない
+# Once you start tweaking design, prep never ends
 
-- 内容よりフォントサイズを触っている時間のほうが長い
-- 「あとで整える」は発表当日まで残り続ける
-- 前回のスライドから使い回せるのは見た目だけ
+- More time spent on font sizes than on content
+- "I'll polish it later" survives all the way to the day of the talk
+- The only thing reusable from last time is the look
 
 ---
 <!-- {"key":"separation","section":"Approach","time":"2m"} -->
-# コンテンツとデザインを分ける
+# Separate content and design
 
-- 内容はMarkdown、見た目はテンプレートとCSS
-- 書いている間、デザインのことは考えなくていい
-- デザインは一度作れば次の発表でも使える
+- Content in Markdown, look and feel in templates and CSS
+- While writing, you don't think about design
+- Design once — reuse across the next talk
 
 ---
 <!-- {"key":"review"} -->
-# スライドがdiffに出る
+# The deck shows up in the diff
 
-- 発表資料もプルリクエストでレビューできる
-- 手直しの履歴が残る
-- タイポの修正がワンライナーになる
+- Slides get reviewed in pull requests
+- The edit history stays
+- Fixing a typo is a one-liner
 
 ---
 <!-- {"key":"closing","section":"Wrap-up","time":"1m"} -->
-# 書くことに集中する
+# Focus on writing
 
-道具の話はここまで。次の5分はあなたの内容の話をしてください。
+Tool talk stops here. Spend the next five minutes on your content.

--- a/examples/two-column/deck.md
+++ b/examples/two-column/deck.md
@@ -2,71 +2,71 @@
 time: 3m
 ---
 
-# 明示スロットで左右2カラム
+# Two columns via explicit slots
 
 ::: {slot=left}
 
-慣習マッピングだけでは`left`と`right`を判別できない。
+Convention mapping alone cannot pick between `left` and `right`.
 
-同じ`accepts=blocks`が2つあると、どちらに入れるべきかが決められない。
+When two `accepts=blocks` slots exist, there is no way to decide where content belongs.
 
 :::
 
 ::: {slot=right}
 
-`::: {slot=name}`で著者が明示指定する。
+`::: {slot=name}` lets the author declare it.
 
-- Markdownネイティブな拡張(HTMLタグを持ち込まない)
-- パーサから型で運ばれる
-- silent dropは発生しない
+- A Markdown-native extension (no HTML tags leaked in)
+- Carried by types out of the parser
+- No silent drops
 
 :::
 
 ---
 
-# 比較: 慣習 vs 明示
+# Compare: convention vs explicit
 
 ::: {slot=left}
 
-## 慣習マッピング
+## Convention mapping
 
-見出しは`title`、コードは`code`、それ以外はまとめて`body`。単一slotで済むレイアウトなら1行も余計な記述はいらない。
+Headings go to `title`, code goes to `code`, everything else goes to `body`. A layout with a single slot needs no extra notation at all.
 
 :::
 
 ::: {slot=right}
 
-## 明示指定
+## Explicit selection
 
-著者が `::: {slot=name}` で意図をコードとして示す。開閉は3コロン、属性は`{slot=name}`だけ。
+The author writes `::: {slot=name}` to encode intent. Three colons open and close, and the only attribute is `{slot=name}`.
 
-複数の`blocks` slotを持つレイアウトで、慣習では判別できない曖昧さを著者側から解消する。
+Use it when a layout has multiple `blocks` slots and convention cannot resolve the ambiguity.
 
 :::
 
 ---
 
-# エラーは行番号+ヘルプで返る
+# Errors come back with a line number and help
 
 ::: {slot=left}
 
-## パース段
+## Parse stage
 
-- 開閉不一致
-- 属性の不正
-- ネスト(v1未対応)
-- 空の`:::`ブロック
-- 4コロン以上のフェンス(将来予約)
+- Unclosed fence
+- Malformed attribute
+- Nested divs (not supported in v1)
+- Empty `:::` block
+- Four-or-more-colon fence (reserved)
 
 :::
 
 ::: {slot=right}
 
-## マッピング段
+## Mapping stage
 
-レイアウトに存在しないslot名を明示すると、その場でエラーになる。
+Naming a slot that the layout does not declare is an immediate error.
 
-- 「unknown slot 'middle' in explicit `::: {slot=...}` for layout 'two-column'」
-- help: 「use one of: left, right, title」
+- "unknown slot 'middle' in explicit `::: {slot=...}` for layout 'two-column'"
+- help: "use one of: left, right, title"
 
 :::

--- a/site/content/examples/keynote.md
+++ b/site/content/examples/keynote.md
@@ -22,6 +22,6 @@ and body slots render; the mechanism is covered in [Layouts](@/guide/layouts.md)
 ## What to look at
 
 The custom CSS gives the deck a centered, serif keynote style with larger cover
-type and measured statement copy. The body text is Japanese, so the CSS also
-sets line breaking for that writing system while leaving the Markdown itself
+type and measured statement copy. Line-breaking rules in the CSS keep the text
+from breaking awkwardly at narrow widths, while the Markdown itself stays
 plain.


### PR DESCRIPTION
Closes #222

Translate the last three example decks that carried Japanese body copy — `examples/keynote/`, `examples/lightning-talk/`, and `examples/two-column/` — into English so `docs/` and `peitho.gosu.ke` are consistent with the project's English-only rule.

Preserved byte-for-byte: slot semantics, `<!-- {"key":...} -->` values, `<!-- {"section":...,"time":...} -->` markers, `time:` frontmatter, and section names. Only the visible reader-facing text is translated.

Verified: each deck rebuilt with the repo peitho keeps its original slide count (keynote 5, lightning-talk 5, two-column 3). `make docs-sources` + `zola build` clean.

Also updates `site/content/examples/keynote.md`'s "What to look at" — it used to say "the body text is Japanese, so the CSS also sets line breaking for that writing system"; now that the body is English, the sentence is rewritten in language-neutral terms (line-breaking rules keep text from breaking awkwardly at narrow widths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
