### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.4.0"
+version = "1.5.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
Version bump for the v1.5.0 release.

## Changes since v1.4.0

### New Features
- #263 Per-slide draft/skip page-settings flags

### Bug Fixes
- #264 fix(presenter): keep measured section actuals visible on revisited agenda rows
- #262 fix(code_images): normalize SVG intrinsic size at the cache-write seam
- #259 fix(examples): drop cascade-colliding width/height on layout root classes
- #257 fix(render): wrap image slot fragments in slot-<name> div

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC