### PR TITLE
site: drop the duplicate 'peitho' hero heading on the landing page

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -4,6 +4,7 @@ template = "index.html"
 
 [extra.hero]
 lead = "An HTML-native presentation tool that treats Markdown as the source of truth."
+tagline = "Layouts as types. Broken decks fail at build, not on stage."
 
 [[extra.sections]]
 title = "Pillars"

--- a/site/static/site.css
+++ b/site/static/site.css
@@ -122,6 +122,18 @@ a:hover {
   max-width: 42rem;
 }
 
+.hero-lead {
+  font-size: 26px;
+  line-height: 1.4;
+}
+
+.hero-tagline {
+  margin-top: 12px;
+  font-size: 26px;
+  line-height: 1.4;
+  font-style: italic;
+}
+
 .lead {
   max-width: 42rem;
   color: var(--dim);

--- a/site/static/site.css
+++ b/site/static/site.css
@@ -104,7 +104,6 @@ a:hover {
   color: var(--dim);
 }
 
-.hero,
 .page-header {
   padding-top: 20px;
   border-top: 1px solid var(--rule);
@@ -119,7 +118,10 @@ a:hover {
   letter-spacing: -0.01em;
 }
 
-.hero p,
+.hero p {
+  max-width: 42rem;
+}
+
 .lead {
   max-width: 42rem;
   color: var(--dim);

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -9,7 +9,6 @@
   {% endfor %}
 
   <section class="hero">
-    <h1>{{ section.title }}</h1>
     <p>{{ section.extra.hero.lead }}</p>
     {{ section.content | safe }}
   </section>

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -2,14 +2,17 @@
 
 {% block content %}
   {% for key, value in section.extra.hero %}
-    {% if key != "lead" %}
+    {% if key != "lead" and key != "tagline" %}
       {# deliberately undefined: referencing it fails the build on a shape violation #}
       {{ throw_unknown_landing_hero_key }}
     {% endif %}
   {% endfor %}
 
   <section class="hero">
-    <p>{{ section.extra.hero.lead }}</p>
+    <p class="hero-lead">{{ section.extra.hero.lead }}</p>
+    {% if section.extra.hero.tagline %}
+      <p class="hero-tagline">{{ section.extra.hero.tagline }}</p>
+    {% endif %}
     {{ section.content | safe }}
   </section>
 


### PR DESCRIPTION
## Summary
The landing page header already shows the "Peitho" wordmark. The hero directly below repeated 'peitho' as an `<h1>`, so the very top of the page read "Peitho" then "peitho" back-to-back with different casing. Remove the hero `<h1>` and keep just the lead sentence.

The shared `.hero h1 / .page-header h1` CSS rule still styles the h1s on Guide and Examples pages, so no CSS change is needed.

## Test plan
- [x] Local `make demo-site` renders `/` with only the header wordmark and the lead sentence at the top.
- [ ] Cloudflare preview confirms the same on the deployed page and that Guide/Examples h1 styling is unchanged.