### PR TITLE
feat: add peitho doctor subcommand for runtime diagnostics

### DIFF
--- a/crates/peitho/src/asset_resolution.rs
+++ b/crates/peitho/src/asset_resolution.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use miette::IntoDiagnostic;
 use peitho_core::{
     error::{BuildError, ErrorKind},
     AssetPath, ParsedFrontmatter,
@@ -21,11 +20,40 @@ pub enum Provenance {
     Builtin,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AssetKey {
+    Layouts,
+    Css,
+    Syntaxes,
+    Fonts,
+}
+
+impl AssetKey {
+    pub(crate) const ALL: [Self; 4] = [Self::Layouts, Self::Css, Self::Syntaxes, Self::Fonts];
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Layouts => "layouts",
+            Self::Css => "css",
+            Self::Syntaxes => "syntaxes",
+            Self::Fonts => "fonts",
+        }
+    }
+}
+
 impl Provenance {
     pub fn path(&self) -> Option<&Path> {
         match self {
             Self::Explicit(path) | Self::DeckAdjacent(path) => Some(path),
             Self::Builtin => None,
+        }
+    }
+
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::Explicit(_) => "explicit",
+            Self::DeckAdjacent(_) => "deck-adjacent",
+            Self::Builtin => "built-in",
         }
     }
 }
@@ -34,40 +62,68 @@ pub fn resolve_assets(
     deck: &Path,
     frontmatter: &ParsedFrontmatter,
 ) -> miette::Result<ResolvedAssets> {
-    let settings = frontmatter.settings();
     Ok(ResolvedAssets {
-        layouts: resolve_asset(deck, frontmatter, "layouts", settings.layouts())?,
-        css: resolve_asset(deck, frontmatter, "css", settings.css())?,
-        syntaxes: resolve_asset(deck, frontmatter, "syntaxes", settings.syntaxes())?,
-        fonts: resolve_asset(deck, frontmatter, "fonts", settings.fonts())?,
+        layouts: core(resolve_asset(deck, frontmatter, AssetKey::Layouts))?,
+        css: core(resolve_asset(deck, frontmatter, AssetKey::Css))?,
+        syntaxes: core(resolve_asset(deck, frontmatter, AssetKey::Syntaxes))?,
+        fonts: core(resolve_asset(deck, frontmatter, AssetKey::Fonts))?,
     })
 }
 
