### PR TITLE
fix(site): render example deck source as an escaped pre block

### DIFF
--- a/site/templates/example-page.html
+++ b/site/templates/example-page.html
@@ -34,9 +34,6 @@
     {{ throw_missing_example_github_path }}
   {% endif %}
   {% set deck_source = load_data(path=page.extra.source_path, format="plain") %}
-  {% set nl = "
-" %}
-  {% set source_block = "````markdown" ~ nl ~ deck_source ~ nl ~ "````" %}
 
   <article class="doc-page doc-body example-page">
     <header class="page-header">
@@ -61,7 +58,11 @@
     </p>
     <section class="deck-source">
       <h2>Deck source</h2>
-      {{ source_block | markdown | safe }}
+      {# Rendered as a plain escaped code block, not via a Markdown fence: a
+         deck that itself contains a four-backtick fence (e.g. code-images'
+         before/after slide) would terminate any fixed-length wrapper fence
+         early and leak the rest of the deck into the page. #}
+      <pre><code>{{ deck_source }}</code></pre>
     </section>
   </article>
 {% endblock docs_content %}


### PR DESCRIPTION
## Problem

On https://peitho.gosu.ke/examples/code-images/, the "Deck source" section broke apart: stray `:::` text appeared on the page, "The deck owns the commands" rendered as a page heading instead of staying inside the source block, the frontmatter YAML rendered as its own code block, and an empty gray box was left at the end.

## Root cause

`example-page.html` wrapped the deck source in a fixed four-backtick Markdown fence (` ````markdown `). The code-images deck itself contains a four-backtick fence — the before/after slide shows Mermaid source inside a ` ````md ` block — and per CommonMark a closing fence only needs to be *at least* as long as the opener, so the deck's own closing ` ```` ` line terminated the wrapper early. Everything after it leaked into the page as regular Markdown.

## Fix

Any fixed-length wrapper fence fails the same way as soon as a deck contains an equal-or-longer backtick run, so the fix removes the Markdown round-trip entirely: the deck source is emitted as a single `<pre><code>` block with Tera's HTML auto-escaping. Fence collision is impossible by construction. The existing generic `pre` / `pre code` site styles apply, so the visual box is unchanged (the block loses markdown token coloring, which was subtle at github-light contrast anyway).

## Verification

- Rebuilt the site and checked all nine example pages programmatically: each renders exactly one deck-source `<pre><code>` block, with no `:::` or headings leaking after it, and all HTML in deck content properly escaped.
- Served the built site locally and visually confirmed the code-images page in Chrome: the full deck source — including the ` ````md ` fence, explicit slot markers, and the final slide's YAML — now stays inside one continuous block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)