### PR TITLE
Docs site: prevent iOS Safari from enlarging long code blocks

### DIFF
--- a/site/static/site.css
+++ b/site/static/site.css
@@ -15,6 +15,11 @@
 
 * { box-sizing: border-box; }
 
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 body {
   margin: 0;
   background: var(--bg);


### PR DESCRIPTION
Closes #229

Add `text-size-adjust: 100%` on `html` in `site/static/site.css` to opt out of iOS Safari's automatic text size adjustment.

## Why

On iOS Safari, WebKit rescales the text of "text-like" containers on mobile when it decides they would be hard to read at the natural viewport-mapped size. Long single-line `<pre>` blocks trigger the heuristic; short ones do not. Same-size CSS + different rendered sizes on iOS.

The specific case that surfaced this: `peitho publish -- aws s3 sync dist/ s3://your-bucket/` on `/guide/cli/` rendered visibly larger than the shorter blocks (`peitho completions zsh`, `peitho build --watch`, etc.) on iPhone. Desktop measurement of every code block on the same page shows a uniform `14.08px`, so the visual difference is entirely iOS Safari's auto-adjust.

## Fix

One rule at the top of `site/static/site.css`:

```css
html {
  -webkit-text-size-adjust: 100%;
  text-size-adjust: 100%;
}
```

Both the `-webkit-` prefix and the unprefixed property are set — the unprefixed form is the modern standard and the prefixed form covers older iOS versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
