### PR TITLE
fix(render): wrap image slot fragments in slot-<name> div

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -163,11 +163,14 @@ fn render_slot(
                 .join("\n");
             format!(r#"<pre class="{class_name}"><code>{body}</code></pre>"#)
         }
-        Accepts::Image => fragments
-            .iter()
-            .map(render_image_fragment)
-            .collect::<Result<Vec<_>>>()?
-            .join("\n"),
+        Accepts::Image => {
+            let body = fragments
+                .iter()
+                .map(render_image_fragment)
+                .collect::<Result<Vec<_>>>()?
+                .join("\n");
+            format!(r#"<div class="{class_name}">{body}</div>"#)
+        }
         Accepts::Blocks | Accepts::Text | Accepts::List => {
             render_block_slot(&class_name, accepts, fragments, breaks)?
         }
@@ -1003,6 +1006,36 @@ mod tests {
         parse_markdown_impl(source, frontmatter, highlighter)
     }
 
+    fn render_image_slot_html(
+        slot_name: &str,
+        fragments: Vec<SourceFragment<ResolvedImagePath>>,
+    ) -> String {
+        let layout_html = format!(
+            r#"<section><figure><slot name="{slot_name}" accepts="image" arity="0..*"></slot></figure></section>"#
+        );
+        let layout = parse_layout("visual", &layout_html).unwrap();
+        let slot = SlotName::new(slot_name).unwrap();
+        let contract = layout.slot(slot_name).unwrap().clone();
+        let mut slots = BTreeMap::new();
+        slots.insert(slot, CheckedSlot::new(contract, fragments));
+        let checked = Deck::checked(
+            DeckSettings::default(),
+            vec![CheckedSlide::new(
+                0,
+                SlideKey::new("visual").unwrap(),
+                layout,
+                slots,
+                None,
+            )],
+        );
+
+        render_deck(checked, &crate::highlight::Highlighter::defaults())
+            .unwrap()
+            .slides()[0]
+            .html()
+            .to_owned()
+    }
+
     #[test]
     fn renders_checked_slide_with_key_and_slot_classes() {
         let markdown = "<!-- {\"key\":\"arch-1\"} -->\n# **Architecture** `Phase`\n\nBody\n\n```rust\nfn main() {}\n```";
@@ -1141,42 +1174,69 @@ mod tests {
 
     #[test]
     fn renders_image_with_resolved_src_and_escaped_alt() {
-        let layout = parse_layout(
-            "visual",
-            r#"<section><figure><slot name="hero" accepts="image" arity="1"></slot></figure></section>"#,
-        )
-        .unwrap();
-        let hero = SlotName::new("hero").unwrap();
-        let contract = layout.slot("hero").unwrap().clone();
-        let mut slots = BTreeMap::new();
-        slots.insert(
-            hero,
-            CheckedSlot::new(
-                contract,
-                vec![SourceFragment::image(
-                    3,
-                    "<Diagram>, \"Notes\" & emoji 🎉",
-                    ResolvedImagePath::from_string("assets/xxx.png".to_owned()),
-                )],
-            ),
-        );
-        let checked = Deck::checked(
-            DeckSettings::default(),
-            vec![CheckedSlide::new(
-                0,
-                SlideKey::new("visual").unwrap(),
-                layout,
-                slots,
-                None,
+        let html = render_image_slot_html(
+            "image",
+            vec![SourceFragment::image(
+                3,
+                "<Diagram>, \"Notes\" & emoji 🎉",
+                ResolvedImagePath::from_string("assets/xxx.png".to_owned()),
             )],
         );
 
-        let rendered = render_deck(checked, &crate::highlight::Highlighter::defaults()).unwrap();
-        let html = rendered.slides()[0].html();
+        assert!(html.contains(
+            r#"<div class="slot-image"><img src="assets/xxx.png" alt="&lt;Diagram&gt;, &quot;Notes&quot; &amp; emoji 🎉"></div>"#
+        ));
+    }
+
+    #[test]
+    fn renders_image_slot_class_matches_slot_name() {
+        let html = render_image_slot_html(
+            "hero",
+            vec![SourceFragment::image(
+                3,
+                "Hero image",
+                ResolvedImagePath::from_string("assets/hero.png".to_owned()),
+            )],
+        );
 
         assert!(html.contains(
-            r#"<img src="assets/xxx.png" alt="&lt;Diagram&gt;, &quot;Notes&quot; &amp; emoji 🎉">"#
+            r#"<div class="slot-hero"><img src="assets/hero.png" alt="Hero image"></div>"#
         ));
+        assert!(!html.contains(r#"<div class="slot-image">"#));
+    }
+
+    #[test]
+    fn renders_multiple_images_in_single_image_slot_wrapper() {
+        let html = render_image_slot_html(
+            "image",
+            vec![
+                SourceFragment::image(
+                    3,
+                    "First image",
+                    ResolvedImagePath::from_string("assets/first.png".to_owned()),
+                ),
+                SourceFragment::image(
+                    4,
+                    "Second image",
+                    ResolvedImagePath::from_string("assets/second.png".to_owned()),
+                ),
+            ],
+        );
+
+        assert_eq!(html.matches(r#"<div class="slot-image">"#).count(), 1);
+        assert_eq!(html.matches("<img ").count(), 2);
+        assert!(html.contains(
+            r#"<div class="slot-image"><img src="assets/first.png" alt="First image">
+<img src="assets/second.png" alt="Second image"></div>"#
+        ));
+    }
+
+    #[test]
+    fn renders_empty_image_slot_without_slot_image_wrapper() {
+        let html = render_image_slot_html("image", Vec::new());
+
+        assert!(!html.contains(r#"class="slot-image""#));
+        assert!(!html.contains("<img "));
     }
 
     #[test]

--- a/docs/plans/2026-07-12-issue-253-slot-image-class.md
+++ b/docs/plans/2026-07-12-issue-253-slot-image-class.md
@@ -1,0 +1,57 @@
+# Issue #253: slot-image wrapper for image slot fragments
+
+## Problem
+
+`render_slot` emits `<span class="slot-<name>">`, `<pre class="slot-<name>"><code>`, or `<div class="slot-<name>">` wrappers for inline / code / block slot kinds, but the `Accepts::Image` branch (crates/peitho-core/src/render.rs:166) joins bare `<img>` tags without a slot-carrying container. Layout / theme authors reaching for `:has(.slot-image)` — the pattern every other slot supports — get a silent no-op. This bit the `examples/code-images/` deck's rendered pane (PR #251, commit `9a7e6b2`) and had to be worked around with `:has(.rendered-pane img)`.
+
+## Decision — Option 1: `<div class="slot-image">` wrapper
+
+Author decision (2026-07-12): wrap all image fragments of a single image slot in one `<div class="slot-image">…</div>`.
+
+Considered:
+- **Option 2** (document the bareness) — leaves the trap in place. Rejected by issue framing.
+- **Option 3** (`class="slot-image"` on each `<img>`) — one class per image, breaks the "1 slot = 1 class instance in the DOM" shape that block slots have. If a future slot rendering needs a caption or a grid of images, the markup shape has to change; Option 1 leaves room in the wrapper.
+
+Option 1 aligns with `Accepts::Blocks | Text | List` (single `<div class="slot-<name>">` wrapping all fragments of that slot). Inline (`<span>`) and code (`<pre>`) are also single-container per slot — Option 1 keeps image consistent with that invariant. The class rides the outermost rendered element for every slot kind.
+
+## Change
+
+`crates/peitho-core/src/render.rs`:
+
+```rust
+Accepts::Image => {
+    let body = fragments
+        .iter()
+        .map(render_image_fragment)
+        .collect::<Result<Vec<_>>>()?
+        .join("\n");
+    format!(r#"<div class="{class_name}">{body}</div>"#)
+}
+```
+
+Behavior: exactly one `<div class="slot-image">` per image slot, containing 1..N `<img>` children (arity is enforced upstream by check.rs, so `fragments.is_empty()` early-returns as before at line 144). Empty slots continue to emit nothing (no empty wrapper).
+
+## Tests
+
+- Update `renders_image_with_resolved_src_and_escaped_alt` (crates/peitho-core/src/render.rs:1142) to assert both the `<div class="slot-image">` wrapper and the wrapped `<img>` (escaping unchanged).
+- Add a multi-image image-slot test: two `SourceFragment::image` fragments produce one wrapper with two `<img>` children.
+- Add an assertion that a slot with zero image fragments emits no `slot-image` wrapper (the `if fragments.is_empty()` guard).
+
+## Non-changes
+
+- No changes to `Accepts::Image` in check.rs or mapping.rs. The slot contract is unchanged.
+- No changes to `examples/code-images/`. The existing `:not(:has(img))` selector keeps working; a future PR can migrate it to `:not(:has(.slot-image))` if desired, but that is not part of this issue's scope (this issue is about consistency at the renderer level).
+- No bindings changes — this is a render-time HTML shape change only. `bindings/*.ts` are Rust-domain types; the emitted HTML is not part of that contract.
+- No shell/preview changes — the class lives in slide HTML, not the shell.
+
+## Verification
+
+Standard gates:
+- `cargo test --workspace` (3 runs)
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all --check`
+- `git diff --exit-code bindings/` (should be clean)
+- `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
+- `git diff --exit-code packages/peitho-present/dist/{shell,preview}.js`
+
+E2E: rebuild `examples/code-images/` and grep the emitted HTML for `class="slot-image"`. Confirm the deck still renders (workaround selector `:not(:has(img))` continues to match).


### PR DESCRIPTION
Closes #253

## Summary

Image slots rendered as bare `<img>` tags without the `slot-<name>` wrapper class that every other `Accepts` kind emits. Layout / theme authors reaching for `:has(.slot-image)` — the natural mental model given every other slot's shape — got a silent no-op. This bit the `examples/code-images/` deck (see PR #251, commit `9a7e6b2`) and had to be worked around with `:has(.rendered-pane img)`.

## Change

`crates/peitho-core/src/render.rs`, `Accepts::Image` branch of `render_slot`: wrap all image fragments of a slot in a single `<div class="slot-<name>">...</div>`.

Shape after the change (all four slot kinds now put the class on the outermost rendered element):

| Accepts | Wrapper |
|---|---|
| `Inline` | `<span class="slot-<name>">…</span>` |
| `Code` | `<pre class="slot-<name>"><code>…</code></pre>` |
| `Blocks` / `Text` / `List` | `<div class="slot-<name>">…</div>` |
| `Image` (**new**) | `<div class="slot-<name>">…</div>` |

The class name still derives from `SlotName` — a slot declared `<slot name="hero" accepts="image">` produces `<div class="slot-hero">`, matching the existing per-slot naming convention. This is pinned by a new test.

## Design choice — Option 1 (wrapper `<div>`)

Issue #253 listed three options. Considered:

- **Option 2** (document the bareness) — leaves the trap in place; the issue framing rejects it.
- **Option 3** (`class="slot-image"` directly on each `<img>`) — one class per image, breaks the "1 slot = 1 class instance in the DOM" shape that block slots have. Future extensions (caption, image grid) would force a markup shape change.
- **Option 1** (wrapper `<div>`, this PR) — aligns with `Accepts::Blocks | Text | List` (single wrapper containing all fragments). Room in the wrapper for future extensions. Consistent semantics with other block-emitting kinds.

## Tests

Refactored the existing image render test into a parameterized helper `render_image_slot_html(slot_name, fragments)` and added three cases:

- `renders_image_slot_class_matches_slot_name` — slot named "hero" produces `<div class="slot-hero">`, not `<div class="slot-image">`. Pins the class-derives-from-SlotName invariant (matches how `Inline`/`Blocks`/`Code` prove this via slot names distinct from the accepts keyword).
- `renders_multiple_images_in_single_image_slot_wrapper` — two image fragments produce exactly one `<div class="slot-image">` containing both `<img>` tags.
- `renders_empty_image_slot_without_slot_image_wrapper` — empty image slot emits nothing (the existing `fragments.is_empty()` early return).

Existing `renders_image_with_resolved_src_and_escaped_alt` was updated to assert the wrapper alongside preserved HTML escaping.

## Scope

- **Included**: only `crates/peitho-core/src/render.rs` and the plan doc.
- **Not touched**: `examples/code-images/` CSS. The existing `:not(:has(img))` workaround continues to work; migration to `.slot-image` is out of scope for this PR (authors can pick it up as they update themes).
- **Not touched**: `check.rs`, `mapping.rs`, `bindings/*`. This is a render-time HTML shape change; the slot contract is unchanged. Bindings are Rust-domain types and stay clean.

## Test plan

- [x] `cargo test --workspace` (3 runs, all pass; 365 unit tests, 1 integration, 2 doctests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
- [x] `git diff --exit-code packages/peitho-present/dist/{shell,preview}.js`
- [x] E2E: `peitho build examples/code-images/deck.md` — verified `class="slot-image"` in output HTML and the deck still renders correctly with the existing workaround selector.