### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.3.3"
+version = "1.4.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.3.3"
+version = "1.4.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## Summary

Version bump to 1.4.0. Minor bump because multiple new features shipped since v1.3.3.

## Changes since v1.3.3

### New Features

- feat: `code_images:` frontmatter for build-time SVG conversion (#251)
- feat: add `peitho doctor` subcommand for runtime diagnostics (#250)
- feat: add `breaks` frontmatter option for hard line breaks (#249)
- feat: add `peitho layouts` subcommand and Provenance-typed asset resolution (#247)

### Docs

- docs: document code_images in README and guide (#254)

## Test plan

- [x] `cargo test --workspace` (3 runs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `npm install && npm run build && npm test && npm run typecheck` in `packages/peitho-present`
- [x] embedded shell/preview drift check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
