### PR TITLE
site: add example gallery tiles to landing and examples index

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -25,6 +25,50 @@ title = "Install"
 code = "brew install mizzy/tap/peitho"
 
 [[extra.sections]]
+title = "Examples"
+gallery_intro = "Same tool, same Markdown conventions — different decks."
+
+[[extra.sections.gallery]]
+path = "@/examples/peitho-tour.md"
+title = "Peitho Tour"
+image = "/deck-shots/peitho-tour.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/minimal.md"
+title = "Minimal"
+image = "/deck-shots/minimal.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/lightning-talk.md"
+title = "Lightning Talk"
+image = "/deck-shots/lightning-talk.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/keynote.md"
+title = "Keynote"
+image = "/deck-shots/keynote.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/code-walkthrough.md"
+title = "Code Walkthrough"
+image = "/deck-shots/code-walkthrough.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/two-column.md"
+title = "Two Column"
+image = "/deck-shots/two-column.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/image-showcase.md"
+title = "Image Showcase"
+image = "/deck-shots/image-showcase.png"
+
+[[extra.sections.gallery]]
+path = "@/examples/aspect-ratio-4-3.md"
+title = "Aspect Ratio 4:3"
+image = "/deck-shots/aspect-ratio-4-3.png"
+
+[[extra.sections]]
 title = "Start"
 
 [[extra.sections.rows]]

--- a/site/static/site.css
+++ b/site/static/site.css
@@ -182,6 +182,46 @@ table {
   height: auto;
 }
 
+.gallery-intro {
+  margin: 24px 0 0;
+  color: var(--dim);
+}
+
+.gallery {
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.gallery-tile a {
+  display: block;
+  border: 1px solid var(--hair);
+  background: var(--code-bg);
+  transition: border-color 0.15s ease;
+  text-decoration: none;
+  color: inherit;
+}
+
+.gallery-tile a:hover {
+  border-color: var(--ink);
+}
+
+.gallery-tile img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.gallery-title {
+  display: block;
+  padding: 10px 14px;
+  border-top: 1px solid var(--hair);
+  font-size: 0.95rem;
+}
+
 ul,
 ol {
   padding-left: 1.25rem;

--- a/site/static/site.css
+++ b/site/static/site.css
@@ -212,7 +212,10 @@ table {
 .gallery-tile img {
   display: block;
   width: 100%;
+  aspect-ratio: 16 / 9;
   height: auto;
+  object-fit: contain;
+  background: #fff;
 }
 
 .gallery-title {

--- a/site/templates/examples.html
+++ b/site/templates/examples.html
@@ -22,5 +22,21 @@
       <h1>{{ section.title }}</h1>
       {{ section.content | safe }}
     </header>
+
+    {% if section.pages %}
+      <ul class="gallery" role="list">
+        {% for example_page in section.pages %}
+          {% if not example_page.extra.deck %}
+            {{ throw_missing_example_deck_on_index }}
+          {% endif %}
+          <li class="gallery-tile">
+            <a href="{{ example_page.permalink }}">
+              <img src="/deck-shots/{{ example_page.extra.deck }}.png" alt="{{ example_page.title }} deck screenshot" loading="lazy">
+              <span class="gallery-title">{{ example_page.title }}</span>
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
   </section>
 {% endblock docs_content %}

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -16,7 +16,7 @@
 
   {% for landing_section in section.extra.sections %}
     {% for key, value in landing_section %}
-      {% if key != "title" and key != "code" and key != "rows" %}
+      {% if key != "title" and key != "code" and key != "rows" and key != "gallery" and key != "gallery_intro" %}
         {{ throw_unknown_landing_section_key }}
       {% endif %}
     {% endfor %}
@@ -24,9 +24,15 @@
     <section>
       <h2>{{ landing_section.title }}</h2>
 
-      {% if landing_section.code and landing_section.rows %}
-        {{ throw_landing_section_has_both_code_and_rows }}
-      {% elif landing_section.code %}
+      {% set shape_flags = [] %}
+      {% if landing_section.code %}{% set_global shape_flags = shape_flags | concat(with="code") %}{% endif %}
+      {% if landing_section.rows %}{% set_global shape_flags = shape_flags | concat(with="rows") %}{% endif %}
+      {% if landing_section.gallery %}{% set_global shape_flags = shape_flags | concat(with="gallery") %}{% endif %}
+      {% if shape_flags | length > 1 %}
+        {{ throw_landing_section_has_multiple_shapes }}
+      {% endif %}
+
+      {% if landing_section.code %}
         <pre><code>{{ landing_section.code }}</code></pre>
       {% elif landing_section.rows %}
         <ul class="rows" role="list">
@@ -55,6 +61,35 @@
                   {% endif %}
                 </div>
               {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% elif landing_section.gallery %}
+        {% if landing_section.gallery_intro %}
+          <p class="gallery-intro">{{ landing_section.gallery_intro }}</p>
+        {% endif %}
+        <ul class="gallery" role="list">
+          {% for tile in landing_section.gallery %}
+            {% for key, value in tile %}
+              {% if key != "title" and key != "path" and key != "image" %}
+                {{ throw_unknown_landing_gallery_key }}
+              {% endif %}
+            {% endfor %}
+            {% if not tile.path %}
+              {{ throw_missing_landing_gallery_path }}
+            {% endif %}
+            {% if not tile.image %}
+              {{ throw_missing_landing_gallery_image }}
+            {% endif %}
+            {% if not tile.title %}
+              {{ throw_missing_landing_gallery_title }}
+            {% endif %}
+
+            <li class="gallery-tile">
+              <a href="{{ get_url(path=tile.path) }}">
+                <img src="{{ tile.image | safe }}" alt="{{ tile.title }} deck screenshot" loading="lazy">
+                <span class="gallery-title">{{ tile.title }}</span>
+              </a>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
## Summary
- Add a tile gallery of the eight example decks to the landing page under a new **Examples** section (2×4 grid, weight-ordered so Peitho Tour leads).
- Add a matching tile grid to the `/examples/` section index below the existing intro text, so visitors can pick a deck visually before drilling into an individual page.
- Both grids reuse `/deck-shots/<name>.png` — no new asset pipeline. `site.css` gets a small `.gallery` / `.gallery-tile` block.
- Landing template validates a new `gallery` section shape strictly (each tile requires `title`, `path`, and `image`; `gallery_intro` optional) so a typo still fails the build the same way the older shapes do.

## Test plan
- [x] `cargo test --workspace` / clippy / fmt all pass.
- [x] `make demo-site && make demo-screenshots` succeeds; landing and `/examples/` both render the grid with the expected weight-based order (Minimal → Lightning Talk → Aspect Ratio 4:3 → Image Showcase → Keynote → Two Column → Code Walkthrough → Peitho Tour on `/examples/`; Peitho Tour first on the landing).
- [ ] Confirm the Cloudflare preview deploy renders both pages with real screenshots and clickable tiles.