### PR TITLE
fix(examples): drop cascade-colliding width/height on layout root classes

### DIFF
--- a/examples/code-images/css/base.css
+++ b/examples/code-images/css/base.css
@@ -9,8 +9,6 @@
 }
 
 .code-images {
-  width: 100%;
-  height: 100%;
   box-sizing: border-box;
   padding: 54px 64px;
 }

--- a/examples/two-column/css/base.css
+++ b/examples/two-column/css/base.css
@@ -27,8 +27,6 @@
 }
 
 .two-column {
-  width: 100%;
-  height: 100%;
   padding: 56px 64px 48px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #256

## Root cause

Layout HTML places `.code-images` (and `.two-column`) on the same `<section>` element that the renderer decorates with `.peitho-slide`. Both classes had `width: 100%; height: 100%` at equal specificity (0,1,0) to `.peitho-slide`'s `width: var(--peitho-canvas-width, 1280px)`. Source order let them win, so the slide sized to its parent (1920px inside `.peitho-slide-wrap`) instead of the 1280px canvas. Combined with `transform: scale(1.5)` in PDF export, the right column overflowed the page edge.

The HTML shell happened to size its container to the canvas var, so `width: 100%` there resolved to 1280px and masked the bug — the overflow only surfaced in PDF export.

## Fix

Remove the redundant `width` / `height` declarations from `.code-images` and `.two-column`. `.peitho-slide` already provides the canvas dimensions.

Issue #256 identified `examples/code-images/css/base.css`. During review I found the same anti-pattern in `examples/two-column/css/base.css` (also reproduced: `slot=right` column overflowing the page) and fixed it in the same PR per the "no per-symptom carve-outs" rule. Sweep of remaining example decks (`image-showcase`, `keynote`, `lightning-talk`, `code-walkthrough`, `peitho-tour`) confirmed none carries this pattern.

## Verification

Rendered before/after PDFs for both decks with `peitho export pdf` and confirmed:

- `code-images` slide 2 (Graphviz): diagram nodes previously clipped at the page edge now fit fully with the pane border visible.
- `two-column` slide 1: right column previously overflowing now sits inside the page with proper margins.
- HTML build (`peitho build`) still renders correctly — no regression in the presentation path.

## Gates

- `cargo test --workspace` — 3 runs, all pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo fmt --all --check` — pass
- `git diff --exit-code bindings/` — clean
- `packages/peitho-present`: `npm run build`, `npm test` (185 tests), `npm run typecheck` — pass
- `git diff --exit-code packages/peitho-present/dist/{shell.js,preview.js}` — no drift