-fn resolve_asset(
+pub(crate) fn resolve_asset(
     deck: &Path,
     frontmatter: &ParsedFrontmatter,
-    key: &'static str,
+    key: AssetKey,
+) -> peitho_core::Result<Provenance> {
+    let settings = frontmatter.settings();
+    let value = match key {
+        AssetKey::Layouts => settings.layouts(),
+        AssetKey::Css => settings.css(),
+        AssetKey::Syntaxes => settings.syntaxes(),
+        AssetKey::Fonts => settings.fonts(),
+    };
+    resolve_asset_value(deck, frontmatter, key, value)
+}
+
+fn resolve_asset_value(
+    deck: &Path,
+    frontmatter: &ParsedFrontmatter,
+    key: AssetKey,
     value: Option<&AssetPath>,
-) -> miette::Result<Provenance> {
+) -> peitho_core::Result<Provenance> {
+    let key_name = key.as_str();
     if let Some(value) = value {
         let path = resolve_against_deck(deck, value);
-        if !path.try_exists().into_diagnostic()? {
+        let exists = path.try_exists().map_err(|err| {
+            BuildError::new(
+                ErrorKind::Parse,
+                frontmatter.key_line(key_name),
+                format!(
+                    "{key_name} path could not be checked: {} ({err})",
+                    path.display()
+                ),
+                format!(
+                    "check filesystem permissions for the {key_name}: value in the frontmatter"
+                ),
+            )
+        })?;
+        if !exists {
             let line = frontmatter
-                .key_line(key)
+                .key_line(key_name)
                 .expect("explicit frontmatter asset keys are recorded with line numbers");
-            return core(Err(BuildError::new(
+            return Err(BuildError::new(
                 ErrorKind::Parse,
                 Some(line),
-                format!("{key} path does not exist: {}", path.display()),
+                format!("{key_name} path does not exist: {}", path.display()),
                 format!(
-                    "check the {key}: value in the frontmatter, or remove the key to use deck-adjacent {key}/"
+                    "check the {key_name}: value in the frontmatter, or remove the key to use deck-adjacent {key_name}/"
                 ),
-            )));
+            ));
         }
         return Ok(Provenance::Explicit(path));
     }
 
-    let conventional = deck_parent(deck).join(key);
+    let conventional = deck_parent(deck).join(key_name);
     if conventional.is_dir() {
         Ok(Provenance::DeckAdjacent(conventional))
     } else {

--- a/crates/peitho/src/displays.rs
+++ b/crates/peitho/src/displays.rs
@@ -204,7 +204,7 @@ pub fn layout_from_jxa_output(
     plan_presentation_layout(&displays, presenter_mode)
 }
 
-pub fn detect_presentation_layout(presenter_mode: PresenterMode) -> Option<PresentationLayout> {
+pub fn detect_nsscreen_json() -> Option<String> {
     if !cfg!(target_os = "macos") {
         return None;
     }
@@ -215,7 +215,11 @@ pub fn detect_presentation_layout(presenter_mode: PresenterMode) -> Option<Prese
     if !output.status.success() {
         return None;
     }
-    let stdout = String::from_utf8(output.stdout).ok()?;
+    String::from_utf8(output.stdout).ok()
+}
+
+pub fn detect_presentation_layout(presenter_mode: PresenterMode) -> Option<PresentationLayout> {
+    let stdout = detect_nsscreen_json()?;
     layout_from_jxa_output(&stdout, presenter_mode)
 }
 

--- a/crates/peitho/src/doctor.rs
+++ b/crates/peitho/src/doctor.rs
@@ -1,0 +1,1233 @@
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use miette::IntoDiagnostic;
+use peitho::{
+    browser::{self, BrowserPlatform},
+    displays,
+};
+use serde_json::Value;
+
+use crate::asset_resolution::{self, AssetKey, Provenance};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DoctorReport {
+    pub(crate) checks: Vec<DoctorCheck>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DoctorCheck {
+    pub(crate) category: DoctorCategory,
+    pub(crate) name: &'static str,
+    pub(crate) status: DoctorStatus,
+    pub(crate) message: String,
+    pub(crate) help: Option<String>,
+    pub(crate) details: Option<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DoctorCategory {
+    Chrome,
+    Displays,
+    EmbeddedShells,
+    Assets,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DoctorStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+pub(crate) struct DoctorEnv {
+    pub(crate) chrome_lookup: crate::ChromeLookupEnv,
+    pub(crate) home: Option<OsString>,
+    pub(crate) platform: BrowserPlatform,
+    pub(crate) display_json: Option<String>,
+}
+
+impl DoctorEnv {
+    pub(crate) fn from_process_env() -> Self {
+        let path_dirs = env::var_os("PATH")
+            .map(|path| env::split_paths(&path).collect())
+            .unwrap_or_default();
+        let platform = if cfg!(target_os = "macos") {
+            BrowserPlatform::Macos
+        } else if cfg!(target_os = "linux") {
+            BrowserPlatform::Linux
+        } else {
+            BrowserPlatform::Other
+        };
+        let display_json = (platform == BrowserPlatform::Macos)
+            .then(displays::detect_nsscreen_json)
+            .flatten();
+
+        Self {
+            chrome_lookup: crate::ChromeLookupEnv {
+                env_path: env::var_os("PEITHO_CHROME_PATH").map(PathBuf::from),
+                mac_chrome: PathBuf::from(
+                    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                ),
+                path_dirs,
+            },
+            home: env::var_os("HOME"),
+            platform,
+            display_json,
+        }
+    }
+}
+
+pub(crate) fn run_doctor(deck: Option<&Path>, env: &DoctorEnv) -> DoctorReport {
+    let mut checks = Vec::new();
+    push_chrome_checks(&mut checks, env);
+    push_display_checks(&mut checks, env);
+    push_embedded_shell_checks(&mut checks);
+    if let Some(deck) = deck {
+        push_asset_checks(&mut checks, deck);
+    }
+    DoctorReport { checks }
+}
+
+pub(crate) fn dispatch(
+    input: Option<PathBuf>,
+    json: bool,
+    env: &DoctorEnv,
+    writer: &mut dyn Write,
+    is_terminal: bool,
+) -> miette::Result<i32> {
+    let report = run_doctor(input.as_deref(), env);
+    if json {
+        print_json(&report, writer)?;
+    } else {
+        print_human(&report, writer, is_terminal)?;
+    }
+    Ok(exit_code_for(&report))
+}
+
+pub(crate) fn print_human<W: Write>(
+    report: &DoctorReport,
+    mut writer: W,
+    is_terminal: bool,
+) -> miette::Result<()> {
+    let mut current_category = None;
+    for check in &report.checks {
+        if current_category != Some(check.category) {
+            if current_category.is_some() {
+                writeln!(writer).into_diagnostic()?;
+            }
+            writeln!(writer, "{}", check.category.human_name()).into_diagnostic()?;
+            current_category = Some(check.category);
+        }
+        writeln!(
+            writer,
+            "  {} {}: {}",
+            status_glyph(check.status, is_terminal),
+            check.name,
+            check.message
+        )
+        .into_diagnostic()?;
+        if let Some(help) = &check.help {
+            writeln!(writer, "      help: {help}").into_diagnostic()?;
+        }
+    }
+
+    let summary = summary_for(report);
+    writeln!(writer).into_diagnostic()?;
+    writeln!(
+        writer,
+        "{} passed, {} warned, {} failed",
+        summary.pass, summary.warn, summary.fail
+    )
+    .into_diagnostic()
+}
+
+pub(crate) fn print_json<W: Write>(report: &DoctorReport, mut writer: W) -> miette::Result<()> {
+    let payload = JsonReport {
+        checks: report
+            .checks
+            .iter()
+            .map(|check| JsonCheck {
+                category: check.category.json_name(),
+                name: check.name,
+                status: check.status.json_name(),
+                message: &check.message,
+                help: check.help.as_deref(),
+                details: check.details.as_ref(),
+            })
+            .collect(),
+        summary: summary_for(report),
+    };
+    serde_json::to_writer_pretty(&mut writer, &payload).into_diagnostic()?;
+    writeln!(writer).into_diagnostic()
+}
+
+pub(crate) fn exit_code_for(report: &DoctorReport) -> i32 {
+    if report
+        .checks
+        .iter()
+        .any(|check| check.status == DoctorStatus::Fail)
+    {
+        2
+    } else {
+        0
+    }
+}
+
+fn push_chrome_checks(checks: &mut Vec<DoctorCheck>, env: &DoctorEnv) {
+    match crate::locate_chrome_with_env(&env.chrome_lookup) {
+        Ok(path) => checks.push(DoctorCheck {
+            category: DoctorCategory::Chrome,
+            name: "binary-discovered",
+            status: DoctorStatus::Pass,
+            message: path.display().to_string(),
+            help: None,
+            details: Some(serde_json::json!({ "path": path.display().to_string() })),
+        }),
+        Err(_) => {
+            checks.push(DoctorCheck {
+                category: DoctorCategory::Chrome,
+                name: "binary-discovered",
+                status: DoctorStatus::Fail,
+                message: chrome_missing_message(env),
+                help: Some(
+                    "install Google Chrome or Chromium, or set PEITHO_CHROME_PATH=<absolute-path>"
+                        .to_owned(),
+                ),
+                details: None,
+            });
+        }
+    }
+
+    let Some(profiles) = browser::chrome_profiles_from_home(env.home.clone()) else {
+        push_home_unavailable_warning(checks);
+        return;
+    };
+    let root = profiles
+        .slides
+        .parent()
+        .expect("chrome profiles path always has a parent");
+    if !root.is_absolute() {
+        push_home_unavailable_warning(checks);
+        return;
+    }
+
+    let root_exists = match root.try_exists() {
+        Ok(exists) => exists,
+        Err(err) => {
+            checks.push(DoctorCheck {
+                category: DoctorCategory::Chrome,
+                name: "profiles-writable",
+                status: DoctorStatus::Fail,
+                message: format!("{} ({err})", root.display()),
+                help: Some("make HOME writable".to_owned()),
+                details: Some(serde_json::json!({ "path": root.display().to_string() })),
+            });
+            return;
+        }
+    };
+
+    if root_exists {
+        match fs::metadata(root) {
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => {
+                checks.push(DoctorCheck {
+                    category: DoctorCategory::Chrome,
+                    name: "profiles-writable",
+                    status: DoctorStatus::Fail,
+                    message: format!("{} is not a directory", root.display()),
+                    help: Some("remove the file or set HOME to a writable directory".to_owned()),
+                    details: Some(serde_json::json!({ "path": root.display().to_string() })),
+                });
+                return;
+            }
+            Err(err) => {
+                checks.push(DoctorCheck {
+                    category: DoctorCategory::Chrome,
+                    name: "profiles-writable",
+                    status: DoctorStatus::Fail,
+                    message: format!("{} ({err})", root.display()),
+                    help: Some("make the Chrome profiles root readable".to_owned()),
+                    details: Some(serde_json::json!({ "path": root.display().to_string() })),
+                });
+                return;
+            }
+        }
+        if let Err(err) = probe_writable(root) {
+            checks.push(DoctorCheck {
+                category: DoctorCategory::Chrome,
+                name: "profiles-writable",
+                status: DoctorStatus::Fail,
+                message: format!("{} ({err})", root.display()),
+                help: Some("make the Chrome profiles root writable".to_owned()),
+                details: Some(serde_json::json!({ "path": root.display().to_string() })),
+            });
+            return;
+        }
+        checks.push(DoctorCheck {
+            category: DoctorCategory::Chrome,
+            name: "profiles-writable",
+            status: DoctorStatus::Pass,
+            message: root.display().to_string(),
+            help: None,
+            details: Some(serde_json::json!({ "path": root.display().to_string() })),
+        });
+        return;
+    }
+
+    if let Err(err) = probe_create_remove_dir(root) {
+        checks.push(DoctorCheck {
+            category: DoctorCategory::Chrome,
+            name: "profiles-writable",
+            status: DoctorStatus::Fail,
+            message: format!("{} ({err})", root.display()),
+            help: Some("make HOME writable".to_owned()),
+            details: Some(serde_json::json!({ "path": root.display().to_string() })),
+        });
+        return;
+    }
+    checks.push(DoctorCheck {
+        category: DoctorCategory::Chrome,
+        name: "profiles-writable",
+        status: DoctorStatus::Pass,
+        message: format!("{} will be created on first present", root.display()),
+        help: None,
+        details: Some(serde_json::json!({ "path": root.display().to_string() })),
+    });
+}
+
+fn probe_writable(dir: &Path) -> std::io::Result<()> {
+    let probe = dir.join(format!(".doctor-write-test-{}", std::process::id()));
+    fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&probe)
+        .and_then(|mut file| file.write_all(b"ok"))?;
+    let _ = fs::remove_file(probe);
+    Ok(())
+}
+
+fn probe_create_remove_dir(dir: &Path) -> std::io::Result<()> {
+    match fs::create_dir(dir) {
+        Ok(()) => {
+            let _ = fs::remove_dir(dir);
+            Ok(())
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => probe_writable(dir),
+        Err(err) => Err(err),
+    }
+}
+
+fn push_home_unavailable_warning(checks: &mut Vec<DoctorCheck>) {
+    checks.push(DoctorCheck {
+        category: DoctorCategory::Chrome,
+        name: "profiles-writable",
+        status: DoctorStatus::Warn,
+        message: "HOME is unset or not absolute; persistent Chrome profiles cannot be prepared"
+            .to_owned(),
+        help: Some(
+            "set HOME to an absolute writable directory before running present mode".to_owned(),
+        ),
+        details: None,
+    });
+}
+
+fn push_display_checks(checks: &mut Vec<DoctorCheck>, env: &DoctorEnv) {
+    if env.platform != BrowserPlatform::Macos {
+        checks.push(DoctorCheck {
+            category: DoctorCategory::Displays,
+            name: "enumeration",
+            status: DoctorStatus::Warn,
+            message: "display enumeration is not implemented on this platform (see Issue #22)"
+                .to_owned(),
+            help: None,
+            details: None,
+        });
+        return;
+    }
+
+    let Some(json) = env.display_json.as_deref() else {
+        checks.push(DoctorCheck {
+            category: DoctorCategory::Displays,
+            name: "enumeration",
+            status: DoctorStatus::Warn,
+            message: "display enumeration failed".to_owned(),
+            help: Some(
+                "osascript may not be installed, or NSScreen access may be denied".to_owned(),
+            ),
+            details: None,
+        });
+        return;
+    };
+
+    let displays = match displays::parse_nsscreen_json(json) {
+        Ok(displays) => displays,
+        Err(err) => {
+            checks.push(DoctorCheck {
+                category: DoctorCategory::Displays,
+                name: "enumeration",
+                status: DoctorStatus::Warn,
+                message: format!("display enumeration failed: {err}"),
+                help: Some(
+                    "osascript may not be installed, or NSScreen access may be denied".to_owned(),
+                ),
+                details: None,
+            });
+            return;
+        }
+    };
+
+    let count = displays.len();
+    let (status, help) = match count {
+        0 => (
+            DoctorStatus::Warn,
+            Some(
+                "no displays are visible; peitho may be running headlessly or NSScreen access may be denied"
+                    .to_owned(),
+            ),
+        ),
+        1 => (
+            DoctorStatus::Warn,
+            Some("connect an external display for presenter mode".to_owned()),
+        ),
+        _ => (DoctorStatus::Pass, None),
+    };
+    checks.push(DoctorCheck {
+        category: DoctorCategory::Displays,
+        name: "enumeration",
+        status,
+        message: format!("{count} display(s) found"),
+        help,
+        details: Some(serde_json::Value::Array(
+            displays
+                .iter()
+                .map(|display| {
+                    serde_json::json!({
+                        "primary": display.primary,
+                        "x": display.x,
+                        "y": display.y,
+                        "width": display.width,
+                        "height": display.height,
+                    })
+                })
+                .collect(),
+        )),
+    });
+}
+
+fn push_embedded_shell_checks(checks: &mut Vec<DoctorCheck>) {
+    checks.push(shell_check("present-shell", crate::BUILTIN_SHELL_JS));
+    checks.push(shell_check("preview-shell", crate::BUILTIN_PREVIEW_JS));
+}
+
+fn shell_check(name: &'static str, source: &str) -> DoctorCheck {
+    let bytes = source.len();
+    let sha256_prefix = crate::short_sha256_hex(source.as_bytes(), 12);
+    DoctorCheck {
+        category: DoctorCategory::EmbeddedShells,
+        name,
+        status: DoctorStatus::Pass,
+        message: format!("{bytes} bytes (sha256: {sha256_prefix})"),
+        help: None,
+        details: Some(serde_json::json!({
+            "bytes": bytes,
+            "sha256_prefix": sha256_prefix,
+        })),
+    }
+}
+
+fn push_asset_checks(checks: &mut Vec<DoctorCheck>, deck: &Path) {
+    let markdown = match fs::read_to_string(deck) {
+        Ok(markdown) => markdown,
+        Err(err) => {
+            checks.push(DoctorCheck {
+                category: DoctorCategory::Assets,
+                name: "deck",
+                status: DoctorStatus::Fail,
+                message: format!("failed to read {}: {err}", deck.display()),
+                help: Some("pass the deck path explicitly if it lives elsewhere".to_owned()),
+                details: Some(serde_json::json!({ "path": deck.display().to_string() })),
+            });
+            return;
+        }
+    };
+    let frontmatter = match peitho_core::parse_frontmatter(&markdown) {
+        Ok(frontmatter) => frontmatter,
+        Err(err) => {
+            checks.push(asset_error_check(
+                "frontmatter",
+                err,
+                Some(serde_json::json!({ "path": deck.display().to_string() })),
+            ));
+            return;
+        }
+    };
+
+    for key in AssetKey::ALL {
+        match asset_resolution::resolve_asset(deck, &frontmatter, key) {
+            Ok(provenance) => checks.push(asset_pass_check(key, provenance)),
+            Err(err) => {
+                checks.push(asset_error_check(key.as_str(), err, None));
+            }
+        }
+    }
+}
+
+fn chrome_missing_message(env: &DoctorEnv) -> String {
+    match &env.chrome_lookup.env_path {
+        Some(path) if !path.as_os_str().is_empty() => {
+            format!("Chrome not found at PEITHO_CHROME_PATH={}", path.display())
+        }
+        _ => "Chrome not found".to_owned(),
+    }
+}
+
+fn asset_pass_check(key: AssetKey, provenance: Provenance) -> DoctorCheck {
+    let provenance_name = provenance.kind();
+    let path = provenance.path().map(|path| path.display().to_string());
+    let message = match &path {
+        Some(path) => format!("{provenance_name} {path}"),
+        None => provenance_name.to_owned(),
+    };
+    DoctorCheck {
+        category: DoctorCategory::Assets,
+        name: key.as_str(),
+        status: DoctorStatus::Pass,
+        message,
+        help: None,
+        details: Some(serde_json::json!({
+            "provenance": provenance_name,
+            "path": path,
+        })),
+    }
+}
+
+fn asset_error_check(
+    name: &'static str,
+    err: peitho_core::error::BuildError,
+    details: Option<serde_json::Value>,
+) -> DoctorCheck {
+    let help = (!err.help.is_empty()).then_some(err.help);
+    DoctorCheck {
+        category: DoctorCategory::Assets,
+        name,
+        status: DoctorStatus::Fail,
+        message: err.message,
+        help,
+        details,
+    }
+}
+
+fn status_glyph(status: DoctorStatus, is_terminal: bool) -> String {
+    let (glyph, color) = match status {
+        DoctorStatus::Pass => ("✓", "32"),
+        DoctorStatus::Warn => ("⚠", "33"),
+        DoctorStatus::Fail => ("✗", "31"),
+    };
+    if is_terminal {
+        format!("\x1b[{color}m{glyph}\x1b[0m")
+    } else {
+        glyph.to_owned()
+    }
+}
+
+fn summary_for(report: &DoctorReport) -> Summary {
+    let mut summary = Summary {
+        pass: 0,
+        warn: 0,
+        fail: 0,
+    };
+    for check in &report.checks {
+        match check.status {
+            DoctorStatus::Pass => summary.pass += 1,
+            DoctorStatus::Warn => summary.warn += 1,
+            DoctorStatus::Fail => summary.fail += 1,
+        }
+    }
+    summary
+}
+
+impl DoctorCategory {
+    fn human_name(self) -> String {
+        self.json_name().replace('-', " ")
+    }
+
+    fn json_name(self) -> &'static str {
+        match self {
+            Self::Chrome => "chrome",
+            Self::Displays => "displays",
+            Self::EmbeddedShells => "embedded-shells",
+            Self::Assets => "assets",
+        }
+    }
+}
+
+impl DoctorStatus {
+    fn json_name(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Warn => "warn",
+            Self::Fail => "fail",
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct JsonReport<'a> {
+    checks: Vec<JsonCheck<'a>>,
+    summary: Summary,
+}
+
+#[derive(serde::Serialize)]
+struct JsonCheck<'a> {
+    category: &'static str,
+    name: &'static str,
+    status: &'static str,
+    message: &'a str,
+    help: Option<&'a str>,
+    details: Option<&'a Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+struct Summary {
+    pass: usize,
+    warn: usize,
+    fail: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::{fs, path::Path};
+
+    fn write_file(path: &Path) {
+        fs::write(path, "fake").unwrap();
+    }
+
+    fn chrome_lookup_with_existing(path: PathBuf) -> crate::ChromeLookupEnv {
+        crate::ChromeLookupEnv {
+            env_path: Some(path),
+            mac_chrome: PathBuf::from("/missing/mac/chrome"),
+            path_dirs: Vec::new(),
+        }
+    }
+
+    fn chrome_lookup_missing() -> crate::ChromeLookupEnv {
+        crate::ChromeLookupEnv {
+            env_path: None,
+            mac_chrome: PathBuf::from("/missing/mac/chrome"),
+            path_dirs: Vec::new(),
+        }
+    }
+
+    fn two_display_json() -> String {
+        r#"[
+          {"x":0,"y":0,"width":1512,"height":982},
+          {"x":1512,"y":0,"width":1920,"height":1080}
+        ]"#
+        .to_owned()
+    }
+
+    fn passing_env(dir: &Path) -> DoctorEnv {
+        let chrome = dir.join("chrome");
+        let home = dir.join("home");
+        write_file(&chrome);
+        fs::create_dir_all(&home).unwrap();
+        DoctorEnv {
+            chrome_lookup: chrome_lookup_with_existing(chrome),
+            home: Some(home.into_os_string()),
+            platform: BrowserPlatform::Macos,
+            display_json: Some(two_display_json()),
+        }
+    }
+
+    fn find_check<'a>(
+        report: &'a DoctorReport,
+        category: DoctorCategory,
+        name: &str,
+    ) -> &'a DoctorCheck {
+        report
+            .checks
+            .iter()
+            .find(|check| check.category == category && check.name == name)
+            .unwrap_or_else(|| panic!("missing check {category:?}/{name} in {report:#?}"))
+    }
+
+    #[test]
+    fn cli_dispatch_calls_run_doctor_and_exits_with_code() {
+        let cli = crate::Cli::parse_from(["peitho", "doctor", "--json"]);
+        let crate::Command::Doctor { input, json } = cli.command else {
+            panic!("expected doctor command");
+        };
+        assert_eq!(input, None);
+        assert!(json);
+
+        let passing_dir = tempfile::tempdir().unwrap();
+        let env = passing_env(passing_dir.path());
+        let mut output = Vec::new();
+        let code = dispatch(input.clone(), json, &env, &mut output, false).unwrap();
+        assert_eq!(code, 0);
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.starts_with("{\n  \"checks\""));
+
+        let failing_dir = tempfile::tempdir().unwrap();
+        let failing_env = DoctorEnv {
+            chrome_lookup: chrome_lookup_missing(),
+            ..passing_env(failing_dir.path())
+        };
+        let mut output = Vec::new();
+        let code = dispatch(input, json, &failing_env, &mut output, false).unwrap();
+        assert_eq!(code, 2);
+    }
+
+    #[test]
+    fn chrome_binary_discovered_reports_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "binary-discovered");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.message.contains("chrome"));
+    }
+
+    #[test]
+    fn chrome_binary_missing_reports_fail_with_help() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            chrome_lookup: chrome_lookup_missing(),
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "binary-discovered");
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert!(check
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("PEITHO_CHROME_PATH")));
+    }
+
+    #[test]
+    fn chrome_binary_missing_omits_empty_env_path_in_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            chrome_lookup: crate::ChromeLookupEnv {
+                env_path: Some(PathBuf::from("")),
+                mac_chrome: PathBuf::from("/missing/mac/chrome"),
+                path_dirs: Vec::new(),
+            },
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "binary-discovered");
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert_eq!(check.message, "Chrome not found");
+    }
+
+    #[test]
+    fn chrome_profiles_writable_reports_pass_for_existing_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.message.contains(".peitho"));
+    }
+
+    #[test]
+    fn chrome_profiles_reports_pass_without_creating_peitho_root_when_home_is_writable() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("home").join(".peitho");
+        let env = passing_env(dir.path());
+        assert!(!root.exists());
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.message.contains("will be created on first present"));
+        assert!(!root.exists());
+        let home_entries = fs::read_dir(root.parent().unwrap())
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(home_entries.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn chrome_profiles_probe_ignores_cleanup_error_and_reports_pass() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let probe = dir
+            .path()
+            .join(format!(".doctor-write-test-{}", std::process::id()));
+        fs::write(&probe, "old").unwrap();
+        let original = fs::metadata(dir.path()).unwrap().permissions();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = probe_writable(dir.path());
+
+        fs::set_permissions(dir.path(), original).unwrap();
+        assert!(result.is_ok());
+        assert!(probe.exists());
+    }
+
+    #[test]
+    fn chrome_profiles_probe_treats_already_exists_as_pass_via_directory_probe() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("home").join(".peitho");
+        let env = passing_env(dir.path());
+        fs::create_dir(&root).unwrap();
+
+        assert!(probe_create_remove_dir(&root).is_ok());
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert_eq!(check.message, root.display().to_string());
+        assert!(root.exists());
+    }
+
+    #[test]
+    fn chrome_profiles_reports_warn_when_home_unset() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            home: None,
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert!(check.message.contains("HOME"));
+    }
+
+    #[test]
+    fn chrome_profiles_reports_warn_when_home_is_empty_or_relative() {
+        let dir = tempfile::tempdir().unwrap();
+        for home in [OsString::from(""), OsString::from("relative-home")] {
+            let env = DoctorEnv {
+                home: Some(home),
+                ..passing_env(dir.path())
+            };
+
+            let report = run_doctor(None, &env);
+
+            let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
+            assert_eq!(check.status, DoctorStatus::Warn);
+            assert!(check.message.contains("HOME"));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn chrome_profiles_reports_fail_when_home_readonly() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        let original = fs::metadata(&home).unwrap().permissions();
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o555)).unwrap();
+        assert!(!home.join(".peitho").exists());
+        let env = DoctorEnv {
+            home: Some(home.clone().into_os_string()),
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        fs::set_permissions(&home, original).unwrap();
+        let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
+        assert_eq!(check.status, DoctorStatus::Fail);
+    }
+
+    #[test]
+    fn displays_enumeration_reports_pass_when_two_or_more_displays() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Displays, "enumeration");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check.message.contains("2 display(s) found"));
+        let details = check.details.as_ref().unwrap().as_array().unwrap();
+        assert_eq!(details.len(), 2);
+        assert_eq!(details[0]["primary"], true);
+        assert_eq!(details[1]["x"], 1512);
+    }
+
+    #[test]
+    fn displays_enumeration_reports_warn_when_zero_displays_returned() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            display_json: Some("[]".to_owned()),
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Displays, "enumeration");
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert!(check.message.contains("0 display(s) found"));
+        assert!(check
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("headlessly")));
+    }
+
+    #[test]
+    fn displays_enumeration_reports_warn_when_provider_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            display_json: None,
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Displays, "enumeration");
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert!(check
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("NSScreen")));
+    }
+
+    #[test]
+    fn displays_reports_warn_on_non_macos() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            platform: BrowserPlatform::Linux,
+            ..passing_env(dir.path())
+        };
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::Displays, "enumeration");
+        assert_eq!(check.status, DoctorStatus::Warn);
+        assert!(check.message.contains("Issue #22"));
+    }
+
+    #[test]
+    fn embedded_shells_report_present_shell_with_byte_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::EmbeddedShells, "present-shell");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check
+            .message
+            .contains(&crate::BUILTIN_SHELL_JS.len().to_string()));
+    }
+
+    #[test]
+    fn embedded_shells_report_preview_shell_with_byte_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+
+        let report = run_doctor(None, &env);
+
+        let check = find_check(&report, DoctorCategory::EmbeddedShells, "preview-shell");
+        assert_eq!(check.status, DoctorStatus::Pass);
+        assert!(check
+            .message
+            .contains(&crate::BUILTIN_PREVIEW_JS.len().to_string()));
+    }
+
+    #[test]
+    fn assets_report_skipped_when_no_deck_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+
+        let report = run_doctor(None, &env);
+
+        let categories = report
+            .checks
+            .iter()
+            .map(|check| check.category)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            categories,
+            vec![
+                DoctorCategory::Chrome,
+                DoctorCategory::Chrome,
+                DoctorCategory::Displays,
+                DoctorCategory::EmbeddedShells,
+                DoctorCategory::EmbeddedShells,
+            ]
+        );
+        assert!(!report
+            .checks
+            .iter()
+            .any(|check| check.category == DoctorCategory::Assets));
+    }
+
+    #[test]
+    fn assets_report_provenance_for_each_asset() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = passing_env(dir.path());
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "# Intro\n").unwrap();
+        fs::create_dir_all(dir.path().join("layouts")).unwrap();
+
+        let report = run_doctor(Some(&deck), &env);
+
+        let layouts = find_check(&report, DoctorCategory::Assets, "layouts");
+        let css = find_check(&report, DoctorCategory::Assets, "css");
+        let syntaxes = find_check(&report, DoctorCategory::Assets, "syntaxes");
+        let fonts = find_check(&report, DoctorCategory::Assets, "fonts");
+        assert_eq!(layouts.status, DoctorStatus::Pass);
+        assert!(layouts.message.contains("deck-adjacent"));
+        assert!(css.message.contains("built-in"));
+        assert!(syntaxes.message.contains("built-in"));
+        assert!(fonts.message.contains("built-in"));
+    }
+
+    #[test]
+    fn assets_report_fail_for_missing_explicit_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = DoctorEnv {
+            chrome_lookup: chrome_lookup_missing(),
+            ..passing_env(dir.path())
+        };
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            &deck,
+            "---\nlayouts: ./layouts\ncss: ./missing.css\nsyntaxes: ./syntaxes\nfonts: ./fonts\n---\n# Intro\n",
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("layouts")).unwrap();
+        fs::create_dir_all(dir.path().join("syntaxes")).unwrap();
+        fs::create_dir_all(dir.path().join("fonts")).unwrap();
+
+        let report = run_doctor(Some(&deck), &env);
+
+        let categories = report
+            .checks
+            .iter()
+            .map(|check| check.category)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            categories,
+            vec![
+                DoctorCategory::Chrome,
+                DoctorCategory::Chrome,
+                DoctorCategory::Displays,
+                DoctorCategory::EmbeddedShells,
+                DoctorCategory::EmbeddedShells,
+                DoctorCategory::Assets,
+                DoctorCategory::Assets,
+                DoctorCategory::Assets,
+                DoctorCategory::Assets,
+            ]
+        );
+        let layouts = find_check(&report, DoctorCategory::Assets, "layouts");
+        let css = find_check(&report, DoctorCategory::Assets, "css");
+        let syntaxes = find_check(&report, DoctorCategory::Assets, "syntaxes");
+        let fonts = find_check(&report, DoctorCategory::Assets, "fonts");
+        assert_eq!(layouts.status, DoctorStatus::Pass);
+        assert_eq!(css.status, DoctorStatus::Fail);
+        assert_eq!(syntaxes.status, DoctorStatus::Pass);
+        assert_eq!(fonts.status, DoctorStatus::Pass);
+        assert!(css.message.contains("css path does not exist"));
+        assert!(!css.message.contains("= help:"));
+        assert!(css
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("frontmatter")));
+    }
+
+    #[test]
+    fn assets_report_omits_help_when_build_error_help_is_empty() {
+        let check = asset_error_check(
+            "css",
+            peitho_core::error::BuildError {
+                kind: peitho_core::error::ErrorKind::Parse,
+                line: None,
+                message: "css path is invalid".to_owned(),
+                help: String::new(),
+                slide: None,
+            },
+            None,
+        );
+
+        assert_eq!(check.status, DoctorStatus::Fail);
+        assert_eq!(check.message, "css path is invalid");
+        assert_eq!(check.help, None);
+    }
+
+    #[test]
+    fn run_doctor_exit_code_is_pass_when_all_pass() {
+        let report = DoctorReport {
+            checks: vec![DoctorCheck {
+                category: DoctorCategory::Chrome,
+                name: "binary-discovered",
+                status: DoctorStatus::Pass,
+                message: "ok".to_owned(),
+                help: None,
+                details: None,
+            }],
+        };
+
+        assert_eq!(exit_code_for(&report), 0);
+    }
+
+    #[test]
+    fn run_doctor_exit_code_is_fail_when_any_fail() {
+        let report = DoctorReport {
+            checks: vec![
+                DoctorCheck {
+                    category: DoctorCategory::Chrome,
+                    name: "binary-discovered",
+                    status: DoctorStatus::Pass,
+                    message: "ok".to_owned(),
+                    help: None,
+                    details: None,
+                },
+                DoctorCheck {
+                    category: DoctorCategory::Assets,
+                    name: "css",
+                    status: DoctorStatus::Fail,
+                    message: "missing".to_owned(),
+                    help: None,
+                    details: None,
+                },
+            ],
+        };
+
+        assert_eq!(exit_code_for(&report), 2);
+    }
+
+    #[test]
+    fn run_doctor_warn_does_not_fail_exit_code() {
+        let report = DoctorReport {
+            checks: vec![DoctorCheck {
+                category: DoctorCategory::Displays,
+                name: "enumeration",
+                status: DoctorStatus::Warn,
+                message: "not implemented".to_owned(),
+                help: None,
+                details: None,
+            }],
+        };
+
+        assert_eq!(exit_code_for(&report), 0);
+    }
+
+    #[test]
+    fn print_human_writes_category_headers_and_status_glyphs() {
+        let report = DoctorReport {
+            checks: vec![
+                DoctorCheck {
+                    category: DoctorCategory::Chrome,
+                    name: "binary-discovered",
+                    status: DoctorStatus::Pass,
+                    message: "ok".to_owned(),
+                    help: None,
+                    details: None,
+                },
+                DoctorCheck {
+                    category: DoctorCategory::Displays,
+                    name: "enumeration",
+                    status: DoctorStatus::Warn,
+                    message: "single display".to_owned(),
+                    help: Some("connect another display".to_owned()),
+                    details: None,
+                },
+                DoctorCheck {
+                    category: DoctorCategory::Assets,
+                    name: "css",
+                    status: DoctorStatus::Fail,
+                    message: "missing".to_owned(),
+                    help: None,
+                    details: None,
+                },
+            ],
+        };
+        let mut output = Vec::new();
+
+        print_human(&report, &mut output, false).unwrap();
+
+        let text = String::from_utf8(output).unwrap();
+        assert!(text.contains("chrome\n"));
+        assert!(text.contains("displays\n"));
+        assert!(text.contains("assets\n"));
+        assert!(text.contains("✓ binary-discovered: ok"));
+        assert!(text.contains("⚠ enumeration: single display"));
+        assert!(text.contains("✗ css: missing"));
+        assert!(text.contains("1 passed, 1 warned, 1 failed"));
+    }
+
+    #[test]
+    fn print_human_uses_no_color_when_not_tty() {
+        let report = DoctorReport {
+            checks: vec![DoctorCheck {
+                category: DoctorCategory::Chrome,
+                name: "binary-discovered",
+                status: DoctorStatus::Pass,
+                message: "ok".to_owned(),
+                help: None,
+                details: None,
+            }],
+        };
+        let mut output = Vec::new();
+
+        print_human(&report, &mut output, false).unwrap();
+
+        let text = String::from_utf8(output).unwrap();
+        assert!(!text.contains("\x1b["));
+    }
+
+    #[test]
+    fn print_json_shape_is_stable_categories_names_and_details() {
+        let report = DoctorReport {
+            checks: vec![DoctorCheck {
+                category: DoctorCategory::EmbeddedShells,
+                name: "present-shell",
+                status: DoctorStatus::Pass,
+                message: "12 bytes".to_owned(),
+                help: None,
+                details: Some(serde_json::json!({"sha256_prefix": "abcdef123456"})),
+            }],
+        };
+        let mut output = Vec::new();
+
+        print_json(&report, &mut output).unwrap();
+
+        let payload: Value = serde_json::from_slice(&output).unwrap();
+        let check = payload["checks"][0].as_object().unwrap();
+        let mut keys = check.keys().map(String::as_str).collect::<Vec<_>>();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec!["category", "details", "help", "message", "name", "status"]
+        );
+        assert_eq!(check["category"], "embedded-shells");
+        assert_eq!(check["name"], "present-shell");
+        assert_eq!(check["help"], Value::Null);
+        assert!(payload["summary"].get("pass").is_some());
+        assert!(payload["summary"].get("warn").is_some());
+        assert!(payload["summary"].get("fail").is_some());
+    }
+}

