### PR TITLE
fix(presenter): keep measured section actuals visible on revisited agenda rows

### DIFF
--- a/docs/plans/2026-07-12-issue-258-agenda-revisit-actual.md
+++ b/docs/plans/2026-07-12-issue-258-agenda-revisit-actual.md
@@ -1,0 +1,63 @@
+# Issue #258: keep measured actual time visible on revisited agenda sections
+
+Date: 2026-07-12
+Issue: #258
+Amends: `docs/specs/2026-07-04-presenter-agenda-design.md` (display semantics of
+upcoming rows that carry a measured actual)
+
+## Problem
+
+The presenter agenda classifies rows purely by the current slide's section
+index (`agendaState`: `done` / `current` / `upcoming`). When the presenter
+navigates back to a slide in an earlier section, every later section is
+re-labeled `upcoming`, and `actualText` in
+`packages/peitho-present/src/agenda.ts` unconditionally rendered the em dash
+for `upcoming` rows. A section that had already accumulated actual time
+therefore snapped back to `— / <planned>` as if it had never been visited.
+
+The stored value was never lost — `actualMs[index]` keeps accumulating
+correctly — only the render suppressed it.
+
+## Fix
+
+Display-layer change at the single render seam, per the direction suggested
+in the issue:
+
+```ts
+function actualText(state: AgendaState, actual: number): string {
+  return actual > 0 || state !== "upcoming" ? formatMinuteSeconds(actual) : EM_DASH;
+}
+```
+
+A measured actual (`> 0`) renders regardless of state; the em dash remains
+only for upcoming sections with no accumulated time (never visited, or
+zeroed by a timer reset).
+
+Nothing else changes:
+
+- `agendaState` classification stays as-is.
+- The outcome styling gate stays state-driven (`outcome` remains `null` for
+  `upcoming`) — the issue explicitly keeps styling semantics on the state
+  class.
+- `deltaText` still shows the delta only for `done` — the issue explicitly
+  defers whether a revisited-then-left section should show a delta.
+- Accumulation (`flushElapsedToSectionOf` / `tick` / reset handling) is
+  untouched.
+
+## Tests
+
+In `packages/peitho-present/test/agenda.test.ts`:
+
+- Updated "accumulates elapsed deltas into the current section and resumes
+  when returning": the revisited-but-not-current section now expects its
+  measured `0:02 / 0:01` instead of the previously locked-in `— / 0:01`,
+  and after a timer reset the same row is asserted to return to `— / 0:01`.
+- Added "renders never-visited upcoming sections with a dash actual" to pin
+  that the em dash still appears for sections with no measured time.
+
+## Known edge (accepted)
+
+A section transited for under ~500ms accumulates a positive actual that
+rounds to `0:00`, so it renders `0:00 / <planned>` rather than the dash.
+That is the intended "visited" semantics of the `> 0` predicate from the
+issue.

--- a/docs/specs/2026-07-04-presenter-agenda-design.md
+++ b/docs/specs/2026-07-04-presenter-agenda-design.md
@@ -77,6 +77,7 @@ presenter.ts / agenda.ts (new) consume shell.manifest.sections
 - `done`/`current`/`upcoming` are decided by the current slide's position: current = the section the current slide belongs to, done = anything before it, upcoming = anything after. Going back to a previous section makes it current again
 - `under`/`over` on done is decided live. The sole judgment source is the **second-rounded difference** `Math.round((actual − planned) / 1000)` — so the sign and color of the delta display are structurally consistent (using raw milliseconds would produce contradictions like "+0:00 shown as over" and "just-on-target shown as −0:00 under"; finalized during implementation review 2026-07-04). Rounded delta > 0 → `over`, otherwise `under`
 - When the timer is not started (stopped), all section actuals are 0. Following the mock, done/current show `actual / planned`, upcoming shows `— / planned`, and delta is shown only for done as `±M:SS` (current/upcoming show `·`)
+- Amendment (2026-07-12, Issue #258): an upcoming section that already accumulated a measured actual (revisit scenario — the presenter navigated back to an earlier section) keeps showing `actual / planned`; the `—` placeholder applies only while the stored actual is 0 (never visited, or zeroed by reset). See `docs/plans/2026-07-12-issue-258-agenda-revisit-actual.md`
 - Time display uses the same `m:ss` format as the tracker ticks (shared with the existing formatter in `timeTracker.ts`)
 
 ## Implementation placement

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -295,7 +295,7 @@ function agendaState(index, currentSection) {
   return "upcoming";
 }
 function actualText(state, actual) {
-  return state === "upcoming" ? EM_DASH : formatMinuteSeconds(actual);
+  return actual > 0 || state !== "upcoming" ? formatMinuteSeconds(actual) : EM_DASH;
 }
 function formatSlideRange(section) {
   const start = String(section.startIndex + 1).padStart(2, "0");

--- a/packages/peitho-present/src/agenda.ts
+++ b/packages/peitho-present/src/agenda.ts
@@ -189,7 +189,7 @@ function agendaState(index: number, currentSection: number): AgendaState {
 }
 
 function actualText(state: AgendaState, actual: number): string {
-  return state === "upcoming" ? EM_DASH : formatMinuteSeconds(actual);
+  return actual > 0 || state !== "upcoming" ? formatMinuteSeconds(actual) : EM_DASH;
 }
 
 function formatSlideRange(section: ManifestSection): string {

--- a/packages/peitho-present/test/agenda.test.ts
+++ b/packages/peitho-present/test/agenda.test.ts
@@ -146,6 +146,26 @@ it("renders agenda header and rows with mock-compatible structure", () => {
   expect(rows[1].hasAttribute("data-peitho-agenda-outcome")).toBe(false);
 });
 
+it("renders never-visited upcoming sections with a dash actual", () => {
+  const root = document.createElement("div");
+  const cleanup = installAgenda({
+    root,
+    shell: shell({ currentIndex: 0 }),
+    sections: [
+      { name: "Setup", startIndex: 0, endIndex: 0, plannedDurationMs: 1_000 },
+      { name: "Demo", startIndex: 1, endIndex: 1, plannedDurationMs: 2_000 }
+    ],
+    bus: new EventTarget(),
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  const rows = Array.from(root.querySelectorAll<HTMLElement>("[data-peitho-agenda-row]"));
+  expect(rows[1].dataset.peithoAgendaState).toBe("upcoming");
+  expect(rows[1].querySelector("[data-peitho-agenda-time]")?.textContent).toBe("— / 0:02");
+});
+
 it("marks the current agenda row over only after exceeding planned duration", () => {
   let elapsed = 0;
   const root = document.createElement("div");
@@ -279,7 +299,7 @@ it("accumulates elapsed deltas into the current section and resumes when returni
     root.querySelectorAll("[data-peitho-agenda-time]"),
     (node) => node.textContent
   );
-  expect(times).toEqual(["0:02 / 0:01", "— / 0:01"]);
+  expect(times).toEqual(["0:02 / 0:01", "0:02 / 0:01"]);
 
   rows = Array.from(root.querySelectorAll<HTMLElement>("[data-peitho-agenda-row]"));
   expect(rows[0].dataset.peithoAgendaState).toBe("current");
@@ -297,6 +317,12 @@ it("accumulates elapsed deltas into the current section and resumes when returni
   expect(rows[0].dataset.peithoAgendaOutcome).toBe("over");
   expect(rows[0].querySelector("[data-peitho-agenda-delta]")?.textContent).toBe("+0:01");
 
+  currentIndex = 0;
+  bus.dispatchEvent(
+    new CustomEvent<SlideChangeDetail>("peitho:slidechange", {
+      detail: { key: "setup", index: 0, total: 3, previousIndex: 2 }
+    })
+  );
   elapsed = 0;
   timerStarted = false;
   bus.dispatchEvent(
@@ -306,6 +332,11 @@ it("accumulates elapsed deltas into the current section and resumes when returni
   );
   vi.advanceTimersByTime(250);
   expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:00 / 0:01");
+  const resetTimes = Array.from(
+    root.querySelectorAll("[data-peitho-agenda-time]"),
+    (node) => node.textContent
+  );
+  expect(resetTimes[1]).toBe("— / 0:01");
 });
 
 it("clears actuals immediately when the timer is reset before restarting", () => {


### PR DESCRIPTION
Closes #258

## Problem

The presenter agenda classifies rows purely by the current slide's section index. Navigating back to a slide in an earlier section re-labels every later section `upcoming`, and `actualText()` unconditionally rendered the em dash for `upcoming` rows — so a section that had already accumulated actual time snapped back to `— / <planned>` as if never visited. The stored `actualMs` value was intact; only the render suppressed it.

## Fix

Display-layer change at the single render seam (`actualText` in `packages/peitho-present/src/agenda.ts`): render the stored actual whenever it is `> 0` regardless of state; the em dash remains only for upcoming rows with no measured time (never visited, or zeroed by a timer reset).

Unchanged per the issue's explicit scoping:
- `agendaState` classification and the state-driven outcome styling gate (`outcome` stays `null` for `upcoming`)
- the delta column stays done-only (the issue defers revisited-section deltas as a follow-up decision)

Known accepted edge (documented in the plan doc): a section transited for under ~500ms accumulates a positive actual that rounds to `0:00`, so it renders `0:00 / <planned>` rather than the dash — the issue's own `> 0` predicate.

## Tests

- Updated "accumulates elapsed deltas into the current section and resumes when returning": the revisited-but-not-current section now keeps its measured `0:02 / 0:01` (previously locked in `— / 0:01`), and after a timer reset the same row is asserted to return to the dash.
- Added "renders never-visited upcoming sections with a dash actual".
- Mutation check: 8 plausible wrong variants of the predicate (dropped state check, `&&` for `||`, `>= 0`, reverted original, etc.) are each killed by the suite.

## Docs

- New design record `docs/plans/2026-07-12-issue-258-agenda-revisit-actual.md`.
- One-line amendment in `docs/specs/2026-07-04-presenter-agenda-design.md` cross-referencing it.

## Gates

- `cargo test --workspace` ×3: pass (11 suites each)
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`: clean
- `git diff --exit-code bindings/`: clean
- `npm run build && npm test && npm run typecheck` (packages/peitho-present): 200/200 tests pass
- `dist/shell.js` regenerated from source (byte-identical rebuild verified); `dist/preview.js` untouched (agenda is not in the preview bundle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC