### PR TITLE
fix(site): remove gray bars around example page deck screenshots

### DIFF
--- a/site/static/site.css
+++ b/site/static/site.css
@@ -349,7 +349,8 @@ ol {
   border: 1px solid var(--hair);
 }
 
-.doc-body .gallery-tile img {
+.doc-body .gallery-tile img,
+.doc-body .deck-shot img {
   margin: 0;
   border: 0;
 }


### PR DESCRIPTION
## Problem

On example pages (e.g. https://peitho.gosu.ke/examples/lightning-talk/), the deck screenshot shows light gray strips above and below the slide image.

## Cause

The screenshot PNG itself is a clean 1600×900 capture. The strips come from the generic `.doc-body img` rule (`margin: 24px 0; border: 1px solid var(--hair)`): inside `.deck-shot` the image sits in a framed `<a>` with a `--code-bg` background, so the vertical margins expose that background as gray bars.

## Fix

Reset `margin` and `border` for `.doc-body .deck-shot img`, extending the existing `.doc-body .gallery-tile img` reset that solves the same problem for gallery tiles. The anchor keeps its own 1px frame, so the screenshot now fills it edge to edge.

Verified by injecting the rule into the live page in Chrome: the bars disappear and the slide fills the frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)