### PR TITLE
docs: unify schema/type terminology across the site

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -4,7 +4,7 @@ template = "index.html"
 
 [extra.hero]
 lead = "An HTML-native presentation tool that treats Markdown as the source of truth."
-tagline = "Layouts as types. Broken decks fail at build, not on stage."
+tagline = "The layout is the schema. Broken decks fail at build, not on stage."
 
 [[extra.sections]]
 title = "Pillars"

--- a/site/content/examples/two-column.md
+++ b/site/content/examples/two-column.md
@@ -17,7 +17,8 @@ Two Column exists for the case convention mapping cannot solve on its own. The
 layout has `left` and `right` slots, and both accept block content, so the deck
 uses `::: {slot=left}` and `::: {slot=right}` fences to route each column.
 
-That explicit routing is still checked against the layout schema. A misspelled
+That explicit routing is still type-checked against the layout's schema. A
+misspelled
 slot name or unsupported fence shape is a build error, as described in
 [Writing Decks](@/guide/writing-decks.md).
 

--- a/site/content/guide/_index.md
+++ b/site/content/guide/_index.md
@@ -24,7 +24,7 @@ notes, page settings, and agenda sections.
 
 ## Design with HTML/CSS
 
-[Layouts](@/guide/layouts.md) covers layouts as schemas, slot contracts,
+[Layouts](@/guide/layouts.md) covers the layout as schema, slot contracts,
 hybrid layout dispatch, keyed CSS overrides, and where layout and CSS assets
 belong.
 

--- a/site/static/og/brand.html
+++ b/site/static/og/brand.html
@@ -156,7 +156,7 @@
 
     <div class="headline">
       <h1 class="wordmark">Peitho</h1>
-      <p class="tagline">Layouts as types. Broken decks fail at build, not on stage.</p>
+      <p class="tagline">The layout is the schema. Broken decks fail at build, not on stage.</p>
     </div>
 
     <div class="diagram" aria-hidden="true">


### PR DESCRIPTION
## Summary

The kickoff spec, README, and the pillar copy all use one consistent vocabulary: **the layout is the schema**, and peitho **type-checks** content against it ("type" is reserved for accepted content types, type-checking, and type-driven dispatch). Four spots on the docs site drifted from that and mixed the two words:

- `site/content/_index.md` — the landing tagline said "Layouts as types", calling layouts *types* while pillar 2 on the very same page says "The layout itself is the schema". Now: "The layout is the schema. Broken decks fail at build, not on stage." (matches the keynote example slide title verbatim)
- `site/static/og/brand.html` — the OG brand card carried the same old tagline
- `site/content/guide/_index.md` — "covers layouts as schemas" (plural) where the linked guide page is headed "Layout as schema"
- `site/content/examples/two-column.md` — "checked against the layout schema" as a compound noun; now "type-checked against the layout's schema", matching README's "peitho type-checks every slide against its layout"

No changes were needed in README or the example decks themselves — they already follow the canonical phrasing.

## Verification

- `make docs-sources && zola build` in `site/`: 13 pages, 0 orphans, no ignored pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC