### PR TITLE
Demonstrate breaks: true in the keynote example

### DIFF
--- a/docs/plans/2026-07-13-breaks-demo.md
+++ b/docs/plans/2026-07-13-breaks-demo.md
@@ -1,0 +1,23 @@
+# breaks: true demo in the keynote example (Issue #278)
+
+Date: 2026-07-13
+
+## Goal
+
+The `breaks` frontmatter key (single newlines render as hard line breaks when
+`true`) appeared in no example deck.
+
+## Approach
+
+`breaks` is deck-level, so it must go in a deck whose existing paragraphs tolerate
+it. The keynote deck qualifies: every existing paragraph is a single source line
+(audited), so enabling `breaks: true` changes nothing about the current slides. Its
+centered serif aesthetic also suits line-break-significant content.
+
+Changes: add `breaks: true` frontmatter, insert one verse slide ("Line breaks are
+content" — one paragraph of three short lines, dispatching structurally to the
+statement layout), and mention the behavior on the keynote example page. No Makefile
+or landing wiring needed (existing deck; landing derives per #274).
+
+A dedicated example was rejected: a one-key deck-level flag does not carry a whole
+gallery entry, and retrofitting is safe here.

--- a/examples/keynote/deck.md
+++ b/examples/keynote/deck.md
@@ -1,3 +1,7 @@
+---
+breaks: true
+---
+
 <!-- {"key":"cover"} -->
 # Peitho
 
@@ -18,6 +22,14 @@ Content in Markdown, look and feel in layouts and CSS. While you write, you neve
 # The layout is the schema
 
 Slot excess and deficiency, type mismatches, broken references — the build stops with line numbers. Nothing is dropped silently.
+
+---
+<!-- {"key":"breaks"} -->
+# Line breaks are content
+
+Write a line.
+Break where you breathe.
+The deck keeps your phrasing.
 
 ---
 <!-- {"key":"closing"} -->

--- a/site/content/examples/keynote.md
+++ b/site/content/examples/keynote.md
@@ -21,6 +21,11 @@ That makes it a compact example of hybrid dispatch by content shape. The
 Markdown stays close to the talk outline, and the layout files decide how title
 and body slots render; the mechanism is covered in [Layouts](@/guide/layouts.md).
 
+The deck also sets `breaks: true` in its frontmatter, so single newlines in
+slide bodies render as hard line breaks. The "Line breaks are content" slide is
+one paragraph of three short lines — broken exactly where the Markdown breaks,
+with no trailing-space or backslash tricks.
+
 ## What to look at
 
 The custom CSS gives the deck a centered, serif keynote style with larger cover


### PR DESCRIPTION
Closes #278

## What

Gives the `breaks` frontmatter key its first example appearance, in the keynote deck.

- `breaks` is deck-level, so the host deck's existing paragraphs must tolerate it: every keynote paragraph is a single source line (audited), so enabling it is a no-op for the current slides
- Adds one verse slide — "Line breaks are content", one paragraph of three short lines — that renders with hard breaks exactly where the Markdown breaks, no trailing-space or backslash tricks; it dispatches structurally to the statement layout like the other body slides
- The keynote example page now mentions the behavior

A dedicated gallery example was considered and rejected: a one-key deck-level flag doesn't carry a whole gallery entry, and the keynote's centered serif aesthetic suits verse. Plan: `docs/plans/2026-07-13-breaks-demo.md`.

## Verification

- `peitho build`: 6 slides; the verse fragment contains the two `<br>` tags; slides 2 and 5 screenshotted in headless Chrome (existing slide unchanged, verse renders as three centered lines)
- `make demo-site` green
- Gates: `cargo test --workspace` ×3, clippy `-D warnings`, `fmt --check`, bindings drift, npm build/test/typecheck, shell/preview dist drift — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)