### PR TITLE
site: stop .doc-body img from adding gap and border to gallery tiles

### DIFF
--- a/site/static/site.css
+++ b/site/static/site.css
@@ -335,6 +335,11 @@ ol {
   border: 1px solid var(--hair);
 }
 
+.doc-body .gallery-tile img {
+  margin: 0;
+  border: 0;
+}
+
 code {
   padding: 0.1em 0.25em;
   background: var(--code-bg);


### PR DESCRIPTION
## Summary
PR #234 added `.doc-body img { margin: 24px 0; border: 1px solid var(--hair) }` so oversized Guide screenshots would not bleed past the 800px content column. That rule also matched every `<img>` inside `.gallery-tile` on `/examples/` (the landing page's gallery is not inside `.doc-body`, so it stayed correct), so each deck thumbnail there gained an extra vertical gap and a second hairline inside the tile frame.

Reset `margin` and `border` to `0` for gallery-tile images that live inside `.doc-body` so the `/examples/` tile grid matches the landing gallery.

## Test plan
- [x] Local `make demo-site` → `/examples/` renders with tile images flush against the tile frame; landing `/` unchanged.
- [ ] Cloudflare preview loads `/examples/` and the tile-images have no top/bottom gap or double border.