### PR TITLE
Add draft/skip flags example (non-demo, with README)

### DIFF
--- a/docs/plans/2026-07-12-draft-skip-example.md
+++ b/docs/plans/2026-07-12-draft-skip-example.md
@@ -1,0 +1,29 @@
+# Draft/skip example (Issue #268)
+
+Date: 2026-07-12
+
+## Goal
+
+Give the per-slide `{"draft":true}` / `{"skip":true}` flags (Issue #242, shipped in
+v1.5.0) a runnable example. The behavior is invisible in a static gallery — draft
+slides are dropped at build and skip only manifests in presenter navigation — so this
+is a local example with a README, modeled after `examples/pdf-export/`.
+
+## Shape
+
+```
+examples/draft-skip/
+  deck.md      # four source slides: cover, skip, draft, rules
+  README.md    # what to run and what to observe
+```
+
+Not added to `DEMO_DECKS` and no `site/content/examples/` page, same as pdf-export.
+
+## Content
+
+The deck is self-describing: the skipped slide's bullets state the skip semantics
+(and its speaker note demonstrates that skipped slides keep notes), the draft slide
+invites the reader to build and count slides, and a closing slide lists the invalid
+combinations. The README shows the measured build output (`built 3 slide(s)` from
+four source slides, `"skip": true` in `manifest.json`) and the exact
+draft+skip build error text.

--- a/examples/draft-skip/README.md
+++ b/examples/draft-skip/README.md
@@ -1,0 +1,37 @@
+# Draft and skip example
+
+A deck mixing normal, skipped, and draft slides. This example is not part of the
+demo-site gallery on purpose: draft slides are dropped at build and skip only
+shows up in presenter navigation, so the behavior has to be observed locally.
+
+## Build: the draft slide disappears
+
+```sh
+cargo run -p peitho -- build examples/draft-skip/deck.md --out /tmp/peitho-draft-skip
+```
+
+The deck has four source slides but the output says `built 3 slide(s)` — the
+`{"draft":true}` slide is dropped at parse end and appears in no output at all.
+The `{"skip":true}` slide is a real slide: it is in `slides/`, and
+`manifest.json` carries `"skip": true` for it.
+
+## Present or preview: navigation steps over the skipped slide
+
+```sh
+cargo run -p peitho -- present examples/draft-skip/deck.md
+```
+
+`next`/`prev` (arrow keys, space) resolve to the next non-skipped slide, and
+present opens on the first non-skipped slide. Direct navigation — number keys,
+Home/End, the preview grid — can still land on the skipped slide, and it keeps
+its speaker notes when you get there. PDF export and publish include it.
+
+## Invalid combinations are build errors
+
+`draft` + `skip` on one slide, `draft` + a `section` marker, and marking every
+slide draft are all line-numbered build errors. For example:
+
+```
+× slide 1 ('slide-1'), line 1: slide cannot be both draft and skipped
+  = help: remove "skip":true because draft slides are excluded from the build
+```

--- a/examples/draft-skip/deck.md
+++ b/examples/draft-skip/deck.md
@@ -1,0 +1,29 @@
+<!-- {"key":"cover"} -->
+# Draft and skip flags
+
+Per-slide page settings for decks that are still moving.
+
+---
+<!-- {"key":"skipped","skip":true} -->
+# A skipped slide
+
+- Present and preview `next`/`prev` step over this slide
+- Direct navigation — number keys, Home/End, the preview grid — can still land on it
+- It stays counted and remains in build output, publish, and PDF export
+
+<!-- Skipped slides keep their speaker notes: you are reading one right now, in the presenter, after navigating here directly. -->
+
+---
+<!-- {"key":"draft","draft":true} -->
+# A draft slide
+
+This slide never leaves the parser. It is dropped at parse end, so it appears in no output at all — not in build, preview, present, publish, or PDF export. Build this deck and count the slides.
+
+---
+<!-- {"key":"rules"} -->
+# The rules
+
+- `draft` and `skip` on the same slide is a build error
+- `draft` combined with a `section` marker is a build error
+- Marking every slide draft is a build error
+- `skip` rides into `manifest.json` (`"skip": true`); `draft` never reaches any phase downstream of the parser


### PR DESCRIPTION
Closes #268

## What

Adds `examples/draft-skip/`, a runnable example for the per-slide `{"draft":true}` / `{"skip":true}` flags shipped in v1.5.0 (#242). Deliberately **not** in the demo-site gallery: draft slides are dropped at build and skip only shows in presenter navigation, so the behavior has to be observed locally — same treatment as `examples/pdf-export/` (README, no `DEMO_DECKS` entry, no site page).

- Four source slides → `built 3 slide(s)`: the draft slide is dropped at parse end
- The skipped slide stays in output with `"skip": true` in `manifest.json`, and carries a speaker note demonstrating that skipped slides keep notes
- README documents present/preview navigation semantics and quotes the measured `draft`+`skip` build error

Plan: `docs/plans/2026-07-12-draft-skip-example.md`.

## Verification

- `peitho build` measured: 3 of 4 slides built, `skip` flags in `manifest.json` confirmed (`cover False / skipped True / rules False`)
- Invalid-combination errors probed: `draft`+`skip` and all-slides-draft both fail with the line-numbered errors quoted in the README
- Navigation semantics in the README restate the shipped #242 behavior (covered by its tests); no code changes in this PR
- Gates: `cargo test --workspace` ×3, clippy `-D warnings`, `fmt --check`, bindings drift, npm build/test/typecheck, shell/preview dist drift — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)