### PR TITLE
feat: add `peitho layouts` subcommand and Provenance-typed asset resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ The deck argument defaults to `deck.md` in the current directory, so it can be o
 # Generate the distribution (dist/ with slides/ fragments + manifest.json + index.html + peitho.css)
 peitho build            # same as: peitho build deck.md
 
+# Inspect layout slot contracts and explain dispatch for a slide key
+peitho layouts --explain intro
+
 # Daily editing loop: watch, serve, open, and reload on every successful rebuild
 peitho preview
 

--- a/crates/peitho-core/src/layout.rs
+++ b/crates/peitho-core/src/layout.rs
@@ -45,6 +45,19 @@ pub struct Layouts {
     layouts: Vec<Layout>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LayoutSummary {
+    pub name: String,
+    pub slots: Vec<SlotSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SlotSummary {
+    pub name: String,
+    pub accepts: String,
+    pub arity: String,
+}
+
 impl Layouts {
     pub fn new(layouts: Vec<Layout>) -> Result<Self> {
         if layouts.is_empty() {
@@ -102,6 +115,24 @@ impl Layouts {
             .flat_map(|layout| layout.slots().keys().map(SlotName::class_name))
             .collect()
     }
+}
+
+pub fn describe_layouts(layouts: &Layouts) -> Vec<LayoutSummary> {
+    layouts
+        .iter()
+        .map(|layout| LayoutSummary {
+            name: layout.name().to_owned(),
+            slots: layout
+                .slots()
+                .values()
+                .map(|slot| SlotSummary {
+                    name: slot.name.as_str().to_owned(),
+                    accepts: slot.accepts.to_string(),
+                    arity: slot.arity.to_string(),
+                })
+                .collect(),
+        })
+        .collect()
 }
 
 pub fn parse_layout(name: impl Into<String>, html: &str) -> Result<Layout> {
@@ -305,6 +336,59 @@ mod tests {
         assert_eq!(
             err.help,
             "wrap each slide layout in one slide host <section> element"
+        );
+    }
+
+    #[test]
+    fn describes_layouts_in_cli_order_with_sorted_slots() {
+        let cover = parse_layout(
+            "cover",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let statement = parse_layout(
+            "statement",
+            r#"<section>
+               <slot name="title" accepts="inline" arity="1"></slot>
+               <slot name="body" accepts="blocks" arity="1..*"></slot>
+               </section>"#,
+        )
+        .unwrap();
+        let title_body_code = parse_layout(
+            "title-body-code",
+            r#"<section>
+               <slot name="title" accepts="inline" arity="1"></slot>
+               <slot name="body" accepts="blocks" arity="0..*"></slot>
+               <slot name="code" accepts="code" arity="0..1"></slot>
+               </section>"#,
+        )
+        .unwrap();
+        let layouts = Layouts::new(vec![cover, statement, title_body_code]).unwrap();
+
+        let summaries = describe_layouts(&layouts);
+
+        assert_eq!(
+            summaries
+                .iter()
+                .map(|summary| summary.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["cover", "statement", "title-body-code"]
+        );
+        assert_eq!(
+            summaries[2]
+                .slots
+                .iter()
+                .map(|slot| (
+                    slot.name.as_str(),
+                    slot.accepts.as_str(),
+                    slot.arity.as_str()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("body", "blocks", "0..*"),
+                ("code", "code", "0..1"),
+                ("title", "inline", "1")
+            ]
         );
     }
 }

--- a/crates/peitho-core/src/lib.rs
+++ b/crates/peitho-core/src/lib.rs
@@ -17,12 +17,15 @@ pub mod theme;
 pub use check::check_deck;
 pub use domain::{AspectRatio, RawImagePath, ResolvedImageAsset, ResolvedImagePath};
 pub use error::{BuildError, Result};
-pub use layout::{parse_layout, Layout, Layouts};
+pub use layout::{describe_layouts, parse_layout, Layout, LayoutSummary, Layouts, SlotSummary};
 pub use manifest::{
     build_manifest, fragment_src, manifest_json, Manifest, ManifestImage, ManifestSection,
     ManifestSlide, ManifestSlideText,
 };
-pub use mapping::{dispatch_by_convention, map_by_convention};
+pub use mapping::{
+    dispatch_by_convention, explain_dispatch, map_by_convention, Candidate, CandidateOutcome,
+    DispatchResult, DispatchTrace,
+};
 pub use notes::{notes_json, Notes};
 pub use parser::{parse_frontmatter, parse_markdown, ParsedFrontmatter};
 pub use phase::{

--- a/crates/peitho-core/src/mapping.rs
+++ b/crates/peitho-core/src/mapping.rs
@@ -8,6 +8,53 @@ use crate::{
     phase::{Deck, Mapped, MappedSlide, MappedSlot, Parsed, ParsedSlide, UnassignedFragment},
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchTrace {
+    Explicit {
+        layout: String,
+        line: usize,
+        result: DispatchResult,
+    },
+    SoleLayout {
+        layout: String,
+        result: DispatchResult,
+    },
+    StructuralMatch {
+        candidates: Vec<Candidate>,
+        result: DispatchResult,
+    },
+}
+
+impl DispatchTrace {
+    pub fn result(&self) -> &DispatchResult {
+        match self {
+            Self::Explicit { result, .. }
+            | Self::SoleLayout { result, .. }
+            | Self::StructuralMatch { result, .. } => result,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchResult {
+    Matched(String),
+    NoMatch { reason: Option<String> },
+    Ambiguous(Vec<String>),
+    UnknownLayout(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    pub layout: String,
+    pub outcome: CandidateOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CandidateOutcome {
+    Matched,
+    Rejected { reason: String },
+}
+
 /// Dispatch every slide to a layout, then map its fragments by convention.
 ///
 /// The rules, in order and deterministic:
@@ -36,63 +83,190 @@ pub fn map_by_convention(deck: Deck<Parsed>, layout: &Layout) -> Result<Deck<Map
     dispatch_by_convention(deck, &Layouts::single(layout.clone()))
 }
 
+pub fn explain_dispatch(slide: &ParsedSlide, layouts: &Layouts) -> DispatchTrace {
+    try_dispatch(slide, layouts).trace
+}
+
+struct DispatchAttempt {
+    trace: DispatchTrace,
+    mapped: Option<MappedSlide>,
+    error: Option<BuildError>,
+}
+
+impl DispatchAttempt {
+    fn matched(trace: DispatchTrace, mapped: MappedSlide) -> Self {
+        Self {
+            trace,
+            mapped: Some(mapped),
+            error: None,
+        }
+    }
+
+    fn failed(trace: DispatchTrace, error: BuildError) -> Self {
+        Self {
+            trace,
+            mapped: None,
+            error: Some(error),
+        }
+    }
+}
+
 fn dispatch_slide(slide: ParsedSlide, layouts: &Layouts) -> Result<MappedSlide> {
+    let attempt = try_dispatch(&slide, layouts);
+    match (attempt.mapped, attempt.error) {
+        (Some(mapped), None) => Ok(mapped),
+        (None, Some(err)) => Err(err),
+        _ => unreachable!("dispatch attempts are either matched or failed"),
+    }
+}
+
+fn try_dispatch(slide: &ParsedSlide, layouts: &Layouts) -> DispatchAttempt {
     if let Some(request) = &slide.layout_request {
         let Some(layout) = layouts.get(&request.name) else {
-            return Err(BuildError::new(
-                ErrorKind::Layout,
-                Some(request.line),
-                format!("unknown layout '{}'", request.name),
-                format!("use one of: {}", layouts.names().join(", ")),
-            ));
+            let trace = DispatchTrace::Explicit {
+                layout: request.name.clone(),
+                line: request.line,
+                result: DispatchResult::UnknownLayout(request.name.clone()),
+            };
+            return DispatchAttempt::failed(trace, unknown_layout_error(request, layouts));
         };
-        return map_slide(&slide, layout);
+        return match map_slide(slide, layout) {
+            Ok(mapped) => {
+                let trace = DispatchTrace::Explicit {
+                    layout: request.name.clone(),
+                    line: request.line,
+                    result: DispatchResult::Matched(layout.name().to_owned()),
+                };
+                DispatchAttempt::matched(trace, mapped)
+            }
+            Err(err) => {
+                let reason = err.message.clone();
+                let trace = DispatchTrace::Explicit {
+                    layout: request.name.clone(),
+                    line: request.line,
+                    result: DispatchResult::NoMatch {
+                        reason: Some(reason),
+                    },
+                };
+                DispatchAttempt::failed(trace, err)
+            }
+        };
     }
 
     if layouts.len() == 1 {
         let layout = layouts.iter().next().expect("single layout exists");
-        return map_slide(&slide, layout);
+        return match map_slide(slide, layout) {
+            Ok(mapped) => {
+                let trace = DispatchTrace::SoleLayout {
+                    layout: layout.name().to_owned(),
+                    result: DispatchResult::Matched(layout.name().to_owned()),
+                };
+                DispatchAttempt::matched(trace, mapped)
+            }
+            Err(err) => {
+                let reason = err.message.clone();
+                let trace = DispatchTrace::SoleLayout {
+                    layout: layout.name().to_owned(),
+                    result: DispatchResult::NoMatch {
+                        reason: Some(reason),
+                    },
+                };
+                DispatchAttempt::failed(trace, err)
+            }
+        };
     }
 
     let mut matches = Vec::new();
     let mut rejections = Vec::new();
+    let mut candidates = Vec::new();
     for layout in layouts.iter() {
-        let mapped = match map_slide(&slide, layout) {
+        let mapped = match map_slide(slide, layout) {
             Ok(mapped) => mapped,
             Err(err) => {
+                candidates.push(Candidate {
+                    layout: layout.name().to_owned(),
+                    outcome: CandidateOutcome::Rejected {
+                        reason: err.message.clone(),
+                    },
+                });
                 rejections.push(format!("{}: {}", layout.name(), err.message));
                 continue;
             }
         };
         match check_slide(&mapped) {
-            Ok(()) => matches.push(mapped),
-            Err(err) => rejections.push(format!("{}: {}", layout.name(), err.message)),
+            Ok(()) => {
+                candidates.push(Candidate {
+                    layout: layout.name().to_owned(),
+                    outcome: CandidateOutcome::Matched,
+                });
+                matches.push(mapped);
+            }
+            Err(err) => {
+                candidates.push(Candidate {
+                    layout: layout.name().to_owned(),
+                    outcome: CandidateOutcome::Rejected {
+                        reason: err.message.clone(),
+                    },
+                });
+                rejections.push(format!("{}: {}", layout.name(), err.message));
+            }
         }
     }
 
     let line = slide.fragments.first().map(SourceFragment::line);
     match matches.len() {
-        1 => Ok(matches.remove(0)),
-        0 => Err(BuildError::new(
-            ErrorKind::Layout,
-            line,
-            format!("no layout matches this slide\n{}", rejections.join("\n")),
-            r#"adjust the slide content or pick a layout explicitly with <!-- {"layout":"…"} -->"#,
-        )),
+        1 => {
+            let mapped = matches.remove(0);
+            let trace = DispatchTrace::StructuralMatch {
+                candidates,
+                result: DispatchResult::Matched(mapped.layout.name().to_owned()),
+            };
+            DispatchAttempt::matched(trace, mapped)
+        }
+        0 => {
+            let trace = DispatchTrace::StructuralMatch {
+                candidates,
+                result: DispatchResult::NoMatch { reason: None },
+            };
+            DispatchAttempt::failed(
+                trace,
+                BuildError::new(
+                    ErrorKind::Layout,
+                    line,
+                    format!("no layout matches this slide\n{}", rejections.join("\n")),
+                    r#"adjust the slide content or pick a layout explicitly with <!-- {"layout":"…"} -->"#,
+                ),
+            )
+        }
         _ => {
             let names = matches
                 .iter()
                 .map(|mapped| mapped.layout.name().to_owned())
-                .collect::<Vec<_>>()
-                .join(", ");
-            Err(BuildError::new(
-                ErrorKind::Layout,
-                line,
-                format!("slide matches multiple layouts: {names}"),
-                r#"pick one explicitly with <!-- {"layout":"…"} -->"#,
-            ))
+                .collect::<Vec<_>>();
+            let trace = DispatchTrace::StructuralMatch {
+                candidates,
+                result: DispatchResult::Ambiguous(names.clone()),
+            };
+            DispatchAttempt::failed(
+                trace,
+                BuildError::new(
+                    ErrorKind::Layout,
+                    line,
+                    format!("slide matches multiple layouts: {}", names.join(", ")),
+                    r#"pick one explicitly with <!-- {"layout":"…"} -->"#,
+                ),
+            )
         }
     }
+}
+
+fn unknown_layout_error(request: &crate::phase::LayoutRequest, layouts: &Layouts) -> BuildError {
+    BuildError::new(
+        ErrorKind::Layout,
+        Some(request.line),
+        format!("unknown layout '{}'", request.name),
+        format!("use one of: {}", layouts.names().join(", ")),
+    )
 }
 
 fn map_slide(slide: &ParsedSlide, layout: &Layout) -> Result<MappedSlide> {
@@ -279,6 +453,236 @@ mod tests {
         .unwrap();
 
         assert_eq!(mapped.mapped_slides()[0].layout.name(), "statement");
+    }
+
+    #[test]
+    fn explain_dispatch_records_explicit_layout_match() {
+        let deck = parse_markdown(
+            "<!-- {\"layout\":\"statement\"} -->\n# Title\n\nBody",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &cover_and_statement());
+
+        assert_eq!(
+            trace,
+            DispatchTrace::Explicit {
+                layout: "statement".to_owned(),
+                line: 1,
+                result: DispatchResult::Matched("statement".to_owned())
+            }
+        );
+    }
+
+    #[test]
+    fn explain_dispatch_records_unknown_explicit_layout() {
+        let deck = parse_markdown(
+            "<!-- {\"layout\":\"missing\"} -->\n# Title",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &cover_and_statement());
+
+        assert_eq!(
+            trace,
+            DispatchTrace::Explicit {
+                layout: "missing".to_owned(),
+                line: 1,
+                result: DispatchResult::UnknownLayout("missing".to_owned())
+            }
+        );
+    }
+
+    #[test]
+    fn explain_dispatch_records_explicit_map_failure_reason() {
+        let deck = parse_markdown(
+            "<!-- {\"layout\":\"cover\"} -->\n# Hello\n\n![alt](pic.png)",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &cover_and_statement());
+
+        match trace {
+            DispatchTrace::Explicit {
+                layout,
+                line,
+                result:
+                    DispatchResult::NoMatch {
+                        reason: Some(reason),
+                    },
+            } => {
+                assert_eq!(layout, "cover");
+                assert_eq!(line, 1);
+                assert!(reason.contains("no slot accepts image in layout 'cover'"));
+            }
+            other => panic!("expected explicit no-match trace, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explain_dispatch_records_sole_layout_match() {
+        let deck = parse_markdown(
+            "# Title\n\nBody",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let layout = parse_layout(
+            "cover",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let layouts = Layouts::single(layout);
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &layouts);
+
+        assert_eq!(
+            trace,
+            DispatchTrace::SoleLayout {
+                layout: "cover".to_owned(),
+                result: DispatchResult::Matched("cover".to_owned())
+            }
+        );
+    }
+
+    #[test]
+    fn explain_dispatch_records_sole_layout_map_failure_reason() {
+        let deck = parse_markdown(
+            "# Hello\n\n![alt](pic.png)",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let layout = parse_layout(
+            "cover",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let layouts = Layouts::single(layout);
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &layouts);
+
+        match trace {
+            DispatchTrace::SoleLayout {
+                layout,
+                result:
+                    DispatchResult::NoMatch {
+                        reason: Some(reason),
+                    },
+            } => {
+                assert_eq!(layout, "cover");
+                assert!(reason.contains("no slot accepts image in layout 'cover'"));
+            }
+            other => panic!("expected sole-layout no-match trace, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explain_dispatch_records_unique_structural_match() {
+        let deck = parse_markdown(
+            "# Statement\n\nBody paragraph",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &cover_and_statement());
+
+        assert_eq!(
+            trace,
+            DispatchTrace::StructuralMatch {
+                candidates: vec![
+                    Candidate {
+                        layout: "cover".to_owned(),
+                        outcome: CandidateOutcome::Rejected {
+                            reason: "unassigned content remains for missing 'body' slot".to_owned()
+                        }
+                    },
+                    Candidate {
+                        layout: "statement".to_owned(),
+                        outcome: CandidateOutcome::Matched
+                    }
+                ],
+                result: DispatchResult::Matched("statement".to_owned())
+            }
+        );
+    }
+
+    #[test]
+    fn explain_dispatch_records_structural_no_match_with_candidate_reasons() {
+        let deck = parse_markdown(
+            "# Title\n\n```rust\nfn main() {}\n```",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &cover_and_statement());
+
+        assert_eq!(
+            trace,
+            DispatchTrace::StructuralMatch {
+                candidates: vec![
+                    Candidate {
+                        layout: "cover".to_owned(),
+                        outcome: CandidateOutcome::Rejected {
+                            reason: "unassigned content remains for missing 'code' slot".to_owned()
+                        }
+                    },
+                    Candidate {
+                        layout: "statement".to_owned(),
+                        outcome: CandidateOutcome::Rejected {
+                            reason: "slot 'body' got 0 item(s), but layout 'statement' allows 1..*"
+                                .to_owned()
+                        }
+                    }
+                ],
+                result: DispatchResult::NoMatch { reason: None }
+            }
+        );
+    }
+
+    #[test]
+    fn explain_dispatch_records_structural_ambiguity() {
+        let cover = parse_layout(
+            "cover",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let closing = parse_layout(
+            "closing",
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let layouts = Layouts::new(vec![cover, closing]).unwrap();
+        let deck =
+            parse_markdown("# Title Only", &crate::highlight::Highlighter::defaults()).unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        let trace = explain_dispatch(slide, &layouts);
+
+        assert_eq!(
+            trace,
+            DispatchTrace::StructuralMatch {
+                candidates: vec![
+                    Candidate {
+                        layout: "cover".to_owned(),
+                        outcome: CandidateOutcome::Matched
+                    },
+                    Candidate {
+                        layout: "closing".to_owned(),
+                        outcome: CandidateOutcome::Matched
+                    }
+                ],
+                result: DispatchResult::Ambiguous(vec!["cover".to_owned(), "closing".to_owned()])
+            }
+        );
     }
 
     #[test]

--- a/crates/peitho/src/asset_resolution.rs
+++ b/crates/peitho/src/asset_resolution.rs
@@ -8,10 +8,26 @@ use peitho_core::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedAssets {
-    pub layouts: Option<PathBuf>,
-    pub css: Option<PathBuf>,
-    pub syntaxes: Option<PathBuf>,
-    pub fonts: Option<PathBuf>,
+    pub layouts: Provenance,
+    pub css: Provenance,
+    pub syntaxes: Provenance,
+    pub fonts: Provenance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Provenance {
+    Explicit(PathBuf),
+    DeckAdjacent(PathBuf),
+    Builtin,
+}
+
+impl Provenance {
+    pub fn path(&self) -> Option<&Path> {
+        match self {
+            Self::Explicit(path) | Self::DeckAdjacent(path) => Some(path),
+            Self::Builtin => None,
+        }
+    }
 }
 
 pub fn resolve_assets(
@@ -32,7 +48,7 @@ fn resolve_asset(
     frontmatter: &ParsedFrontmatter,
     key: &'static str,
     value: Option<&AssetPath>,
-) -> miette::Result<Option<PathBuf>> {
+) -> miette::Result<Provenance> {
     if let Some(value) = value {
         let path = resolve_against_deck(deck, value);
         if !path.try_exists().into_diagnostic()? {
@@ -48,11 +64,15 @@ fn resolve_asset(
                 ),
             )));
         }
-        return Ok(Some(path));
+        return Ok(Provenance::Explicit(path));
     }
 
     let conventional = deck_parent(deck).join(key);
-    Ok(conventional.is_dir().then_some(conventional))
+    if conventional.is_dir() {
+        Ok(Provenance::DeckAdjacent(conventional))
+    } else {
+        Ok(Provenance::Builtin)
+    }
 }
 
 fn resolve_against_deck(deck: &Path, value: &AssetPath) -> PathBuf {
@@ -92,7 +112,20 @@ mod tests {
 
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.layouts, Some(layouts));
+        assert_eq!(assets.layouts, Provenance::Explicit(layouts));
+    }
+
+    #[test]
+    fn explicit_layouts_path_records_explicit_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let layouts = dir.path().join("theme").join("layouts");
+        std::fs::create_dir_all(&layouts).unwrap();
+        let frontmatter = parse("---\nlayouts: ./theme/layouts\n---\n# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.layouts, Provenance::Explicit(layouts));
     }
 
     #[test]
@@ -105,7 +138,7 @@ mod tests {
 
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.fonts, Some(fonts));
+        assert_eq!(assets.fonts, Provenance::Explicit(fonts));
     }
 
     #[test]
@@ -139,7 +172,46 @@ mod tests {
     }
 
     #[test]
-    fn deck_adjacent_directory_is_used_without_frontmatter_key() {
+    fn explicit_css_path_records_explicit_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let css = dir.path().join("theme").join("css");
+        std::fs::create_dir_all(&css).unwrap();
+        let frontmatter = parse("---\ncss: ./theme/css\n---\n# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.css, Provenance::Explicit(css));
+    }
+
+    #[test]
+    fn explicit_syntaxes_path_records_explicit_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let syntaxes = dir.path().join("theme").join("syntaxes");
+        std::fs::create_dir_all(&syntaxes).unwrap();
+        let frontmatter = parse("---\nsyntaxes: ./theme/syntaxes\n---\n# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.syntaxes, Provenance::Explicit(syntaxes));
+    }
+
+    #[test]
+    fn deck_adjacent_layouts_directory_records_deck_adjacent_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let layouts = dir.path().join("layouts");
+        std::fs::create_dir_all(&layouts).unwrap();
+        let frontmatter = parse("# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.layouts, Provenance::DeckAdjacent(layouts));
+    }
+
+    #[test]
+    fn deck_adjacent_css_directory_records_deck_adjacent_provenance() {
         let dir = tempfile::tempdir().unwrap();
         let deck = dir.path().join("deck.md");
         let css = dir.path().join("css");
@@ -148,11 +220,24 @@ mod tests {
 
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.css, Some(css));
+        assert_eq!(assets.css, Provenance::DeckAdjacent(css));
     }
 
     #[test]
-    fn deck_adjacent_fonts_directory_is_used_without_frontmatter_key() {
+    fn deck_adjacent_syntaxes_directory_records_deck_adjacent_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let syntaxes = dir.path().join("syntaxes");
+        std::fs::create_dir_all(&syntaxes).unwrap();
+        let frontmatter = parse("# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.syntaxes, Provenance::DeckAdjacent(syntaxes));
+    }
+
+    #[test]
+    fn deck_adjacent_fonts_directory_records_deck_adjacent_provenance() {
         let dir = tempfile::tempdir().unwrap();
         let deck = dir.path().join("deck.md");
         let fonts = dir.path().join("fonts");
@@ -161,6 +246,50 @@ mod tests {
 
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.fonts, Some(fonts));
+        assert_eq!(assets.fonts, Provenance::DeckAdjacent(fonts));
+    }
+
+    #[test]
+    fn missing_layouts_directory_records_builtin_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let frontmatter = parse("# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.layouts, Provenance::Builtin);
+    }
+
+    #[test]
+    fn missing_css_directory_records_builtin_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let frontmatter = parse("# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.css, Provenance::Builtin);
+    }
+
+    #[test]
+    fn missing_syntaxes_directory_records_builtin_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let frontmatter = parse("# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.syntaxes, Provenance::Builtin);
+    }
+
+    #[test]
+    fn missing_fonts_directory_records_builtin_provenance() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let frontmatter = parse("# Intro\n");
+
+        let assets = resolve_assets(&deck, &frontmatter).unwrap();
+
+        assert_eq!(assets.fonts, Provenance::Builtin);
     }
 }

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -18,11 +18,12 @@ use notify::{PollWatcher, RecursiveMode};
 use notify_debouncer_mini::{
     new_debouncer_opt, Config as DebounceConfig, DebounceEventResult, Debouncer,
 };
+use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 mod asset_resolution;
 
-use asset_resolution::{resolve_assets, ResolvedAssets};
+use asset_resolution::{resolve_assets, Provenance, ResolvedAssets};
 use peitho::{browser, server};
 
 struct BuildArtifacts {
@@ -132,27 +133,27 @@ impl WatchTargets {
             path: input,
             ext: Some("md"),
         }];
-        if let Some(path) = &assets.layouts {
+        if let Some(path) = assets.layouts.path() {
             roots.push(WatchRoot {
-                path: path.clone(),
+                path: path.to_path_buf(),
                 ext: Some("html"),
             });
         }
-        if let Some(path) = &assets.css {
+        if let Some(path) = assets.css.path() {
             roots.push(WatchRoot {
-                path: path.clone(),
+                path: path.to_path_buf(),
                 ext: Some("css"),
             });
         }
-        if let Some(path) = &assets.syntaxes {
+        if let Some(path) = assets.syntaxes.path() {
             roots.push(WatchRoot {
-                path: path.clone(),
+                path: path.to_path_buf(),
                 ext: Some("sublime-syntax"),
             });
         }
-        if let Some(path) = &assets.fonts {
+        if let Some(path) = assets.fonts.path() {
             roots.push(WatchRoot {
-                path: path.clone(),
+                path: path.to_path_buf(),
                 ext: None,
             });
         }
@@ -313,6 +314,14 @@ enum Command {
         #[arg(long)]
         watch: bool,
     },
+    Layouts {
+        #[arg(default_value = "deck.md")]
+        input: PathBuf,
+        #[arg(long)]
+        explain: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
     Preview {
         #[arg(default_value = "deck.md")]
         input: PathBuf,
@@ -390,6 +399,11 @@ fn main() -> miette::Result<()> {
                 build(&options)
             }
         }
+        Command::Layouts {
+            input,
+            explain,
+            json,
+        } => cmd_layouts(input, explain, json),
         Command::Preview {
             input,
             port,
@@ -461,6 +475,409 @@ fn export_pdf(input: PathBuf, out: Option<PathBuf>) -> miette::Result<()> {
         out.display()
     );
     Ok(())
+}
+
+fn cmd_layouts(input: PathBuf, explain: Option<String>, json: bool) -> miette::Result<()> {
+    let markdown = fs::read_to_string(&input).map_err(|err| {
+        miette::miette!(
+            "failed to read {}\nhelp: the deck argument defaults to deck.md in the current directory when omitted; pass the deck path explicitly if it lives elsewhere\ncaused by: {err}",
+            input.display()
+        )
+    })?;
+    let frontmatter = core(peitho_core::parse_frontmatter(&markdown))?;
+    let assets = resolve_assets(&input, &frontmatter)?;
+    let layouts = load_layouts(assets.layouts.path())?;
+
+    let Some(key) = explain else {
+        if json {
+            print_layouts_json(&assets.layouts, &layouts)?;
+        } else {
+            print_layouts_human(&assets.layouts, &layouts);
+        }
+        return Ok(());
+    };
+
+    let highlighter = load_highlighter(assets.syntaxes.path())?;
+    let parsed = core(peitho_core::parse_markdown(
+        &markdown,
+        frontmatter,
+        &highlighter,
+    ))?;
+    let Some(slide) = parsed
+        .parsed_slides()
+        .iter()
+        .find(|slide| slide.key.as_str() == key)
+    else {
+        let known_keys = parsed
+            .parsed_slides()
+            .iter()
+            .map(|slide| slide.key.as_str())
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let message = format!("slide key '{key}' not found in {}", input.display());
+        if json {
+            let payload = UnknownSlideKeyJson {
+                error: "slide-key-not-found",
+                key: key.clone(),
+                known_keys,
+                message,
+            };
+            eprintln!(
+                "{}",
+                serde_json::to_string_pretty(&payload).into_diagnostic()?
+            );
+            std::process::exit(2);
+        }
+        let err = peitho_core::BuildError::new(
+            peitho_core::error::ErrorKind::Parse,
+            None,
+            message,
+            format!("known keys: {}", known_keys.join(", ")),
+        );
+        eprintln!("{err}");
+        std::process::exit(2);
+    };
+    let trace = peitho_core::explain_dispatch(slide, &layouts);
+    if json {
+        print_explain_json(&assets.layouts, slide, &trace)?;
+    } else {
+        print_explain_human(&assets.layouts, slide, &trace);
+    }
+    if matches!(trace.result(), peitho_core::DispatchResult::Matched(_)) {
+        Ok(())
+    } else {
+        std::process::exit(1);
+    }
+}
+
+#[derive(Serialize)]
+struct SourceJson {
+    kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct LayoutsJson {
+    source: SourceJson,
+    layouts: Vec<LayoutJson>,
+}
+
+#[derive(Serialize)]
+struct LayoutJson {
+    name: String,
+    slots: Vec<SlotJson>,
+}
+
+#[derive(Serialize)]
+struct SlotJson {
+    name: String,
+    accepts: String,
+    arity: String,
+}
+
+#[derive(Serialize)]
+struct ExplainJson {
+    source: SourceJson,
+    slide: SlideJson,
+    dispatch: DispatchJson,
+}
+
+#[derive(Serialize)]
+struct SlideJson {
+    key: String,
+    index: usize,
+}
+
+#[derive(Serialize)]
+struct UnknownSlideKeyJson {
+    error: &'static str,
+    key: String,
+    known_keys: Vec<String>,
+    message: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum DispatchJson {
+    Explicit {
+        layout: String,
+        line: usize,
+        result: DispatchResultJson,
+    },
+    SoleLayout {
+        layout: String,
+        result: DispatchResultJson,
+    },
+    StructuralMatch {
+        candidates: Vec<CandidateJson>,
+        result: DispatchResultJson,
+    },
+}
+
+#[derive(Serialize)]
+struct CandidateJson {
+    layout: String,
+    outcome: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum DispatchResultJson {
+    Matched(String),
+    Failure(DispatchFailureJson),
+}
+
+#[derive(Serialize)]
+struct DispatchFailureJson {
+    kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    layout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    layouts: Option<Vec<String>>,
+}
+
+fn print_layouts_human(source: &Provenance, layouts: &peitho_core::Layouts) {
+    println!("layouts source: {}", provenance_human(source));
+    for summary in peitho_core::describe_layouts(layouts) {
+        println!();
+        println!("{}", summary.name);
+        println!("  slots:");
+        let width = summary
+            .slots
+            .iter()
+            .map(|slot| slot.name.len())
+            .max()
+            .unwrap_or(0);
+        for slot in summary.slots {
+            println!(
+                "    - {:width$}  accepts={} arity={}",
+                slot.name,
+                slot.accepts,
+                slot.arity,
+                width = width
+            );
+        }
+    }
+}
+
+fn print_layouts_json(source: &Provenance, layouts: &peitho_core::Layouts) -> miette::Result<()> {
+    let payload = LayoutsJson {
+        source: source_json(source),
+        layouts: peitho_core::describe_layouts(layouts)
+            .into_iter()
+            .map(layout_json)
+            .collect(),
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).into_diagnostic()?
+    );
+    Ok(())
+}
+
+fn print_explain_human(
+    source: &Provenance,
+    slide: &peitho_core::phase::ParsedSlide,
+    trace: &peitho_core::DispatchTrace,
+) {
+    println!("layouts source: {}", provenance_human(source));
+    println!("slide: {} (index {})", slide.key.as_str(), slide.index);
+    println!();
+    match trace {
+        peitho_core::DispatchTrace::Explicit {
+            layout,
+            line,
+            result,
+        } => {
+            println!("dispatch: explicit layout request");
+            println!("  requested: {layout} (line {line})");
+            println!("  result: {}", dispatch_result_human(result));
+            print_no_match_reason(result);
+        }
+        peitho_core::DispatchTrace::SoleLayout { layout, result } => {
+            println!("dispatch: sole layout");
+            println!("  layout: {layout}");
+            println!("  result: {}", dispatch_result_human(result));
+            print_no_match_reason(result);
+        }
+        peitho_core::DispatchTrace::StructuralMatch { candidates, result } => {
+            println!("dispatch: structural match");
+            println!("  candidates:");
+            let width = candidates
+                .iter()
+                .map(|candidate| candidate.layout.len())
+                .max()
+                .unwrap_or(0);
+            for candidate in candidates {
+                match &candidate.outcome {
+                    peitho_core::CandidateOutcome::Matched => {
+                        println!("    - {:width$}  matched", candidate.layout, width = width);
+                    }
+                    peitho_core::CandidateOutcome::Rejected { reason } => {
+                        println!(
+                            "    - {:width$}  rejected: {reason}",
+                            candidate.layout,
+                            width = width
+                        );
+                    }
+                }
+            }
+            println!("  result: {}", dispatch_result_human(result));
+        }
+    }
+}
+
+fn print_explain_json(
+    source: &Provenance,
+    slide: &peitho_core::phase::ParsedSlide,
+    trace: &peitho_core::DispatchTrace,
+) -> miette::Result<()> {
+    let payload = ExplainJson {
+        source: source_json(source),
+        slide: SlideJson {
+            key: slide.key.as_str().to_owned(),
+            index: slide.index,
+        },
+        dispatch: dispatch_json(trace),
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&payload).into_diagnostic()?
+    );
+    Ok(())
+}
+
+fn source_json(source: &Provenance) -> SourceJson {
+    SourceJson {
+        kind: provenance_kind(source).to_owned(),
+        path: source.path().map(|path| path.display().to_string()),
+    }
+}
+
+fn layout_json(summary: peitho_core::LayoutSummary) -> LayoutJson {
+    LayoutJson {
+        name: summary.name,
+        slots: summary
+            .slots
+            .into_iter()
+            .map(|slot| SlotJson {
+                name: slot.name,
+                accepts: slot.accepts,
+                arity: slot.arity,
+            })
+            .collect(),
+    }
+}
+
+fn dispatch_json(trace: &peitho_core::DispatchTrace) -> DispatchJson {
+    match trace {
+        peitho_core::DispatchTrace::Explicit {
+            layout,
+            line,
+            result,
+        } => DispatchJson::Explicit {
+            layout: layout.clone(),
+            line: *line,
+            result: dispatch_result_json(result),
+        },
+        peitho_core::DispatchTrace::SoleLayout { layout, result } => DispatchJson::SoleLayout {
+            layout: layout.clone(),
+            result: dispatch_result_json(result),
+        },
+        peitho_core::DispatchTrace::StructuralMatch { candidates, result } => {
+            DispatchJson::StructuralMatch {
+                candidates: candidates
+                    .iter()
+                    .map(|candidate| match &candidate.outcome {
+                        peitho_core::CandidateOutcome::Matched => CandidateJson {
+                            layout: candidate.layout.clone(),
+                            outcome: "matched".to_owned(),
+                            reason: None,
+                        },
+                        peitho_core::CandidateOutcome::Rejected { reason } => CandidateJson {
+                            layout: candidate.layout.clone(),
+                            outcome: "rejected".to_owned(),
+                            reason: Some(reason.clone()),
+                        },
+                    })
+                    .collect(),
+                result: dispatch_result_json(result),
+            }
+        }
+    }
+}
+
+fn dispatch_result_json(result: &peitho_core::DispatchResult) -> DispatchResultJson {
+    match result {
+        peitho_core::DispatchResult::Matched(layout) => DispatchResultJson::Matched(layout.clone()),
+        peitho_core::DispatchResult::NoMatch { reason } => {
+            DispatchResultJson::Failure(DispatchFailureJson {
+                kind: "no-match".to_owned(),
+                reason: reason.clone(),
+                layout: None,
+                layouts: None,
+            })
+        }
+        peitho_core::DispatchResult::Ambiguous(layouts) => {
+            DispatchResultJson::Failure(DispatchFailureJson {
+                kind: "ambiguous".to_owned(),
+                reason: None,
+                layout: None,
+                layouts: Some(layouts.clone()),
+            })
+        }
+        peitho_core::DispatchResult::UnknownLayout(layout) => {
+            DispatchResultJson::Failure(DispatchFailureJson {
+                kind: "unknown-layout".to_owned(),
+                reason: None,
+                layout: Some(layout.clone()),
+                layouts: None,
+            })
+        }
+    }
+}
+
+fn dispatch_result_human(result: &peitho_core::DispatchResult) -> String {
+    match result {
+        peitho_core::DispatchResult::Matched(layout) => layout.clone(),
+        peitho_core::DispatchResult::NoMatch { .. } => "no match".to_owned(),
+        peitho_core::DispatchResult::Ambiguous(layouts) => {
+            format!("ambiguous: {}", layouts.join(", "))
+        }
+        peitho_core::DispatchResult::UnknownLayout(layout) => {
+            format!("unknown layout: {layout}")
+        }
+    }
+}
+
+fn print_no_match_reason(result: &peitho_core::DispatchResult) {
+    if let peitho_core::DispatchResult::NoMatch {
+        reason: Some(reason),
+    } = result
+    {
+        println!("  reason: {reason}");
+    }
+}
+
+fn provenance_human(source: &Provenance) -> String {
+    match source {
+        Provenance::Explicit(path) => format!("explicit ({})", path.display()),
+        Provenance::DeckAdjacent(path) => format!("deck-adjacent ({})", path.display()),
+        Provenance::Builtin => "built-in".to_owned(),
+    }
+}
+
+fn provenance_kind(source: &Provenance) -> &'static str {
+    match source {
+        Provenance::Explicit(_) => "explicit",
+        Provenance::DeckAdjacent(_) => "deck-adjacent",
+        Provenance::Builtin => "built-in",
+    }
 }
 
 fn keep_workspace_for_error(tmp: tempfile::TempDir, err: impl std::fmt::Display) -> miette::Report {
@@ -651,10 +1068,10 @@ fn deck_only_watch_targets(input: &Path) -> WatchTargets {
     WatchTargets::new(
         input.to_path_buf(),
         ResolvedAssets {
-            layouts: None,
-            css: None,
-            syntaxes: None,
-            fonts: None,
+            layouts: Provenance::Builtin,
+            css: Provenance::Builtin,
+            syntaxes: Provenance::Builtin,
+            fonts: Provenance::Builtin,
         },
     )
 }
@@ -675,12 +1092,12 @@ fn refresh_watch_targets_after_deck_change(
             return Ok(());
         }
     };
-    if state.targets.assets == current_assets {
-        return Ok(());
-    }
-
+    let paths_changed = resolved_asset_paths_changed(&state.targets.assets, &current_assets);
     let next_targets = WatchTargets::new(state.input.clone(), current_assets);
     state.targets = next_targets;
+    if !paths_changed {
+        return Ok(());
+    }
     writeln!(
         stderr,
         "note: watching new asset paths from frontmatter: {}",
@@ -689,6 +1106,13 @@ fn refresh_watch_targets_after_deck_change(
     .into_diagnostic()?;
     stderr.flush().into_diagnostic()?;
     Ok(())
+}
+
+fn resolved_asset_paths_changed(old: &ResolvedAssets, new: &ResolvedAssets) -> bool {
+    old.layouts.path() != new.layouts.path()
+        || old.css.path() != new.css.path()
+        || old.syntaxes.path() != new.syntaxes.path()
+        || old.fonts.path() != new.fonts.path()
 }
 
 fn watch_all_dirs(watcher: &mut dyn WatchController, dirs: &[PathBuf]) -> miette::Result<()> {
@@ -788,17 +1212,33 @@ fn write_suppressed_watch_note(
 
 fn describe_resolved_assets(assets: &ResolvedAssets) -> String {
     let mut parts = Vec::new();
-    if let Some(path) = &assets.layouts {
-        parts.push(format!("layouts={}", path.display()));
+    if let Some(path) = assets.layouts.path() {
+        parts.push(format!(
+            "layouts={}({})",
+            provenance_kind(&assets.layouts),
+            path.display()
+        ));
     }
-    if let Some(path) = &assets.css {
-        parts.push(format!("css={}", path.display()));
+    if let Some(path) = assets.css.path() {
+        parts.push(format!(
+            "css={}({})",
+            provenance_kind(&assets.css),
+            path.display()
+        ));
     }
-    if let Some(path) = &assets.syntaxes {
-        parts.push(format!("syntaxes={}", path.display()));
+    if let Some(path) = assets.syntaxes.path() {
+        parts.push(format!(
+            "syntaxes={}({})",
+            provenance_kind(&assets.syntaxes),
+            path.display()
+        ));
     }
-    if let Some(path) = &assets.fonts {
-        parts.push(format!("fonts={}", path.display()));
+    if let Some(path) = assets.fonts.path() {
+        parts.push(format!(
+            "fonts={}({})",
+            provenance_kind(&assets.fonts),
+            path.display()
+        ));
     }
     if parts.is_empty() {
         "none".to_owned()
@@ -857,6 +1297,18 @@ fn collect_asset_files(path: &Path, ext: &str) -> miette::Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+fn load_highlighter(
+    syntaxes_path: Option<&Path>,
+) -> miette::Result<peitho_core::highlight::Highlighter> {
+    match syntaxes_path {
+        Some(path) => {
+            let files = collect_asset_files(path, "sublime-syntax")?;
+            core(peitho_core::highlight::Highlighter::with_user_files(&files))
+        }
+        None => Ok(peitho_core::highlight::Highlighter::defaults()),
+    }
+}
+
 fn load_layouts(layouts_path: Option<&Path>) -> miette::Result<peitho_core::Layouts> {
     let Some(path) = layouts_path else {
         let layout = core(peitho_core::parse_layout(
@@ -902,15 +1354,9 @@ fn build_artifacts(input: &Path) -> miette::Result<BuildArtifacts> {
     })?;
     let frontmatter = core(peitho_core::parse_frontmatter(&markdown))?;
     let assets = resolve_assets(input, &frontmatter)?;
-    let highlighter = match assets.syntaxes.as_deref() {
-        Some(path) => {
-            let files = collect_asset_files(path, "sublime-syntax")?;
-            core(peitho_core::highlight::Highlighter::with_user_files(&files))?
-        }
-        None => peitho_core::highlight::Highlighter::defaults(),
-    };
-    let layouts = load_layouts(assets.layouts.as_deref())?;
-    let css_files = load_css(assets.css.as_deref())?;
+    let highlighter = load_highlighter(assets.syntaxes.path())?;
+    let layouts = load_layouts(assets.layouts.path())?;
+    let css_files = load_css(assets.css.path())?;
     let parsed = core(peitho_core::parse_markdown(
         &markdown,
         frontmatter,
@@ -938,7 +1384,7 @@ fn build_artifacts(input: &Path) -> miette::Result<BuildArtifacts> {
         manifest_json,
         css,
         image_assets,
-        fonts_source: assets.fonts,
+        fonts_source: assets.fonts.path().map(Path::to_path_buf),
     })
 }
 
@@ -2114,6 +2560,7 @@ fn layout_name(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_cmd::Command as AssertCommand;
     use std::cell::{Cell, RefCell};
 
     const CARINA_SUBLIME_SYNTAX: &str = r#"%YAML 1.2
@@ -2150,10 +2597,10 @@ contexts:
         let targets = WatchTargets::new(
             dir.path().join("deck.md"),
             ResolvedAssets {
-                layouts: Some(layouts.clone()),
-                css: Some(css.clone()),
-                syntaxes: Some(syntaxes.clone()),
-                fonts: None,
+                layouts: Provenance::Explicit(layouts.clone()),
+                css: Provenance::Explicit(css.clone()),
+                syntaxes: Provenance::Explicit(syntaxes.clone()),
+                fonts: Provenance::Builtin,
             },
         );
 
@@ -2179,10 +2626,10 @@ contexts:
         let targets = WatchTargets::new(
             dir.path().join("deck.md"),
             ResolvedAssets {
-                layouts: None,
-                css: None,
-                syntaxes: None,
-                fonts: Some(fonts.clone()),
+                layouts: Provenance::Builtin,
+                css: Provenance::Builtin,
+                syntaxes: Provenance::Builtin,
+                fonts: Provenance::Explicit(fonts.clone()),
             },
         );
 
@@ -2203,10 +2650,10 @@ contexts:
         let targets = WatchTargets::new(
             dir.path().join("deck.md"),
             ResolvedAssets {
-                layouts: None,
-                css: None,
-                syntaxes: None,
-                fonts: Some(fonts.clone()),
+                layouts: Provenance::Builtin,
+                css: Provenance::Builtin,
+                syntaxes: Provenance::Builtin,
+                fonts: Provenance::Explicit(fonts.clone()),
             },
         );
 
@@ -2224,10 +2671,10 @@ contexts:
         let targets = WatchTargets::new(
             dir.path().join("deck.md"),
             ResolvedAssets {
-                layouts: None,
-                css: None,
-                syntaxes: None,
-                fonts: Some(fonts.clone()),
+                layouts: Provenance::Builtin,
+                css: Provenance::Builtin,
+                syntaxes: Provenance::Builtin,
+                fonts: Provenance::Explicit(fonts.clone()),
             },
         );
 
@@ -2250,10 +2697,10 @@ contexts:
         let targets = WatchTargets::new(
             deck,
             ResolvedAssets {
-                layouts: None,
-                css: None,
-                syntaxes: None,
-                fonts: Some(missing_fonts.clone()),
+                layouts: Provenance::Builtin,
+                css: Provenance::Builtin,
+                syntaxes: Provenance::Builtin,
+                fonts: Provenance::Explicit(missing_fonts.clone()),
             },
         );
 
@@ -2328,8 +2775,11 @@ contexts:
         let frontmatter = peitho_core::parse_frontmatter("# Intro\n").unwrap();
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.layouts, Some(dir.path().join("layouts")));
-        assert_eq!(assets.css, Some(dir.path().join("css")));
+        assert_eq!(
+            assets.layouts,
+            Provenance::DeckAdjacent(dir.path().join("layouts"))
+        );
+        assert_eq!(assets.css, Provenance::DeckAdjacent(dir.path().join("css")));
     }
 
     #[test]
@@ -2345,7 +2795,7 @@ contexts:
                 .unwrap();
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.layouts, Some(explicit));
+        assert_eq!(assets.layouts, Provenance::Explicit(explicit));
     }
 
     #[test]
@@ -2356,8 +2806,8 @@ contexts:
         let frontmatter = peitho_core::parse_frontmatter("# Intro\n").unwrap();
         let assets = resolve_assets(&deck, &frontmatter).unwrap();
 
-        assert_eq!(assets.layouts, None);
-        assert_eq!(assets.css, None);
+        assert_eq!(assets.layouts, Provenance::Builtin);
+        assert_eq!(assets.css, Provenance::Builtin);
     }
 
     #[test]
@@ -2539,10 +2989,10 @@ contexts:
         let targets = WatchTargets::new(
             dir.path().join("deck.md"),
             ResolvedAssets {
-                layouts: Some(dir.path().join("title-body-code.html")),
-                css: Some(dir.path().join("base.css")),
-                syntaxes: None,
-                fonts: None,
+                layouts: Provenance::Explicit(dir.path().join("title-body-code.html")),
+                css: Provenance::Explicit(dir.path().join("base.css")),
+                syntaxes: Provenance::Builtin,
+                fonts: Provenance::Builtin,
             },
         );
 
@@ -2743,7 +3193,7 @@ contexts:
 
         assert_eq!(
             state.targets.assets.layouts,
-            Some(alternate_layouts.clone())
+            Provenance::Explicit(alternate_layouts.clone())
         );
         assert!(watcher
             .watched
@@ -2794,9 +3244,85 @@ contexts:
         refresh_watch_targets_after_deck_change(&mut state, &mut stderr).unwrap();
 
         assert!(state.watched_dirs.iter().any(|path| path == &old_layouts));
-        assert_eq!(state.targets.assets.layouts, Some(alternate_layouts));
+        assert_eq!(
+            state.targets.assets.layouts,
+            Provenance::Explicit(alternate_layouts)
+        );
         let stderr = String::from_utf8(stderr).unwrap();
         assert!(stderr.contains("note: watching new asset paths from frontmatter:"));
+    }
+
+    #[test]
+    fn refresh_watch_targets_does_not_note_when_only_provenance_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = fs::canonicalize(dir.path()).unwrap();
+        let deck = root.join("deck.md");
+        let layouts = root.join("layouts");
+        fs::create_dir_all(&layouts).unwrap();
+        fs::write(layouts.join("title-body-code.html"), TEST_LAYOUT_HTML).unwrap();
+        fs::write(&deck, "# Intro\n").unwrap();
+        let targets = resolve_watch_targets(&deck).unwrap();
+        assert_eq!(
+            targets.assets.layouts,
+            Provenance::DeckAdjacent(layouts.clone())
+        );
+        let watched_dirs = targets.watch_dirs();
+        let mut state = WatchState::new(deck.clone(), targets, watched_dirs);
+        fs::write(&deck, "---\nlayouts: ./layouts\n---\n# Intro\n").unwrap();
+        let mut stderr = Vec::new();
+
+        refresh_watch_targets_after_deck_change(&mut state, &mut stderr).unwrap();
+
+        assert!(
+            stderr.is_empty(),
+            "actual stderr: {}",
+            String::from_utf8_lossy(&stderr)
+        );
+        assert_eq!(state.targets.assets.layouts, Provenance::Explicit(layouts));
+    }
+
+    #[test]
+    fn deck_refresh_updates_targets_when_frontmatter_asset_removed_and_no_deck_adjacent_dir_exists()
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let root = fs::canonicalize(dir.path()).unwrap();
+        let deck = root.join("deck.md");
+        let explicit_layouts = root.join("x").join("layouts");
+        fs::create_dir_all(&explicit_layouts).unwrap();
+        fs::write(
+            explicit_layouts.join("title-body-code.html"),
+            TEST_LAYOUT_HTML,
+        )
+        .unwrap();
+        fs::write(&deck, "---\nlayouts: ./x/layouts\n---\n# Intro\n").unwrap();
+        let targets = resolve_watch_targets(&deck).unwrap();
+        assert_eq!(
+            targets.assets.layouts,
+            Provenance::Explicit(explicit_layouts.clone())
+        );
+        let watched_dirs = targets.watch_dirs();
+        assert!(watched_dirs.iter().any(|path| path == &explicit_layouts));
+        let mut state = WatchState::new(deck.clone(), targets, watched_dirs);
+        let mut watcher = RecordingWatchController::default();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        fs::write(&deck, "# Intro\n").unwrap();
+
+        handle_watch_paths_with_rebuild(
+            &mut state,
+            &mut watcher,
+            std::slice::from_ref(&deck),
+            &mut stdout,
+            &mut stderr,
+            |_stdout, _stderr| Ok(()),
+        )
+        .unwrap();
+
+        assert_eq!(state.targets.assets.layouts, Provenance::Builtin);
+        assert!(!state
+            .watched_dirs
+            .iter()
+            .any(|path| path == &explicit_layouts));
     }
 
     #[test]
@@ -3775,6 +4301,7 @@ contexts:
                 assert!(presenter_windowed);
             }
             Command::Build { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -3799,6 +4326,7 @@ contexts:
                 assert!(no_open);
             }
             Command::Build { .. }
+            | Command::Layouts { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -3820,6 +4348,7 @@ contexts:
                 assert_eq!(out, Some(PathBuf::from("out.pdf")));
             }
             Command::Build { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
@@ -3838,11 +4367,37 @@ contexts:
                 assert_eq!(shell, Shell::Bash);
             }
             Command::Build { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. } => {
                 panic!("expected completions command");
+            }
+        }
+    }
+
+    #[test]
+    fn layouts_command_defaults_input_and_accepts_explain_and_json() {
+        let cli = Cli::parse_from(["peitho", "layouts", "--explain", "intro", "--json"]);
+
+        match cli.command {
+            Command::Layouts {
+                input,
+                explain,
+                json,
+            } => {
+                assert_eq!(input, PathBuf::from("deck.md"));
+                assert_eq!(explain, Some("intro".to_owned()));
+                assert!(json);
+            }
+            Command::Build { .. }
+            | Command::Preview { .. }
+            | Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected layouts command");
             }
         }
     }
@@ -4435,6 +4990,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
             }
             Command::Present { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -4453,6 +5009,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
             }
             Command::Build { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -4473,6 +5030,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
             }
             Command::Build { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
@@ -4513,6 +5071,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert!(watch);
             }
             Command::Present { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -4533,6 +5092,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert!(!watch);
             }
             Command::Present { .. }
+            | Command::Layouts { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -4554,6 +5114,308 @@ printf '0 bytes written to file %s\n' "$out" >&2
 
             assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
         }
+    }
+
+    #[test]
+    fn layouts_command_prints_builtin_layout_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "# Intro\n\nBody\n").unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .assert()
+            .success();
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(
+            stdout.contains("layouts source: built-in"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("title-body-code"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("- title") && stdout.contains("accepts=inline arity=1"),
+            "actual stdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn layouts_command_json_prints_expected_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "# Intro\n\nBody\n").unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--json")
+            .assert()
+            .success();
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(json["source"]["kind"], "built-in");
+        assert!(json["source"].get("path").is_none());
+        assert_eq!(json["layouts"][0]["name"], "title-body-code");
+        assert_eq!(json["layouts"][0]["slots"][0]["name"], "body");
+    }
+
+    #[test]
+    fn layouts_explain_matching_slide_exits_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "<!-- {\"key\":\"intro\"} -->\n# Intro\n\nBody\n").unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("intro")
+            .assert()
+            .success();
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(
+            stdout.contains("slide: intro (index 0)"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("dispatch: sole layout"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("result: title-body-code"),
+            "actual stdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn layouts_explain_unknown_slide_key_exits_two_with_help() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "<!-- {\"key\":\"intro\"} -->\n# Intro\n").unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("missing")
+            .assert()
+            .code(2);
+
+        let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+        assert!(
+            stderr.contains("slide key 'missing' not found"),
+            "actual stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("help: known keys: intro"),
+            "actual stderr: {stderr}"
+        );
+    }
+
+    #[test]
+    fn layouts_explain_unknown_slide_key_with_json_emits_structured_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "<!-- {\"key\":\"intro\"} -->\n# Intro\n\nBody\n").unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("missing")
+            .arg("--json")
+            .assert()
+            .code(2);
+
+        let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&stderr).unwrap();
+        assert_eq!(json["error"], "slide-key-not-found");
+        assert_eq!(json["key"], "missing");
+        assert!(json["known_keys"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|key| key.as_str() == Some("intro")));
+        assert!(json["message"]
+            .as_str()
+            .unwrap()
+            .contains("slide key 'missing' not found"));
+    }
+
+    #[test]
+    fn layouts_explain_unknown_explicit_layout_prints_trace_and_exits_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            &deck,
+            "<!-- {\"key\":\"bad\",\"layout\":\"missing\"} -->\n# Hi\n",
+        )
+        .unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("bad")
+            .assert()
+            .code(1);
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(
+            stdout.contains("result: unknown layout: missing"),
+            "actual stdout: {stdout}"
+        );
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("bad")
+            .arg("--json")
+            .assert()
+            .code(1);
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(json["dispatch"]["kind"], "explicit");
+        assert_eq!(json["dispatch"]["result"]["kind"], "unknown-layout");
+        assert_eq!(json["dispatch"]["result"]["layout"], "missing");
+    }
+
+    #[test]
+    fn layouts_explain_dispatch_failure_exits_one_and_prints_trace() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let layouts = dir.path().join("layouts");
+        fs::create_dir_all(&layouts).unwrap();
+        fs::write(
+            layouts.join("cover.html"),
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        fs::write(
+            layouts.join("statement.html"),
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="1..*"></slot></section>"#,
+        )
+        .unwrap();
+        fs::write(
+            &deck,
+            "<!-- {\"key\":\"bad\"} -->\n# Intro\n\n```rust\nfn main() {}\n```\n",
+        )
+        .unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("bad")
+            .assert()
+            .code(1);
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(
+            stdout.contains("layouts source: deck-adjacent"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("dispatch: structural match"),
+            "actual stdout: {stdout}"
+        );
+        assert!(stdout.contains("rejected:"), "actual stdout: {stdout}");
+        assert!(
+            stdout.contains("result: no match"),
+            "actual stdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn layouts_explain_json_includes_reason_for_sole_layout_no_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let layouts = dir.path().join("layouts");
+        fs::create_dir_all(&layouts).unwrap();
+        fs::write(
+            layouts.join("cover.html"),
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        fs::write(
+            &deck,
+            "<!-- {\"key\":\"bad\"} -->\n# Hi\n\n![alt](pic.png)\n",
+        )
+        .unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("bad")
+            .arg("--json")
+            .assert()
+            .code(1);
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert_eq!(json["dispatch"]["kind"], "sole-layout");
+        assert_eq!(json["dispatch"]["result"]["kind"], "no-match");
+        assert_eq!(json["slide"]["key"], "bad");
+        let reason = json["dispatch"]["result"]["reason"].as_str().unwrap();
+        assert!(!reason.is_empty());
+        assert!(reason.contains("image"), "actual reason: {reason}");
+    }
+
+    #[test]
+    fn layouts_explain_sole_layout_failure_prints_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let layouts = dir.path().join("layouts");
+        fs::create_dir_all(&layouts).unwrap();
+        fs::write(
+            layouts.join("cover.html"),
+            r#"<section><slot name="title" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        fs::write(
+            &deck,
+            "<!-- {\"key\":\"hello\"} -->\n# Hello\n\n![alt](pic.png)\n",
+        )
+        .unwrap();
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("layouts")
+            .arg(&deck)
+            .arg("--explain")
+            .arg("hello")
+            .assert()
+            .code(1);
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(
+            stdout.contains("dispatch: sole layout"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("result: no match"),
+            "actual stdout: {stdout}"
+        );
+        assert!(
+            stdout.contains("reason: no slot accepts image in layout 'cover'"),
+            "actual stdout: {stdout}"
+        );
     }
 
     fn contains_watch_path(paths: &[PathBuf], path: &Path) -> bool {
@@ -4685,10 +5547,10 @@ printf '0 bytes written to file %s\n' "$out" >&2
 
     fn empty_assets() -> ResolvedAssets {
         ResolvedAssets {
-            layouts: None,
-            css: None,
-            syntaxes: None,
-            fonts: None,
+            layouts: Provenance::Builtin,
+            css: Provenance::Builtin,
+            syntaxes: Provenance::Builtin,
+            fonts: Provenance::Builtin,
         }
     }
 

--- a/docs/plans/2026-07-10-peitho-layouts.md
+++ b/docs/plans/2026-07-10-peitho-layouts.md
@@ -1,0 +1,308 @@
+# `peitho layouts` — inspect layout contracts and explain dispatch
+
+Issue: #243. Adds a CLI subcommand that surfaces peitho's layout schema
+(the third pillar: "the layout **is** the schema") so authors can
+inspect slot contracts and understand why a slide dispatched to a given
+layout.
+
+## Design decisions (locked with the author 2026-07-10)
+
+- **Positional arg**: `deck.md` (defaults to `deck.md`, matches `build` /
+  `preview` / `present` / `export pdf`). Frontmatter drives layout
+  resolution, so a deck path is the natural input.
+- **`--explain <slide-key>`**: `SlideKey` only. Keys are already the
+  public slide identifier used in `manifest.json` and `notes.json`;
+  index-based addressing would drift when a deck is edited.
+- **Output**: human-first by default, `--json` for programmatic use.
+- **Provenance**: report which asset resolution branch was taken
+  (`explicit frontmatter <path>` / `deck-adjacent <path>` / `built-in`)
+  at the top of both modes. This is half the value per the Issue.
+
+## Non-goals
+
+- No `--watch` (this is a one-shot introspection command, not a build).
+- No editing / fixing of dispatch failures — this only reports.
+- No new deck-level frontmatter keys; the command reads what is already
+  parsed.
+- No changes to the dispatch algorithm itself. This subcommand only
+  observes what `dispatch_by_convention` decides.
+
+## User surface
+
+### `peitho layouts [<deck.md>] [--json]`
+
+Human-readable output (one layout per block, layouts in CLI order):
+
+```
+layouts source: deck-adjacent (./layouts)
+
+title-body-code
+  slots:
+    - title  accepts=inline  arity=1
+    - body   accepts=blocks  arity=0..*
+    - code   accepts=code    arity=0..1
+
+statement
+  slots:
+    - title  accepts=inline  arity=1
+    - body   accepts=blocks  arity=1..*
+```
+
+`--json`:
+
+```json
+{
+  "source": { "kind": "deck-adjacent", "path": "./layouts" },
+  "layouts": [
+    {
+      "name": "title-body-code",
+      "slots": [
+        { "name": "title", "accepts": "inline", "arity": "1" },
+        { "name": "body",  "accepts": "blocks", "arity": "0..*" },
+        { "name": "code",  "accepts": "code",   "arity": "0..1" }
+      ]
+    }
+  ]
+}
+```
+
+- `source.kind` is one of `explicit`, `deck-adjacent`, `built-in`.
+- `source.path` is present for `explicit` / `deck-adjacent`, absent for
+  `built-in`.
+- Slots preserve `BTreeMap` iteration order (alphabetical by slot
+  name), matching how `Layouts::slot_classes()` composes them.
+
+### `peitho layouts [<deck.md>] --explain <slide-key> [--json]`
+
+Runs the deck through parse → frontmatter → layouts, locates the slide
+by `SlideKey`, and reports the dispatch decision.
+
+Three trace shapes, matching `dispatch_slide`'s three paths:
+
+1. **Explicit layout request** (`{"layout":"name"}` in a page comment)
+2. **Sole layout** (only one layout available)
+3. **Structural match** (probed against each layout in CLI order)
+
+Human-readable output (structural match example):
+
+```
+layouts source: deck-adjacent (./layouts)
+slide: intro (index 2)
+
+dispatch: structural match
+  candidates:
+    - cover        rejected: too many body fragments
+    - title-body-code  matched
+    - statement    rejected: title slot required but not present
+  result: title-body-code
+```
+
+Explicit and sole-layout no-match failures also print a `reason:` line
+with the underlying map error; JSON includes the same text in the
+`reason` field for those no-match results.
+
+`--json` mirrors the trace as a discriminated `kind` union:
+
+```json
+{
+  "source": { "kind": "deck-adjacent", "path": "./layouts" },
+  "slide": { "key": "intro", "index": 2 },
+  "dispatch": {
+    "kind": "structural-match",
+    "candidates": [
+      { "layout": "cover", "outcome": "rejected", "reason": "…" },
+      { "layout": "title-body-code", "outcome": "matched" },
+      { "layout": "statement", "outcome": "rejected", "reason": "…" }
+    ],
+    "result": "title-body-code"
+  }
+}
+```
+
+Failure modes for `--explain`:
+
+- **Unknown slide key** → exit 2, human error message `slide key
+  '<key>' not found in <deck.md>` + `help: known keys: intro, agenda,
+  …`. Uses the standard `BuildError`-style formatting to stay
+  consistent with build errors.
+- **Dispatch failure inside the slide** → the command *does not fail
+  the build*: it prints the failure trace (candidates + reasons) and
+  exits with a non-zero code so scripts can detect it. Unlike `build`,
+  which stops at the first slide error, `layouts --explain` is a
+  diagnostic tool — the whole reason to run it is when dispatch is
+  broken.
+
+### `peitho layouts --explain <key>` without a matching layout at all
+
+If layout resolution itself failed (e.g. `layouts:` in frontmatter
+points at a non-existent path), the command surfaces the same
+line-numbered error as `build` and exits non-zero. Provenance is
+"unknown" only when we reach here — never a silent fallback to
+built-in.
+
+## Implementation shape
+
+### 1. New public helpers in `peitho-core`
+
+- `layout::LayoutSummary`, `layout::SlotSummary` — plain-old-data
+  structs holding the fields the CLI needs to print / serialize. These
+  are derived from `Layout` / `SlotContract`, so the domain types stay
+  unchanged.
+- `layout::describe_layouts(layouts: &Layouts) -> Vec<LayoutSummary>` —
+  produces the summaries in CLI order.
+- `mapping::explain_dispatch(slide: &ParsedSlide, layouts: &Layouts)
+  -> DispatchTrace` — returns a structured trace without failing.
+  Internally shares code with `dispatch_slide` (both call a common
+  `try_dispatch` that produces `(Result<MappedSlide>, Vec<Rejection>)`
+  or similar). **This is the key refactor**: rather than copy-pasting
+  the dispatch logic into `explain`, split `dispatch_slide` into a
+  trace-producing core plus the current thin failure-projection.
+
+  The trace enum:
+
+  ```rust
+  pub enum DispatchTrace {
+      Explicit { layout: String, line: usize, result: DispatchResult },
+      SoleLayout { layout: String, result: DispatchResult },
+      StructuralMatch { candidates: Vec<Candidate>, result: DispatchResult },
+  }
+  pub enum DispatchResult {
+      Matched(String),
+      NoMatch { reason: Option<String> },
+      Ambiguous(Vec<String>),
+      UnknownLayout(String),
+      // Explicit / SoleLayout failures carry `Some(reason)` from `map_slide`;
+      // structural no-match keeps `None` because each candidate has a reason.
+  }
+  pub struct Candidate {
+      pub layout: String,
+      pub outcome: CandidateOutcome, // Matched / Rejected { reason }
+  }
+  ```
+
+- Do **not** re-export `MappedSlide` fields, do **not** touch the
+  typestate. The trace holds only names and reasons, not phase-typed
+  data.
+
+### 2. Provenance in the CLI
+
+`asset_resolution::resolve_assets` currently returns `Option<PathBuf>`
+which conflates "explicit" and "deck-adjacent". Extend `ResolvedAssets`
+with a per-asset `Provenance` enum:
+
+```rust
+pub enum Provenance {
+    Explicit(PathBuf),   // author wrote `layouts: ./…` in frontmatter
+    DeckAdjacent(PathBuf), // ./layouts/ exists next to deck.md
+    Builtin,             // fell through to the built-in embed
+}
+```
+
+`resolve_assets` returns `Provenance` for each asset key. `build`
+callers only need the path, so add `Provenance::path() -> Option<&Path>`
+and change one line each in `build_artifacts` / `WatchTargets::new` /
+`preview` to `.path()`. No behavioral change to `build`.
+
+**Type-level rationale**: this replaces the "None means built-in"
+convention (currently only documented in `load_layouts` /
+`load_css`) with an exhaustive enum. A future caller cannot accidentally
+treat `None` as "user asked for nothing" vs. "user asked for built-in"
+— the compiler forces them to handle all three branches.
+
+### 3. New CLI subcommand in `crates/peitho/src/main.rs`
+
+```rust
+Command::Layouts {
+    #[arg(default_value = "deck.md")]
+    input: PathBuf,
+    #[arg(long)]
+    explain: Option<String>,
+    #[arg(long)]
+    json: bool,
+},
+```
+
+Handler `cmd_layouts(input, explain, json)`:
+
+1. Read deck → parse frontmatter → resolve assets → load layouts.
+2. If `explain.is_none()`: print `LayoutSummary` list. Return.
+3. If `explain.is_some(key)`: parse markdown, find the `ParsedSlide`
+   whose `SlideKey == key`, call `explain_dispatch`, print the trace.
+   Exit non-zero if the trace's result is not `Matched`.
+
+Printing: two functions — `print_layouts_human` /
+`print_layouts_json`, `print_explain_human` / `print_explain_json`.
+JSON via `serde_json::to_string_pretty`. The serialization structs are
+CLI-local (not in peitho-core), so we don't leak serde derives into
+the domain types.
+
+### 4. Tests (TDD, delegated to Codex)
+
+Layered from unit → integration → CLI:
+
+- **`peitho-core::layout::describe_layouts`**: given a `Layouts` with three
+  layouts, returns three summaries in order with correct slot/arity/accepts
+  strings.
+- **`peitho-core::mapping::explain_dispatch`**:
+  - Explicit-request trace records line + result Matched
+  - Explicit-request with unknown name → `UnknownLayout`
+  - Explicit + map failure → `NoMatch { reason: Some(_) }` (surface the
+    `map_slide` error)
+  - Sole-layout trace records `SoleLayout { result: Matched }`
+  - SoleLayout + map failure → `NoMatch { reason: Some(_) }` (same)
+  - Structural-match with one winner → `StructuralMatch { result: Matched }`
+  - Structural-match with zero winners → `StructuralMatch { result: NoMatch }`
+    with per-candidate `Rejected { reason }`
+  - Structural-match with multiple winners → `StructuralMatch { result:
+    Ambiguous(names) }`
+- **`asset_resolution::resolve_assets`**: three tests per asset kind
+  (explicit / deck-adjacent / built-in) confirming the `Provenance`
+  variant.
+- **CLI integration** (`crates/peitho/src/main.rs` `#[cfg(test)]`):
+  - `layouts deck.md` prints provenance + one layout with the builtin
+  - `layouts deck.md --json` produces valid JSON with expected shape
+  - `layouts deck.md --explain <key>` on a matching slide exits 0
+  - `layouts deck.md --explain <unknown-key>` exits 2 with help
+  - `layouts deck.md --explain <key>` on a slide with dispatch failure
+    exits non-zero and prints the trace
+
+### 5. Docs
+
+- `README.md` — one-line addition to the "commands" table (if it
+  exists; otherwise skip).
+- `site/content/guide/**` — a small "Inspecting layouts" section. Skip
+  if the guide doesn't have a natural home; the Issue doesn't require
+  guide docs and the command is discoverable via `--help`.
+- Do **not** add to the docs guide unless there's an obvious slot.
+
+### 6. Gates
+
+Standard peitho gates (CLAUDE.md):
+
+- `cargo test --workspace` 3× consecutively (race guard)
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --exit-code bindings/` — no ts-rs changes expected, since
+  `LayoutSummary` / `DispatchTrace` stay Rust-side (not exposed to TS)
+- Present-shell / preview-shell drift checks (no JS changes expected)
+
+## Risks & mitigations
+
+- **Refactoring `dispatch_slide`**: the current implementation is the
+  single source of truth for dispatch behavior. The refactor must not
+  change semantics — proven by keeping every existing dispatch test
+  passing while adding new trace-producing tests. If any existing test
+  breaks, the refactor is wrong.
+- **Provenance change in `ResolvedAssets`**: touches `build` / `watch` /
+  `preview` call sites. Kept minimal by adding `Provenance::path()` so
+  the migration is one call per site. All existing behavior tests must
+  still pass.
+- **`SlideKey` collisions**: today keys are unique per deck (enforced
+  in parser). `--explain <key>` matches on `SlideKey`, so we get
+  uniqueness for free.
+
+## Rollout
+
+Single PR (non-draft — peitho convention).
+
+Closes #243.

--- a/site/content/guide/layouts.md
+++ b/site/content/guide/layouts.md
@@ -54,6 +54,19 @@ An unknown explicit layout name is a build error. With structural dispatch,
 zero matches and multiple matches are also build errors; Peitho does not pick a
 layout silently.
 
+## Inspecting layouts
+
+Use `peitho layouts deck.md` to print the resolved layout source and each
+slot contract. Add `--json` when another tool needs the same information.
+
+When dispatch is unclear, use `peitho layouts deck.md --explain <slide-key>`.
+The trace shows the resolved layout source, the addressed slide, each structural
+candidate, and the final dispatch result. A missing slide key exits with status
+2 and prints the known keys; a dispatch failure trace exits with status 1.
+Explicit and sole-layout no-match failures include a `reason:` line, such as
+`reason: no slot accepts image in layout 'cover'`, with the underlying mapping
+error.
+
 ## Keyed CSS overrides
 
 Give a slide a stable key in its page settings comment:


### PR DESCRIPTION
## Summary

- Add `peitho layouts [deck] [--json]` to inspect the resolved layout set and its slot contracts. Provenance (`explicit` / `deck-adjacent` / `built-in`) is always shown at the top of both human and JSON output.
- Add `peitho layouts [deck] --explain <slide-key> [--json]` to trace the dispatch decision (Explicit / SoleLayout / StructuralMatch) for a specific slide, including per-candidate rejection reasons.
- Refactor `dispatch_slide` into a shared `try_dispatch` core that both the production dispatch path and the new `explain_dispatch` project from. All existing dispatch semantics are byte-preserved; verified by the existing dispatch test suite passing unchanged.
- Replace `ResolvedAssets`'s `Option<PathBuf>` fields with a three-variant `Provenance` enum (`Explicit` / `DeckAdjacent` / `Builtin`) so the "None means built-in" convention becomes a type-level invariant. Callers that only need the path go through `.path()`; watch-mode logs surface the provenance verbatim.

Design record: `docs/plans/2026-07-10-peitho-layouts.md`.

Closes #243.

## Test plan

- [x] `cargo test --workspace` 3x consecutively — 588 tests pass, no flakes (race guard per CLAUDE.md)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/` — no drift (new types stay Rust-side)
- [x] E2E: `peitho layouts <deck>` on a deck with `layouts:` frontmatter, deck-adjacent `layouts/`, and no assets — all three provenance variants render correctly
- [x] E2E: `peitho layouts <deck> --explain <key>` on Explicit / SoleLayout / StructuralMatch dispatch paths, both `--json` and human forms
- [x] Regression: existing `peitho build`, `peitho preview`, `peitho present`, `peitho export pdf` continue to work with the `Provenance` refactor (all test suites pass)

## Review loop

5-round self-review found and fixed 3 bugs before merge:

1. Explicit/SoleLayout dispatch failures used to hide the `map_slide` reason from `--explain`; now `DispatchResult::NoMatch { reason: Option<String> }` carries it.
2. `--explain <unknown-key> --json` used to emit plaintext to stderr; now emits structured JSON with the same exit code (2).
3. `describe_resolved_assets` used to drop provenance from watch-mode logs; now renders `layouts=explicit(/path)` / `deck-adjacent(/path)` inline.

Rounds 3-5 also tightened tests (added CLI coverage for unknown explicit layout, sole-layout no-match JSON shape, structural NoMatch strict-equality assertion, provenance-only watch-change and Explicit→Builtin watch-transition regression tests) and doc updates.