--- a/crates/peitho/src/doctor.rs
+++ b/crates/peitho/src/doctor.rs
@@ -83,25 +83,25 @@ impl DoctorEnv {
     }
 }
 
-pub(crate) fn run_doctor(deck: Option<&Path>, env: &DoctorEnv) -> DoctorReport {
+pub(crate) fn run_doctor(deck: &Path, env: &DoctorEnv) -> DoctorReport {
     let mut checks = Vec::new();
     push_chrome_checks(&mut checks, env);
     push_display_checks(&mut checks, env);
     push_embedded_shell_checks(&mut checks);
-    if let Some(deck) = deck {
+    if deck.is_file() {
         push_asset_checks(&mut checks, deck);
     }
     DoctorReport { checks }
 }
 
 pub(crate) fn dispatch(
-    input: Option<PathBuf>,
+    input: PathBuf,
     json: bool,
     env: &DoctorEnv,
     writer: &mut dyn Write,
     is_terminal: bool,
 ) -> miette::Result<i32> {
-    let report = run_doctor(input.as_deref(), env);
+    let report = run_doctor(&input, env);
     if json {
         print_json(&report, writer)?;
     } else {
@@ -666,7 +666,7 @@ mod tests {
         let crate::Command::Doctor { input, json } = cli.command else {
             panic!("expected doctor command");
         };
-        assert_eq!(input, None);
+        assert_eq!(input, PathBuf::from("deck.md"));
         assert!(json);
 
         let passing_dir = tempfile::tempdir().unwrap();
@@ -692,7 +692,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let env = passing_env(dir.path());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "binary-discovered");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -707,7 +707,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "binary-discovered");
         assert_eq!(check.status, DoctorStatus::Fail);
@@ -729,7 +729,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "binary-discovered");
         assert_eq!(check.status, DoctorStatus::Fail);
@@ -741,7 +741,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let env = passing_env(dir.path());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -755,7 +755,7 @@ mod tests {
         let env = passing_env(dir.path());
         assert!(!root.exists());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -796,7 +796,7 @@ mod tests {
         fs::create_dir(&root).unwrap();
 
         assert!(probe_create_remove_dir(&root).is_ok());
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -812,7 +812,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
         assert_eq!(check.status, DoctorStatus::Warn);
@@ -828,7 +828,7 @@ mod tests {
                 ..passing_env(dir.path())
             };
 
-            let report = run_doctor(None, &env);
+            let report = run_doctor(&dir.path().join("deck.md"), &env);
 
             let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
             assert_eq!(check.status, DoctorStatus::Warn);
@@ -852,7 +852,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         fs::set_permissions(&home, original).unwrap();
         let check = find_check(&report, DoctorCategory::Chrome, "profiles-writable");
@@ -864,7 +864,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let env = passing_env(dir.path());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Displays, "enumeration");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -883,7 +883,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Displays, "enumeration");
         assert_eq!(check.status, DoctorStatus::Warn);
@@ -902,7 +902,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Displays, "enumeration");
         assert_eq!(check.status, DoctorStatus::Warn);
@@ -920,7 +920,7 @@ mod tests {
             ..passing_env(dir.path())
         };
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::Displays, "enumeration");
         assert_eq!(check.status, DoctorStatus::Warn);
