### PR TITLE
Docs site: screenshot every example deck's first slide on CI

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -38,6 +38,16 @@ jobs:
           sudo install -m 0755 /tmp/zola /usr/local/bin/zola
           zola --version
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install Playwright chromium
+        run: |
+          set -euo pipefail
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --no-save --no-package-lock playwright@latest
+          npx playwright@latest install --with-deps chromium
+
       # このリポジトリ自身がpeithoなので、リリースバイナリではなく
       # ソースからビルドした今のpeithoでデモサイトを組む
       - name: Build demo site
@@ -47,9 +57,10 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             alias=$(echo "$HEAD_REF" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-28 | sed 's/^-*//; s/-*$//')
-            make demo-site ZOLA_BASE_URL="https://${alias}.peitho-4yr.pages.dev"
+            base_url="https://${alias}.peitho-4yr.pages.dev"
+            make demo-site ZOLA_BASE_URL="$base_url" && make demo-screenshots ZOLA_BASE_URL="$base_url"
           else
-            make demo-site
+            make demo-site && make demo-screenshots
           fi
 
       - name: Deploy to Cloudflare Pages

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ packages/peitho-present/dist/*
 !packages/peitho-present/dist/shell.js
 !packages/peitho-present/dist/preview.js
 /.demo-site
+/.demo-site/deck-shots/
 /.screenshots
 site/static/giallo.css
 site/static/deck-sources/

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,13 @@ ZOLA_BASE_URL ?=
 DEMO_OUT = .demo-site
 DEMO_OUT_ABS := $(abspath $(DEMO_OUT))
 DEMO_DECKS = minimal lightning-talk code-walkthrough keynote feature-tour two-column image-showcase aspect-ratio-4-3
+DEMO_SCREENSHOTS_DIR = $(DEMO_OUT)/deck-shots
 DOCS_SOURCE_DIR = site/static/deck-sources
 WRANGLER ?= npx -y wrangler
 
 .PHONY: help minimal lightning-talk code-walkthrough keynote feature-tour shell \
 	minimal-windowed lightning-talk-windowed code-walkthrough-windowed keynote-windowed \
-	feature-tour-windowed docs-sources demo-site deploy-demo screenshots
+	feature-tour-windowed docs-sources demo-site demo-screenshots deploy-demo screenshots
 
 help:
 	@echo "サンプルの動作確認ターゲット:"
@@ -98,6 +99,10 @@ demo-site: docs-sources
 	for d in $(DEMO_DECKS); do \
 		$(PEITHO) publish --dist $(DEMO_OUT)/demo/$$d -- true || exit 1; \
 	done
+
+demo-screenshots: demo-site
+	mkdir -p $(DEMO_SCREENSHOTS_DIR)
+	node scripts/screenshot-decks.mjs $(DEMO_DECKS)
 
 deploy-demo: demo-site
 	$(WRANGLER) pages deploy $(DEMO_OUT) --project-name peitho --branch main

--- a/scripts/screenshot-decks.mjs
+++ b/scripts/screenshot-decks.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { dirname, extname, join, normalize, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const DEMO_OUT = join(ROOT, ".demo-site");
+const SHOTS_DIR = join(DEMO_OUT, "deck-shots");
+const HOST = "127.0.0.1";
+const PORT = 8765;
+const SETTLE_MS = 500;
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".woff2": "font/woff2",
+  ".pdf": "application/pdf",
+};
+
+function parseMakeWords(value) {
+  return value.split(/\s+/).map((word) => word.trim()).filter(Boolean);
+}
+
+async function readDemoDecksFromMakefile() {
+  const makefile = await readFile(join(ROOT, "Makefile"), "utf8");
+  const lines = makefile.split(/\r?\n/);
+  let value = "";
+  let collecting = false;
+
+  for (const line of lines) {
+    if (!collecting) {
+      const match = line.match(/^DEMO_DECKS\s*(?:[:+?]?=)\s*(.*)$/);
+      if (!match) continue;
+      value += match[1].replace(/\\\s*$/, " ");
+      collecting = /\\\s*$/.test(match[1]);
+      if (!collecting) break;
+      continue;
+    }
+
+    value += line.replace(/\\\s*$/, " ");
+    collecting = /\\\s*$/.test(line);
+    if (!collecting) break;
+  }
+
+  const decks = parseMakeWords(value);
+  if (decks.length === 0) {
+    throw new Error("could not find DEMO_DECKS in Makefile");
+  }
+  return decks;
+}
+
+function resolveRequestPath(req) {
+  const url = new URL(req.url ?? "/", `http://${HOST}:${PORT}`);
+  const decoded = decodeURIComponent(url.pathname);
+  const rel = normalize(decoded).replace(/^([/\\])+/, "");
+  if (rel.startsWith("..") || rel.split(sep).includes("..")) {
+    return null;
+  }
+  return join(DEMO_OUT, rel);
+}
+
+function startStaticServer() {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const requested = resolveRequestPath(req);
+      if (!requested) {
+        res.statusCode = 400;
+        res.end("bad path");
+        return;
+      }
+
+      let filePath = requested;
+      let stat;
+      try {
+        stat = statSync(filePath);
+      } catch {
+        res.statusCode = 404;
+        res.end("not found");
+        return;
+      }
+
+      if (stat.isDirectory()) {
+        filePath = join(filePath, "index.html");
+        if (!existsSync(filePath)) {
+          res.statusCode = 404;
+          res.end("not found");
+          return;
+        }
+      }
+
+      res.setHeader("content-type", MIME[extname(filePath)] || "application/octet-stream");
+      createReadStream(filePath).pipe(res);
+    });
+
+    server.once("error", reject);
+    server.listen(PORT, HOST, () => resolve(server));
+  });
+}
+
+function closeServer(server) {
+  if (!server) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function viewportFor(deck) {
+  if (deck === "aspect-ratio-4-3") {
+    return { width: 1200, height: 900 };
+  }
+  return { width: 1600, height: 900 };
+}
+
+async function screenshotDeck(browser, deck) {
+  const viewport = viewportFor(deck);
+  const context = await browser.newContext({ viewport });
+  const page = await context.newPage();
+  const url = `http://${HOST}:${PORT}/demo/${encodeURIComponent(deck)}/index.html`;
+  const shotPath = join(SHOTS_DIR, `${deck}.png`);
+
+  try {
+    console.log(`screenshot ${deck} -> ${shotPath}`);
+    const response = await page.goto(url, { waitUntil: "load", timeout: 30_000 });
+    if (!response || !response.ok()) {
+      throw new Error(`${deck}: failed to load ${url} (${response?.status() ?? "no response"})`);
+    }
+    await page.waitForTimeout(SETTLE_MS);
+    await page.screenshot({ path: shotPath, type: "png", fullPage: false });
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  const decks = process.argv.slice(2).length > 0
+    ? parseMakeWords(process.argv.slice(2).join(" "))
+    : await readDemoDecksFromMakefile();
+  if (decks.length === 0) {
+    throw new Error("no decks to screenshot");
+  }
+
+  await mkdir(SHOTS_DIR, { recursive: true });
+  const server = await startStaticServer();
+  let browser;
+  try {
+    browser = await chromium.launch();
+    for (const deck of decks) {
+      await screenshotDeck(browser, deck);
+    }
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+    await closeServer(server);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/site/content/examples/aspect-ratio-4-3.md
+++ b/site/content/examples/aspect-ratio-4-3.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A short deck that switches Peitho from widescreen defaults to a 4:3 logical canvas."
 
 [extra]
+deck = "aspect-ratio-4-3"
 demo_path = "/demo/aspect-ratio-4-3/"
 source_path = "static/deck-sources/aspect-ratio-4-3/deck.md"
 +++

--- a/site/content/examples/code-walkthrough.md
+++ b/site/content/examples/code-walkthrough.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A Rust typestate walkthrough that requires one code block per slide and styles annotation text beside it like a terminal."
 
 [extra]
+deck = "code-walkthrough"
 demo_path = "/demo/code-walkthrough/"
 source_path = "static/deck-sources/code-walkthrough/deck.md"
 +++

--- a/site/content/examples/feature-tour.md
+++ b/site/content/examples/feature-tour.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A broad tour deck that combines custom layouts, presenter timing, notes, list slots, code slots, and keyed CSS."
 
 [extra]
+deck = "feature-tour"
 demo_path = "/demo/feature-tour/"
 source_path = "static/deck-sources/feature-tour/deck.md"
 +++

--- a/site/content/examples/image-showcase.md
+++ b/site/content/examples/image-showcase.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A minimal visual deck that maps one local Markdown image into a required image slot."
 
 [extra]
+deck = "image-showcase"
 demo_path = "/demo/image-showcase/"
 source_path = "static/deck-sources/image-showcase/deck.md"
 +++

--- a/site/content/examples/keynote.md
+++ b/site/content/examples/keynote.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A centered serif keynote deck where slide shape dispatches title-only covers and body statement slides."
 
 [extra]
+deck = "keynote"
 demo_path = "/demo/keynote/"
 source_path = "static/deck-sources/keynote/deck.md"
 +++

--- a/site/content/examples/lightning-talk.md
+++ b/site/content/examples/lightning-talk.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A five-minute poster-style talk that uses sections, notes, and a title/body layout with no code slot."
 
 [extra]
+deck = "lightning-talk"
 demo_path = "/demo/lightning-talk/"
 source_path = "static/deck-sources/lightning-talk/deck.md"
 +++

--- a/site/content/examples/minimal.md
+++ b/site/content/examples/minimal.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A single-file starter deck that uses built-in defaults for layout, CSS, slide splitting, code, keys, and notes."
 
 [extra]
+deck = "minimal"
 demo_path = "/demo/minimal/"
 source_path = "static/deck-sources/minimal/deck.md"
 +++

--- a/site/content/examples/two-column.md
+++ b/site/content/examples/two-column.md
@@ -5,6 +5,7 @@ template = "example-page.html"
 description = "A two-column deck that resolves matching block slots with explicit left and right slot fences."
 
 [extra]
+deck = "two-column"
 demo_path = "/demo/two-column/"
 source_path = "static/deck-sources/two-column/deck.md"
 +++

--- a/site/static/site.css
+++ b/site/static/site.css
@@ -1,4 +1,5 @@
 :root {
+  --ink: #000;
   --fg: #000;
   --bg: #fff;
   --dim: #888;
@@ -152,6 +153,28 @@ ol,
 pre,
 table {
   margin: 0 0 22px;
+}
+
+.deck-shot {
+  display: block;
+  margin: 24px 0;
+}
+
+.deck-shot a {
+  display: block;
+  border: 1px solid var(--hair);
+  background: var(--code-bg);
+  transition: border-color 0.15s ease;
+}
+
+.deck-shot a:hover {
+  border-color: var(--ink);
+}
+
+.deck-shot img {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 ul,

--- a/site/templates/example-page.html
+++ b/site/templates/example-page.html
@@ -19,7 +19,7 @@
 
 {% block docs_content %}
   {% for key, value in page.extra %}
-    {% if key != "demo_path" and key != "source_path" %}
+    {% if key != "demo_path" and key != "source_path" and key != "deck" %}
       {{ throw_unknown_example_extra_key }}
     {% endif %}
   {% endfor %}
@@ -44,6 +44,12 @@
     </header>
 
     {{ page.content | safe }}
+
+    {% if page.extra.deck %}
+      <p class="deck-shot">
+        <a href="{{ page.extra.demo_path }}"><img src="/deck-shots/{{ page.extra.deck }}.png" alt="{{ page.title }} deck screenshot"></a>
+      </p>
+    {% endif %}
 
     <p><a href="{{ page.extra.demo_path }}">Open live demo</a></p>
     <section class="deck-source">


### PR DESCRIPTION
Closes #223

Show a screenshot of each example deck's first slide on its docs page, generated on CI.

## How it works

- `.github/workflows/deploy-demo.yml` installs Playwright chromium after Zola, then runs `make demo-screenshots` between `make demo-site` and the Cloudflare deploy
- `make demo-screenshots` calls `scripts/screenshot-decks.mjs`, which spins up a static HTTP server rooted at `.demo-site/`, navigates headless chromium to each `/demo/<name>/`, and writes `.demo-site/deck-shots/<name>.png`
- Viewport per deck: `1200x900` for `aspect-ratio-4-3`, `1600x900` for the rest
- Screenshots ride the same Cloudflare Pages deploy — nothing is committed to the repo, no local Chrome is touched
- `example-page.html` wraps the `<img src="/deck-shots/<name>.png">` inside the same anchor as "Open live demo"; `site.css` frames it with the paper-toned `--code-bg` and a `--hair` border that darkens on hover, so the whole image reads as one clickable card

## Trade-off vs the earlier local-Chrome approach

Previous attempt tried to screenshot locally via the existing `scripts/take-screenshots.sh` (headless Chrome + `peitho present --presenter-windowed --no-open`), which threw crash dialogs at the author. This CI approach avoids the user's Chrome entirely (Playwright manages its own bundled chromium) and matches how the sibling `decks` repo generates its thumbnails.

## Verify

The preview deploy of this PR will produce the screenshots. If the images render on the preview URL, the pipeline is working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