@@ -932,7 +932,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let env = passing_env(dir.path());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::EmbeddedShells, "present-shell");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -946,7 +946,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let env = passing_env(dir.path());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let check = find_check(&report, DoctorCategory::EmbeddedShells, "preview-shell");
         assert_eq!(check.status, DoctorStatus::Pass);
@@ -956,11 +956,11 @@ mod tests {
     }
 
     #[test]
-    fn assets_report_skipped_when_no_deck_path() {
+    fn assets_report_skipped_when_deck_does_not_exist() {
         let dir = tempfile::tempdir().unwrap();
         let env = passing_env(dir.path());
 
-        let report = run_doctor(None, &env);
+        let report = run_doctor(&dir.path().join("deck.md"), &env);
 
         let categories = report
             .checks
@@ -991,7 +991,7 @@ mod tests {
         fs::write(&deck, "# Intro\n").unwrap();
         fs::create_dir_all(dir.path().join("layouts")).unwrap();
 
-        let report = run_doctor(Some(&deck), &env);
+        let report = run_doctor(&deck, &env);
 
         let layouts = find_check(&report, DoctorCategory::Assets, "layouts");
         let css = find_check(&report, DoctorCategory::Assets, "css");
@@ -1021,7 +1021,7 @@ mod tests {
         fs::create_dir_all(dir.path().join("syntaxes")).unwrap();
         fs::create_dir_all(dir.path().join("fonts")).unwrap();
 
-        let report = run_doctor(Some(&deck), &env);
+        let report = run_doctor(&deck, &env);
 
         let categories = report
             .checks

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -324,7 +324,8 @@ enum Command {
         json: bool,
     },
     Doctor {
-        input: Option<PathBuf>,
+        #[arg(default_value = "deck.md")]
+        input: PathBuf,
         #[arg(long)]
         json: bool,
     },

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -3,7 +3,7 @@ use std::{
     env,
     ffi::OsString,
     fs,
-    io::{Read, Write},
+    io::{IsTerminal, Read, Write},
     path::{Component, Path, PathBuf},
     process::{Child, Stdio},
     sync::mpsc,
@@ -22,6 +22,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 
 mod asset_resolution;
+mod doctor;
 
 use asset_resolution::{resolve_assets, Provenance, ResolvedAssets};
 use peitho::{browser, server};
@@ -322,6 +323,11 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    Doctor {
+        input: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
     Preview {
         #[arg(default_value = "deck.md")]
         input: PathBuf,
@@ -404,6 +410,16 @@ fn main() -> miette::Result<()> {
             explain,
             json,
         } => cmd_layouts(input, explain, json),
+        Command::Doctor { input, json } => {
+            let env = doctor::DoctorEnv::from_process_env();
+            let mut stdout = std::io::stdout();
+            let is_terminal = stdout.is_terminal();
+            let code = doctor::dispatch(input, json, &env, &mut stdout, is_terminal)?;
+            if code != 0 {
+                std::process::exit(code);
+            }
+            Ok(())
+        }
         Command::Preview {
             input,
             port,
@@ -754,7 +770,7 @@ fn print_explain_json(
 
 fn source_json(source: &Provenance) -> SourceJson {
     SourceJson {
-        kind: provenance_kind(source).to_owned(),
+        kind: source.kind().to_owned(),
         path: source.path().map(|path| path.display().to_string()),
     }
 }
@@ -869,14 +885,6 @@ fn provenance_human(source: &Provenance) -> String {
         Provenance::Explicit(path) => format!("explicit ({})", path.display()),
         Provenance::DeckAdjacent(path) => format!("deck-adjacent ({})", path.display()),
         Provenance::Builtin => "built-in".to_owned(),
-    }
-}
-
-fn provenance_kind(source: &Provenance) -> &'static str {
-    match source {
-        Provenance::Explicit(_) => "explicit",
-        Provenance::DeckAdjacent(_) => "deck-adjacent",
-        Provenance::Builtin => "built-in",
     }
 }
 
@@ -1215,30 +1223,22 @@ fn describe_resolved_assets(assets: &ResolvedAssets) -> String {
     if let Some(path) = assets.layouts.path() {
         parts.push(format!(
             "layouts={}({})",
-            provenance_kind(&assets.layouts),
+            assets.layouts.kind(),
             path.display()
         ));
     }
     if let Some(path) = assets.css.path() {
-        parts.push(format!(
-            "css={}({})",
-            provenance_kind(&assets.css),
-            path.display()
-        ));
+        parts.push(format!("css={}({})", assets.css.kind(), path.display()));
     }
     if let Some(path) = assets.syntaxes.path() {
         parts.push(format!(
             "syntaxes={}({})",
-            provenance_kind(&assets.syntaxes),
+            assets.syntaxes.kind(),
             path.display()
         ));
     }
     if let Some(path) = assets.fonts.path() {
-        parts.push(format!(
-            "fonts={}({})",
-            provenance_kind(&assets.fonts),
-            path.display()
-        ));
+        parts.push(format!("fonts={}({})", assets.fonts.kind(), path.display()));
     }
     if parts.is_empty() {
         "none".to_owned()
@@ -1485,10 +1485,10 @@ fn copy_dir_contents(source: &Path, destination: &Path) -> miette::Result<()> {
 }
 
 #[derive(Debug, Clone)]
-struct ChromeLookupEnv {
-    env_path: Option<PathBuf>,
-    mac_chrome: PathBuf,
-    path_dirs: Vec<PathBuf>,
+pub(crate) struct ChromeLookupEnv {
+    pub(crate) env_path: Option<PathBuf>,
+    pub(crate) mac_chrome: PathBuf,
+    pub(crate) path_dirs: Vec<PathBuf>,
 }
 
 fn locate_chrome() -> miette::Result<PathBuf> {
@@ -1502,7 +1502,7 @@ fn locate_chrome() -> miette::Result<PathBuf> {
     })
 }
 
-fn locate_chrome_with_env(lookup: &ChromeLookupEnv) -> miette::Result<PathBuf> {
+pub(crate) fn locate_chrome_with_env(lookup: &ChromeLookupEnv) -> miette::Result<PathBuf> {
     if let Some(path) = &lookup.env_path {
         if path.is_file() {
             return Ok(path.clone());
@@ -2465,7 +2465,7 @@ impl ImageResolver {
             ));
         }
         let bytes = fs::read(&source_abs).map_err(|err| image_read_error(display_path, err))?;
-        let hash = short_sha256_hex(&bytes);
+        let hash = short_sha256_hex(&bytes, 16);
         if let Some(asset) = self.by_hash.get(&hash) {
             return Ok(asset.clone());
         }
@@ -2533,16 +2533,18 @@ fn image_read_error(path: &str, err: std::io::Error) -> peitho_core::BuildError 
     }
 }
 
-fn short_sha256_hex(bytes: &[u8]) -> String {
+pub(crate) fn short_sha256_hex(bytes: &[u8], hex_chars: usize) -> String {
     use std::fmt::Write as _;
 
     let mut hasher = Sha256::new();
     hasher.update(bytes);
     let hash: [u8; 32] = hasher.finalize().into();
-    let mut hex = String::with_capacity(16);
-    for byte in &hash[..8] {
+    let byte_count = hex_chars.div_ceil(2).min(hash.len());
+    let mut hex = String::with_capacity(byte_count * 2);
+    for byte in &hash[..byte_count] {
         write!(&mut hex, "{byte:02x}").expect("writing to String cannot fail");
     }
+    hex.truncate(hex_chars);
     hex
 }
 
@@ -4302,6 +4304,7 @@ contexts:
             }
             Command::Build { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -4327,6 +4330,7 @@ contexts:
             }
             Command::Build { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -4349,6 +4353,7 @@ contexts:
             }
             Command::Build { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
@@ -4368,6 +4373,7 @@ contexts:
             }
             Command::Build { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
@@ -4392,6 +4398,7 @@ contexts:
                 assert!(json);
             }
             Command::Build { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
@@ -4991,6 +4998,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
             }
             Command::Present { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -5010,6 +5018,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
             }
             Command::Build { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -5031,6 +5040,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
             }
             Command::Build { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
@@ -5072,6 +5082,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
             }
             Command::Present { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
@@ -5093,6 +5104,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
             }
             Command::Present { .. }
             | Command::Layouts { .. }
+            | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }

--- a/docs/plans/2026-07-11-peitho-doctor.md
+++ b/docs/plans/2026-07-11-peitho-doctor.md
@@ -1,0 +1,290 @@
+# `peitho doctor` — diagnose Chrome, displays, embedded shells, and assets
+
+Issue: #244. Adds a CLI subcommand that runs peitho's runtime dependencies
+through a battery of checks and reports pass/warn/fail with remediation
+hints for each, so a broken `present` / `preview` / `export pdf` session
+can be diagnosed without correlating error messages against the § Pitfalls
+lore in CLAUDE.md.
+
+## Design decisions
+
+- **Positional arg**: `peitho doctor [<deck.md>]`. No-arg runs
+  environment-only checks (Chrome, displays, embedded shells present).
+  With a deck path, adds deck-specific asset resolution checks.
+  Consistent with the shape of `peitho layouts` (Issue #243 / PR #247).
+- **Exit code**: non-zero (2) on any `fail`. `warn` does not fail the
+  exit code (so single-display laptops still exit 0). This matches the
+  precedent of `peitho layouts --explain` returning 2 for hard errors.
+- **Output**: one line per check, human-first by default with ANSI color
+  when `stdout` is a TTY (auto-detected via `std::io::IsTerminal`),
+  `--json` for programmatic use. Categories act as section headers in
+  human mode.
+- **Categories** (fixed order for deterministic output):
+  1. `chrome` — binary discovery + persistent profiles
+  2. `displays` — enumeration + multi-display availability (macOS only)
+  3. `embedded shells` — bundled `shell.js` / `preview.js` present at
+     compile time (satisfied by construction of the binary itself, but
+     surfaced so the user sees they exist and how big they are)
+  4. `assets` — deck-specific; only present when a deck path is given
+- **Statuses**: `pass` / `warn` / `fail`. Rules:
+  - `warn` = things that reduce peitho functionality but do not break
+    the golden path (e.g., only one display, no Chrome on Linux path
+    means present-mode will not work but build/preview will).
+  - `fail` = things that break the golden path (Chrome cannot be
+    located when required for `export pdf` / `present`; explicit
+    frontmatter asset path missing).
+- **Deck-mode does not require Chrome**: a deck with all-explicit
+  assets should be fully checkable even on a headless CI Linux box
+  without Chrome. Chrome discovery is still surfaced but stays a
+  warn/fail per the category rules, not a hard abort.
+
+## Non-goals
+
+- **No `bindings/` drift check** and **no committed-shell drift check**.
+  Both require the peitho source tree; the shipped binary sits outside
+  it. These are CI concerns (already covered by `git diff --exit-code`
+  in the § Gates section) rather than a runtime user surface.
+- **No "Chrome version known-good" check**. The known-good version
+  window drifts continually and encoding it in the binary would rot
+  faster than the pitfall it warns about. If a specific version becomes
+  actively broken, a follow-up can add a fail on that exact version;
+  today, reporting the discovered version and letting the user
+  cross-reference is enough.
+- **No "lingering Chrome process" check**. This is inherently a
+  `present`-time concern (peitho already terminates lingering processes
+  before opening); running it from `doctor` would be a snapshot that
+  goes stale the moment the user launches Chrome. Left to `present`.
+- **No `--json` schema stability guarantees** in this PR. The shape is
+  documented in the plan and mirrored in a snapshot test; a future
+  contract commitment can lock it down.
+- **No Linux display enumeration**. Issue #22 is deferred by author
+  decision (memory: `issue-22-linux-deferred`); doctor reports
+  "not implemented on non-macOS" as an informational skip, not a fail.
+
+## User surface
+
+### `peitho doctor [<deck.md>] [--json]`
+
+Human-readable output:
+
+```
+chrome
+  ✓ binary-discovered: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+  ✓ profiles-writable: /Users/alice/.peitho
+displays
+  ✓ enumeration: 2 display(s) found
+embedded shells
+  ✓ present-shell: 57769 bytes (sha256: b059b6eee546)
+  ✓ preview-shell: 27787 bytes (sha256: c7d6c317f284)
+
+5 passed, 0 warned, 0 failed
+```
+
+With `<deck.md>`, an `assets` section is appended:
+
+```
+assets
+  ✓ layouts: deck-adjacent ./layouts
+  ✓ css: built-in
+  ✗ syntaxes: syntaxes path does not exist: /Users/alice/deck/syntaxes/missing
+      help: fix the syntaxes: frontmatter value, or remove the key
+  ✓ fonts: built-in
+```
+
+`--json` shape:
+
+```json
+{
+  "checks": [
+    { "category": "chrome", "name": "binary-discovered", "status": "pass",
+      "message": "/Applications/Google Chrome.app/...", "help": null },
+    { "category": "chrome", "name": "profiles-writable", "status": "pass",
+      "message": "/Users/alice/.peitho", "help": null },
+    { "category": "displays", "name": "enumeration", "status": "pass",
+      "message": "2 display(s) found",
+      "details": [
+        { "primary": true, "x": 0, "y": 0, "width": 1920, "height": 1080 },
+        { "primary": false, "x": 1920, "y": 0, "width": 2560, "height": 1440 }
+      ]
+    },
+    { "category": "embedded-shells", "name": "present-shell", "status": "pass",
+      "message": "356532 bytes", "help": null },
+    { "category": "embedded-shells", "name": "preview-shell", "status": "pass",
+      "message": "176723 bytes", "help": null }
+  ],
+  "summary": { "pass": 5, "warn": 0, "fail": 0 }
+}
+```
+
+- One JSON object per check, `null` for absent fields (no
+  `serde(skip_serializing_if)`), so schema shape is stable.
+- Exit codes:
+  - `0` — everything passed or warned
+  - `2` — any check failed (mirrors `layouts --explain`)
+
+## Check catalog (implementation-level)
+
+### chrome
+- `binary-discovered`: reuse `locate_chrome_with_env` in `main.rs`. If
+  it succeeds, `pass` with the discovered path. If it fails, `fail`
+  with the existing help string (`install Google Chrome or ...`). The
+  `PEITHO_CHROME_PATH` env var is surfaced in the message when set.
+- `profiles-writable`: reuse `chrome_profiles_from_home` in
+  `browser.rs`. If `$HOME` is unset, `warn` (peitho would still work
+  for `build` / `preview` but `present` needs profiles). If the
+  `~/.peitho` root cannot be created (permission), `fail`. Actually
+  creating the profile subdirectories is deferred to `present`; doctor
+  only checks that the root is writable.
+
+### displays
+- `enumeration` (macOS only): call `detect_presentation_layout` via the
+  same osascript path, parse the display list, report count and
+  bounds. If enumeration fails, `warn` with help (`osascript may not be
+  installed, or NSScreen access may be denied`).
+- On non-macOS: emit one `skip` status (a new fourth status? or
+  degrade to `warn`?). To keep the model simple, use `warn` with a
+  message "not implemented on this platform (see Issue #22)".
+
+### embedded shells
+- Both `BUILTIN_SHELL_JS` and `BUILTIN_PREVIEW_JS` are `include_str!`d
+  at compile time, so their presence is compile-guaranteed. Report
+  their byte length and a short SHA-256 prefix (first 12 hex chars)
+  so a user comparing installs can see they match. This is the check
+  that is closest to a status-of-the-installed-binary readout.
+
+### assets (deck mode only)
+- For each of `layouts` / `css` / `syntaxes` / `fonts`: call
+  `resolve_assets` from `asset_resolution.rs`. Report the resolved
+  `Provenance` and path.
+- Explicit paths that fail existence are surfaced by `resolve_assets`
+  itself as a build error today; doctor should not abort on the first
+  failure but continue to report the remaining assets. Split the
+  resolution into per-asset calls in doctor (calling
+  `resolve_asset(...)` directly — currently `pub(crate)`, needs to be
+  exposed) so that one failing asset only fails its own check.
+
+**Implementation note on scope**: exposing `resolve_asset` per-key is a
+minor change and matches the doctor-mode requirement (independent
+per-asset results). Alternative — running `resolve_assets` and
+catching its first-error return — would only surface the first
+failure and hide the rest. The per-key exposure is the root-cause
+factoring.
+
+## Code structure
+
+New file: `crates/peitho/src/doctor.rs` (or a submodule of `main.rs` if
+small — start as a separate module to keep `main.rs` from growing
+past its already-large 5,500 LOC).
+
+Shape:
+
+```rust
+pub struct DoctorReport {
+    pub checks: Vec<DoctorCheck>,
+}
+
+pub struct DoctorCheck {
+    pub category: DoctorCategory,
+    pub name: &'static str,
+    pub status: DoctorStatus,
+    pub message: String,
+    pub help: Option<String>,
+    pub details: Option<serde_json::Value>,
+}
+
+pub enum DoctorCategory { Chrome, Displays, EmbeddedShells, Assets }
+pub enum DoctorStatus { Pass, Warn, Fail }
+
+pub fn run_doctor(deck: Option<&Path>, env: &DoctorEnv) -> DoctorReport;
+```
+
+Wire-up in `main.rs`:
+
+- Add `Command::Doctor { input: Option<PathBuf>, json: bool }` to the
+  `Command` enum.
+- Add `mod doctor;` and dispatch from `main`.
+- Print the report via `doctor::print_human` or `doctor::print_json`
+  and return the correct exit code.
+
+## Testing plan (TDD)
+
+Unit tests live alongside `doctor.rs`. All use dependency injection
+(`DoctorEnv`) so no real Chrome / display / filesystem access happens
+in unit tests. The pattern is already established by
+`locate_chrome_with_env` in `main.rs`.
+
+Red-Green-Refactor cycles:
+
+1. `chrome_binary_discovered_reports_pass` — when `locate_chrome_with_env`
+   would return `Ok`, doctor reports `pass` with the path.
+2. `chrome_binary_missing_reports_fail_with_help` — when
+   `locate_chrome_with_env` errors, doctor reports `fail` and the help
+   string is included.
+3. `chrome_profiles_writable_reports_pass_for_existing_home` — with a
+   writable `HOME` tempdir, doctor reports `pass`.
+4. `chrome_profiles_reports_warn_when_home_unset` — no `HOME`, `warn`.
+5. `chrome_profiles_reports_fail_when_root_readonly` — mkdir denies,
+   `fail`. (`#[cfg(unix)]` gated because chmod semantics.)
+6. `displays_enumeration_reports_pass_with_counts` — feed a fixture
+   JSON via a test-only `DoctorEnv::displays_provider`; assert
+   `pass`, count, and bounds details.
+7. `displays_enumeration_reports_warn_when_provider_returns_none` —
+   `warn` with help.
+8. `displays_reports_warn_on_non_macos` — when
+   `DoctorEnv::platform == BrowserPlatform::Linux`, `warn` with a
+   pointer to Issue #22.
+9. `embedded_shells_report_present_shell_with_byte_count` — asserts the
+   `pass` and the exact byte length matches
+   `BUILTIN_SHELL_JS.len()`.
+10. `embedded_shells_report_preview_shell_with_byte_count` — same
+    for preview.
+11. `assets_report_skipped_when_no_deck_path` — no `Assets` category
+    lines.
+12. `assets_report_provenance_for_each_asset` — synthesize a tempdir
+    deck with a `layouts/` sibling and no others; assert deck-adjacent
+    / built-in provenance is reported per asset.
+13. `assets_report_fail_for_missing_explicit_path` — frontmatter
+    points at nonexistent path; that asset alone gets `fail`, other
+    assets still get their own status.
+14. `run_doctor_exit_code_is_pass_when_all_pass` — helper
+    `exit_code_for(&report)` returns 0.
+15. `run_doctor_exit_code_is_fail_when_any_fail` — returns 2.
+16. `run_doctor_warn_does_not_fail_exit_code` — returns 0.
+17. `print_human_writes_category_headers_and_status_glyphs` — string
+    match on stdout.
+18. `print_human_uses_no_color_when_not_tty` — inject
+    `is_terminal=false`, assert no ANSI escapes.
+19. `print_json_shape_is_stable_categories_names_and_details` —
+    snapshot the JSON keys, not the values.
+20. `cli_dispatch_calls_run_doctor_and_exits_with_code` — top-level
+    integration test through `Cli::parse_from`.
+
+Cover the invariants that matter:
+- Fixed check-order (deterministic output).
+- Warn vs fail exit-code split.
+- All-explicit-assets deck runs clean without Chrome.
+- Non-macOS still passes doctor with a warn for displays.
+
+## Rollout
+
+- New subcommand, no changes to existing subcommands or their exit
+  codes. Adding a `Doctor` variant to the `Command` enum is
+  backward-compatible (clap dispatches by explicit variant name).
+- Bindings: no changes to core / no new TS types (doctor is
+  CLI-side only, does not touch the manifest/notes contract). Skip
+  `git diff --exit-code bindings/`.
+- Shell / preview drift: no changes. Skip the npm-side rebuild step.
+- Update the guide (`site/content/guide/*`) with a doctor entry after
+  the plan lands.
+
+## Records this plan supersedes / references
+
+- Issue #244 (proposal).
+- Issue #22 (Linux display enumeration; deferred, referenced in the
+  displays check).
+- `docs/plans/2026-07-10-peitho-layouts.md` (structural precedent for
+  a read-only introspection subcommand).
+- `crates/peitho/src/asset_resolution.rs` (`resolve_assets` /
+  `Provenance` — the shape the assets check reports).
+- CLAUDE.md § Pitfalls (the pain points doctor is designed to
+  short-cut).

--- a/docs/plans/2026-07-11-peitho-doctor.md
+++ b/docs/plans/2026-07-11-peitho-doctor.md
@@ -8,9 +8,10 @@ lore in CLAUDE.md.
 
 ## Design decisions
 
-- **Positional arg**: `peitho doctor [<deck.md>]`. No-arg runs
+- **Positional arg**: `peitho doctor [<deck.md>]`, defaulting to
+  `deck.md` when omitted. If the deck file does not exist, doctor runs
   environment-only checks (Chrome, displays, embedded shells present).
-  With a deck path, adds deck-specific asset resolution checks.
+  When the deck file exists, it adds deck-specific asset resolution checks.
   Consistent with the shape of `peitho layouts` (Issue #243 / PR #247).
 - **Exit code**: non-zero (2) on any `fail`. `warn` does not fail the
   exit code (so single-display laptops still exit 0). This matches the
@@ -25,7 +26,7 @@ lore in CLAUDE.md.
   3. `embedded shells` — bundled `shell.js` / `preview.js` present at
      compile time (satisfied by construction of the binary itself, but
      surfaced so the user sees they exist and how big they are)
-  4. `assets` — deck-specific; only present when a deck path is given
+  4. `assets` — deck-specific; only present when the deck file exists
 - **Statuses**: `pass` / `warn` / `fail`. Rules:
   - `warn` = things that reduce peitho functionality but do not break
     the golden path (e.g., only one display, no Chrome on Linux path
@@ -195,13 +196,13 @@ pub struct DoctorCheck {
 pub enum DoctorCategory { Chrome, Displays, EmbeddedShells, Assets }
 pub enum DoctorStatus { Pass, Warn, Fail }
 
-pub fn run_doctor(deck: Option<&Path>, env: &DoctorEnv) -> DoctorReport;
+pub fn run_doctor(deck: &Path, env: &DoctorEnv) -> DoctorReport;
 ```
 
 Wire-up in `main.rs`:
 
-- Add `Command::Doctor { input: Option<PathBuf>, json: bool }` to the
-  `Command` enum.
+- Add `Command::Doctor { input: PathBuf, json: bool }` to the
+  `Command` enum, with `input` defaulting to `deck.md`.
 - Add `mod doctor;` and dispatch from `main`.
 - Print the report via `doctor::print_human` or `doctor::print_json`
   and return the correct exit code.
@@ -238,8 +239,8 @@ Red-Green-Refactor cycles:
    `BUILTIN_SHELL_JS.len()`.
 10. `embedded_shells_report_preview_shell_with_byte_count` — same
     for preview.
-11. `assets_report_skipped_when_no_deck_path` — no `Assets` category
-    lines.
+11. `assets_report_skipped_when_deck_does_not_exist` — no `Assets`
+    category lines.
 12. `assets_report_provenance_for_each_asset` — synthesize a tempdir
     deck with a `layouts/` sibling and no others; assert deck-adjacent
     / built-in provenance is reported per asset.


### PR DESCRIPTION
## Summary

- Adds `peitho doctor [<deck.md>] [--json]` — a diagnostic command that reports pass/warn/fail with remediation hints for Chrome discovery, macOS display enumeration, embedded present/preview shells, and (when a deck path is given) per-key asset resolution. Exit code 2 on any fail.
- Full DI via `DoctorEnv`: unit tests exercise every branch without spawning Chrome, running osascript, or touching the user's HOME.
- Refactors `resolve_asset` to return `Result<Provenance, BuildError>` so doctor consumes structured `message` / `help` fields directly (was previously round-tripping through `Display`). Preserves the existing all-or-nothing `resolve_assets` API for build/preview/present/export.
- Replaces the `&str` key + `_ => panic!` in `resolve_asset` with an exhaustive `AssetKey` enum, in line with the CLAUDE.md rule against type-shape-weakening wildcards.
- Profile writability probe never leaves stray files or an empty `~/.peitho` behind, and treats `AlreadyExists` as pass to close a TOCTOU with concurrent `peitho present`.
- Shares `provenance_kind` / `short_sha256_hex` with the layouts command instead of duplicating them.

Closes #244

## Sample output

```
$ peitho doctor examples/minimal/deck.md
chrome
  ✓ binary-discovered: /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
  ✓ profiles-writable: /Users/alice/.peitho
displays
  ⚠ enumeration: 1 display(s) found
      help: connect an external display for presenter mode
embedded shells
  ✓ present-shell: 57769 bytes (sha256: b059b6eee546)
  ✓ preview-shell: 27787 bytes (sha256: c7d6c317f284)
assets
  ✓ layouts: built-in
  ✓ css: built-in
  ✓ syntaxes: built-in
  ✓ fonts: built-in

8 passed, 1 warned, 0 failed
```

Design record: `docs/plans/2026-07-11-peitho-doctor.md`.

## Test plan

- [x] `cargo test --workspace` (3 consecutive runs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
- [x] `git diff --exit-code packages/peitho-present/dist/shell.js packages/peitho-present/dist/preview.js`
- [x] Manual smoke: `peitho doctor`, `peitho doctor <deck.md>`, `peitho doctor --json` (on macOS, HOME writable, single display).
- [x] Manual side-effect check: `HOME=$(mktemp -d) peitho doctor` leaves `$HOME` empty (no `.peitho/`, no stray probe files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC