### PR TITLE
feat(cli): add peitho new starter deck scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The three pillars, in short:
 brew install mizzy/tap/peitho    # prebuilt binaries and cargo: see Install below
 ```
 
-Write `deck.md`. Convention mapping turns plain Markdown into slides as-is: slides are separated by `---`, the shallowest heading is the title, code blocks go to the code slot, and the rest becomes the body. Deck-level settings live in YAML frontmatter, per-slide settings in a `<!-- { ... } -->` JSON comment, and non-JSON HTML comments become speaker notes:
+Write `deck.md` (or scaffold one with `peitho new my-deck`). Convention mapping turns plain Markdown into slides as-is: slides are separated by `---`, the shallowest heading is the title, code blocks go to the code slot, and the rest becomes the body. Deck-level settings live in YAML frontmatter, per-slide settings in a `<!-- { ... } -->` JSON comment, and non-JSON HTML comments become speaker notes:
 
 ````markdown
 ---
@@ -215,6 +215,9 @@ Available targets: `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-
 The deck argument defaults to `deck.md` in the current directory, so it can be omitted when the file follows the convention.
 
 ```sh
+# Scaffold a starter deck (deck.md + layouts/ + css/base.css + .gitignore; --layouts default|split|cover, --theme light|dark)
+peitho new my-deck
+
 # Generate the distribution (dist/ with slides/ fragments + manifest.json + index.html + peitho.css)
 peitho build            # same as: peitho build deck.md
 

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -23,6 +23,7 @@ use sha2::{Digest, Sha256};
 
 mod asset_resolution;
 mod doctor;
+mod new_cmd;
 
 use asset_resolution::{resolve_assets, Provenance, ResolvedAssets};
 use peitho::{browser, server};
@@ -340,6 +341,19 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    New {
+        #[arg(default_value = ".")]
+        dir: PathBuf,
+        #[arg(long, value_enum, default_value_t = new_cmd::LayoutVariant::Default)]
+        layouts: new_cmd::LayoutVariant,
+        #[arg(long, value_enum, default_value_t = new_cmd::ThemeVariant::Light)]
+        theme: new_cmd::ThemeVariant,
+        #[arg(
+            long,
+            help = "overwrite the scaffold-owned files (deck.md, layouts/, css/base.css, .gitignore) in a non-empty directory"
+        )]
+        force: bool,
+    },
     Build {
         #[arg(default_value = "deck.md")]
         input: PathBuf,
@@ -431,6 +445,20 @@ const PRESENTATION_ONLY_DIST_FILES: &[&str] =
 fn main() -> miette::Result<()> {
     let cli = Cli::parse();
     match cli.command {
+        Command::New {
+            dir,
+            layouts,
+            theme,
+            force,
+        } => new_cmd::run(
+            new_cmd::NewOptions {
+                target: dir,
+                layouts,
+                theme,
+                force,
+            },
+            &mut std::io::stdout(),
+        ),
         Command::Build { input, out, watch } => {
             let options = BuildOptions { input, out };
             if watch {
@@ -4550,6 +4578,7 @@ contexts:
                 assert!(presenter_windowed);
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -4576,6 +4605,7 @@ contexts:
                 assert!(no_open);
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Present { .. }
@@ -4599,6 +4629,7 @@ contexts:
                 assert_eq!(out, Some(PathBuf::from("out.pdf")));
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -4619,6 +4650,7 @@ contexts:
                 assert_eq!(shell, Shell::Bash);
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -4645,6 +4677,7 @@ contexts:
                 assert!(json);
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
             | Command::Present { .. }
@@ -5403,6 +5436,153 @@ printf '0 bytes written to file %s\n' "$out" >&2
     }
 
     #[test]
+    fn new_command_defaults_and_accepts_options() {
+        let cli = Cli::parse_from([
+            "peitho",
+            "new",
+            "starter",
+            "--layouts",
+            "cover",
+            "--theme",
+            "dark",
+            "--force",
+        ]);
+
+        match cli.command {
+            Command::New {
+                dir,
+                layouts,
+                theme,
+                force,
+            } => {
+                assert_eq!(dir, PathBuf::from("starter"));
+                assert_eq!(layouts, new_cmd::LayoutVariant::Cover);
+                assert_eq!(theme, new_cmd::ThemeVariant::Dark);
+                assert!(force);
+            }
+            Command::Build { .. }
+            | Command::Layouts { .. }
+            | Command::Doctor { .. }
+            | Command::Preview { .. }
+            | Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected new command");
+            }
+        }
+
+        let cli = Cli::parse_from(["peitho", "new"]);
+        match cli.command {
+            Command::New {
+                dir,
+                layouts,
+                theme,
+                force,
+            } => {
+                assert_eq!(dir, PathBuf::from("."));
+                assert_eq!(layouts, new_cmd::LayoutVariant::Default);
+                assert_eq!(theme, new_cmd::ThemeVariant::Light);
+                assert!(!force);
+            }
+            Command::Build { .. }
+            | Command::Layouts { .. }
+            | Command::Doctor { .. }
+            | Command::Preview { .. }
+            | Command::Present { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected new command");
+            }
+        }
+    }
+
+    #[test]
+    fn new_command_is_listed_in_help() {
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("--help")
+            .assert()
+            .success();
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let lists_new_subcommand = stdout.lines().any(|line| {
+            line.strip_prefix("  new")
+                .and_then(|rest| rest.chars().next())
+                .is_some_and(char::is_whitespace)
+        });
+        assert!(lists_new_subcommand, "actual stdout: {stdout}");
+    }
+
+    #[test]
+    fn new_command_scaffolds_from_cli() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("starter");
+
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("new")
+            .arg(&target)
+            .arg("--layouts")
+            .arg("split")
+            .arg("--theme")
+            .arg("dark")
+            .assert()
+            .success();
+
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        assert!(stdout.contains("deck.md"), "actual stdout: {stdout}");
+        assert!(stdout.contains("peitho preview"), "actual stdout: {stdout}");
+        assert!(target.join("deck.md").is_file());
+        assert!(target.join("layouts/title-body-code.html").is_file());
+        assert!(target.join("layouts/two-column.html").is_file());
+        assert!(target.join("css/base.css").is_file());
+        assert!(target.join(".gitignore").is_file());
+    }
+
+    #[test]
+    fn generated_scaffolds_build_for_all_layout_and_theme_combinations() {
+        let layouts = [
+            new_cmd::LayoutVariant::Default,
+            new_cmd::LayoutVariant::Split,
+            new_cmd::LayoutVariant::Cover,
+        ];
+        let themes = [new_cmd::ThemeVariant::Light, new_cmd::ThemeVariant::Dark];
+
+        for layout in layouts {
+            for theme in themes {
+                let dir = tempfile::tempdir().unwrap();
+                let target = dir
+                    .path()
+                    .join(format!("{layout:?}-{theme:?}").to_lowercase());
+                let mut stdout = Vec::new();
+
+                new_cmd::run(
+                    new_cmd::NewOptions {
+                        target: target.clone(),
+                        layouts: layout,
+                        theme,
+                        force: false,
+                    },
+                    &mut stdout,
+                )
+                .unwrap();
+                build(&BuildOptions {
+                    input: target.join("deck.md"),
+                    out: target.join("dist"),
+                })
+                .unwrap();
+
+                assert!(
+                    target.join("dist/manifest.json").is_file(),
+                    "missing manifest for {layout:?}/{theme:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn build_command_defaults_input_to_deck_md() {
         let cli = Cli::parse_from(["peitho", "build"]);
 
@@ -5411,6 +5591,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
             }
             Command::Present { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -5431,6 +5612,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -5453,6 +5635,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert_eq!(input, PathBuf::from("deck.md"));
             }
             Command::Build { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -5495,6 +5678,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert!(watch);
             }
             Command::Present { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }
@@ -5517,6 +5701,7 @@ printf '0 bytes written to file %s\n' "$out" >&2
                 assert!(!watch);
             }
             Command::Present { .. }
+            | Command::New { .. }
             | Command::Layouts { .. }
             | Command::Doctor { .. }
             | Command::Preview { .. }

--- a/crates/peitho/src/new_cmd.rs
+++ b/crates/peitho/src/new_cmd.rs
@@ -1,0 +1,463 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use clap::ValueEnum;
+use miette::IntoDiagnostic;
+
+const DECK_DEFAULT_MD: &str = include_str!("../templates/new/deck-default.md");
+const DECK_SPLIT_MD: &str = include_str!("../templates/new/deck-split.md");
+const DECK_COVER_MD: &str = include_str!("../templates/new/deck-cover.md");
+const TWO_COLUMN_HTML: &str = include_str!("../templates/new/two-column.html");
+const COVER_HTML: &str = include_str!("../templates/new/cover.html");
+const TWO_COLUMN_CSS: &str = include_str!("../templates/new/two-column.css");
+const COVER_CSS: &str = include_str!("../templates/new/cover.css");
+const DARK_CSS: &str = include_str!("../templates/new/dark.css");
+const DARK_TWO_COLUMN_CSS: &str = include_str!("../templates/new/dark-two-column.css");
+const DARK_COVER_CSS: &str = include_str!("../templates/new/dark-cover.css");
+const GITIGNORE: &str = include_str!("../templates/new/gitignore");
+
+const BASE_CSS_HEADER: &str = "/*\n  This file replaces peitho's embedded themes/base.css for this deck.\n  Edit it as your deck's complete theme.\n*/\n\n";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum LayoutVariant {
+    Default,
+    Split,
+    Cover,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub(crate) enum ThemeVariant {
+    Light,
+    Dark,
+}
+
+#[derive(Debug)]
+pub(crate) struct ScaffoldFile {
+    pub(crate) relative_path: PathBuf,
+    pub(crate) content: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct NewOptions {
+    pub(crate) target: PathBuf,
+    pub(crate) layouts: LayoutVariant,
+    pub(crate) theme: ThemeVariant,
+    pub(crate) force: bool,
+}
+
+pub(crate) fn plan(layouts: LayoutVariant, theme: ThemeVariant) -> Vec<ScaffoldFile> {
+    let mut files = vec![
+        scaffold_file("deck.md", deck_template(layouts)),
+        scaffold_file("layouts/title-body-code.html", crate::BUILTIN_LAYOUT_HTML),
+    ];
+
+    match layouts {
+        LayoutVariant::Default => {}
+        LayoutVariant::Split => {
+            files.push(scaffold_file("layouts/two-column.html", TWO_COLUMN_HTML));
+        }
+        LayoutVariant::Cover => {
+            files.push(scaffold_file("layouts/cover.html", COVER_HTML));
+        }
+    }
+
+    files.push(ScaffoldFile {
+        relative_path: PathBuf::from("css/base.css"),
+        content: base_css(layouts, theme),
+    });
+    files.push(scaffold_file(".gitignore", GITIGNORE));
+    files
+}
+
+pub(crate) fn run(options: NewOptions, stdout: &mut dyn Write) -> miette::Result<()> {
+    ensure_target_dir(&options.target, options.force)?;
+    let files = plan(options.layouts, options.theme);
+
+    for file in &files {
+        write_scaffold_file(&options.target, file)?;
+    }
+
+    print_success(stdout, &options.target, &files)?;
+    Ok(())
+}
+
+fn scaffold_file(path: impl Into<PathBuf>, content: &str) -> ScaffoldFile {
+    ScaffoldFile {
+        relative_path: path.into(),
+        content: content.to_owned(),
+    }
+}
+
+fn deck_template(layouts: LayoutVariant) -> &'static str {
+    match layouts {
+        LayoutVariant::Default => DECK_DEFAULT_MD,
+        LayoutVariant::Split => DECK_SPLIT_MD,
+        LayoutVariant::Cover => DECK_COVER_MD,
+    }
+}
+
+fn base_css(layouts: LayoutVariant, theme: ThemeVariant) -> String {
+    let mut css = String::new();
+    css.push_str(BASE_CSS_HEADER);
+    css.push_str(crate::BUILTIN_BASE_CSS);
+
+    match layouts {
+        LayoutVariant::Default => {}
+        LayoutVariant::Split => append_css_block(&mut css, TWO_COLUMN_CSS),
+        LayoutVariant::Cover => append_css_block(&mut css, COVER_CSS),
+    }
+
+    if matches!(theme, ThemeVariant::Dark) {
+        append_css_block(&mut css, DARK_CSS);
+        match layouts {
+            LayoutVariant::Default => {}
+            LayoutVariant::Split => append_css_block(&mut css, DARK_TWO_COLUMN_CSS),
+            LayoutVariant::Cover => append_css_block(&mut css, DARK_COVER_CSS),
+        }
+    }
+
+    css
+}
+
+fn append_css_block(css: &mut String, block: &str) {
+    if !css.ends_with('\n') {
+        css.push('\n');
+    }
+    css.push('\n');
+    css.push_str(block.trim_end());
+    css.push('\n');
+}
+
+fn ensure_target_dir(target: &Path, force: bool) -> miette::Result<()> {
+    if !target.exists() {
+        fs::create_dir_all(target).map_err(|err| {
+            miette::miette!(
+                "failed to create target directory {}\nhelp: check the path and parent directory permissions\ncaused by: {err}",
+                target.display()
+            )
+        })?;
+        return Ok(());
+    }
+
+    let metadata = fs::metadata(target).map_err(|err| {
+        miette::miette!(
+            "failed to inspect target path {}\nhelp: check filesystem permissions\ncaused by: {err}",
+            target.display()
+        )
+    })?;
+    if !metadata.is_dir() {
+        return Err(miette::miette!(
+            "target path exists and is not a directory: {}\nhelp: choose a directory path for `peitho new`",
+            target.display()
+        ));
+    }
+
+    if !force && directory_has_entries(target)? {
+        return Err(miette::miette!(
+            "target directory is not empty: {}\nhelp: pass --force to overwrite scaffold files in this directory, or choose a fresh directory",
+            target.display()
+        ));
+    }
+
+    Ok(())
+}
+
+fn directory_has_entries(target: &Path) -> miette::Result<bool> {
+    let mut entries = fs::read_dir(target).map_err(|err| {
+        miette::miette!(
+            "failed to read target directory {}\nhelp: check directory permissions\ncaused by: {err}",
+            target.display()
+        )
+    })?;
+    match entries.next() {
+        Some(Ok(_entry)) => Ok(true),
+        Some(Err(err)) => Err(miette::miette!(
+            "failed to read entry in target directory {}\nhelp: check directory permissions\ncaused by: {err}",
+            target.display()
+        )),
+        None => Ok(false),
+    }
+}
+
+fn write_scaffold_file(target: &Path, file: &ScaffoldFile) -> miette::Result<()> {
+    let path = target.join(&file.relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            miette::miette!(
+                "failed to create scaffold directory {}\nhelp: check filesystem permissions\ncaused by: {err}",
+                parent.display()
+            )
+        })?;
+    }
+    fs::write(&path, &file.content).map_err(|err| {
+        miette::miette!(
+            "failed to write scaffold file {}\nhelp: fix the cause, then re-run with --force to overwrite the partial scaffold (or remove the directory and retry)\ncaused by: {err}",
+            path.display()
+        )
+    })
+}
+
+fn print_success(
+    stdout: &mut dyn Write,
+    target: &Path,
+    files: &[ScaffoldFile],
+) -> miette::Result<()> {
+    writeln!(stdout, "generated peitho deck in {}", target.display()).into_diagnostic()?;
+    writeln!(stdout, "files:").into_diagnostic()?;
+    for file in files {
+        writeln!(stdout, "  {}", file.relative_path.display()).into_diagnostic()?;
+    }
+    let next = if target == Path::new(".") {
+        "peitho preview".to_owned()
+    } else {
+        format!("cd {} && peitho preview", shell_single_quoted(target))
+    };
+    writeln!(stdout, "next: {next}").into_diagnostic()?;
+    Ok(())
+}
+
+fn shell_single_quoted(path: &Path) -> String {
+    let mut quoted = String::from("'");
+    for ch in path.display().to_string().chars() {
+        if ch == '\'' {
+            quoted.push_str(r#"'\''"#);
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn paths(files: &[ScaffoldFile]) -> Vec<&Path> {
+        files
+            .iter()
+            .map(|file| file.relative_path.as_path())
+            .collect()
+    }
+
+    fn content<'a>(files: &'a [ScaffoldFile], path: &str) -> &'a str {
+        files
+            .iter()
+            .find(|file| file.relative_path == Path::new(path))
+            .unwrap_or_else(|| panic!("missing scaffold file: {path}"))
+            .content
+            .as_str()
+    }
+
+    fn default_options(target: PathBuf) -> NewOptions {
+        NewOptions {
+            target,
+            layouts: LayoutVariant::Default,
+            theme: ThemeVariant::Light,
+            force: false,
+        }
+    }
+
+    #[test]
+    fn default_plan_has_the_complete_minimum_tree() {
+        let files = plan(LayoutVariant::Default, ThemeVariant::Light);
+
+        assert_eq!(
+            paths(&files),
+            vec![
+                Path::new("deck.md"),
+                Path::new("layouts/title-body-code.html"),
+                Path::new("css/base.css"),
+                Path::new(".gitignore"),
+            ]
+        );
+        assert_eq!(
+            content(&files, "layouts/title-body-code.html"),
+            crate::BUILTIN_LAYOUT_HTML
+        );
+        assert!(content(&files, "css/base.css").contains(crate::BUILTIN_BASE_CSS));
+        assert!(!content(&files, "deck.md").contains("\nlayouts:"));
+        assert!(!content(&files, "deck.md").contains("\ncss:"));
+    }
+
+    #[test]
+    fn split_and_cover_plans_add_only_their_extra_layout() {
+        let split = plan(LayoutVariant::Split, ThemeVariant::Light);
+        let cover = plan(LayoutVariant::Cover, ThemeVariant::Light);
+
+        assert_eq!(
+            paths(&split),
+            vec![
+                Path::new("deck.md"),
+                Path::new("layouts/title-body-code.html"),
+                Path::new("layouts/two-column.html"),
+                Path::new("css/base.css"),
+                Path::new(".gitignore"),
+            ]
+        );
+        assert_eq!(
+            paths(&cover),
+            vec![
+                Path::new("deck.md"),
+                Path::new("layouts/title-body-code.html"),
+                Path::new("layouts/cover.html"),
+                Path::new("css/base.css"),
+                Path::new(".gitignore"),
+            ]
+        );
+    }
+
+    #[test]
+    fn dark_theme_appends_overrides_after_the_embedded_base_css() {
+        let light = plan(LayoutVariant::Default, ThemeVariant::Light);
+        let dark = plan(LayoutVariant::Default, ThemeVariant::Dark);
+
+        let light_css = content(&light, "css/base.css");
+        let dark_css = content(&dark, "css/base.css");
+
+        assert!(dark_css.starts_with(light_css));
+        assert!(dark_css.contains("Dark scaffold theme overrides"));
+        assert!(
+            !dark_css.contains(".two-column"),
+            "default dark CSS must not reference split-only selectors:\n{dark_css}"
+        );
+        assert!(
+            !dark_css.contains(".cover"),
+            "default dark CSS must not reference cover-only selectors:\n{dark_css}"
+        );
+
+        let split = plan(LayoutVariant::Split, ThemeVariant::Dark);
+        let split_css = content(&split, "css/base.css");
+        assert!(split_css.contains(DARK_TWO_COLUMN_CSS.trim_end()));
+        assert!(
+            !split_css.contains(".cover"),
+            "split dark CSS must not reference cover-only selectors:\n{split_css}"
+        );
+
+        let cover = plan(LayoutVariant::Cover, ThemeVariant::Dark);
+        let cover_css = content(&cover, "css/base.css");
+        assert!(cover_css.contains(DARK_COVER_CSS.trim_end()));
+        assert!(
+            !cover_css.contains(".two-column"),
+            "cover dark CSS must not reference split-only selectors:\n{cover_css}"
+        );
+    }
+
+    #[test]
+    fn run_creates_missing_target_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("nested").join("deck");
+        let mut stdout = Vec::new();
+
+        run(default_options(target.clone()), &mut stdout).unwrap();
+
+        assert!(target.join("deck.md").is_file());
+        assert!(target.join("layouts/title-body-code.html").is_file());
+        assert!(target.join("css/base.css").is_file());
+        assert!(String::from_utf8(stdout)
+            .unwrap()
+            .contains("peitho preview"));
+    }
+
+    #[test]
+    fn run_quotes_next_step_path_with_spaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("it's a deck with space");
+        let mut stdout = Vec::new();
+
+        run(default_options(target.clone()), &mut stdout).unwrap();
+
+        let stdout = String::from_utf8(stdout).unwrap();
+        let quoted_target = target.display().to_string().replace('\'', r#"'\''"#);
+        assert!(
+            stdout.contains(&format!("next: cd '{quoted_target}' && peitho preview")),
+            "actual stdout: {stdout}"
+        );
+    }
+
+    #[test]
+    fn print_success_omits_cd_for_current_directory() {
+        let mut stdout = Vec::new();
+
+        print_success(&mut stdout, Path::new("."), &[]).unwrap();
+
+        let stdout = String::from_utf8(stdout).unwrap();
+        assert!(stdout.contains("next: peitho preview\n"));
+        assert!(!stdout.contains("next: cd "), "actual stdout: {stdout}");
+    }
+
+    #[test]
+    fn run_allows_empty_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("deck");
+        fs::create_dir(&target).unwrap();
+        let mut stdout = Vec::new();
+
+        run(default_options(target.clone()), &mut stdout).unwrap();
+
+        assert!(target.join("deck.md").is_file());
+    }
+
+    #[test]
+    fn run_refuses_non_empty_directory_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("deck");
+        fs::create_dir(&target).unwrap();
+        fs::write(target.join("notes.txt"), "keep me").unwrap();
+        let mut stdout = Vec::new();
+
+        let err = run(default_options(target), &mut stdout).unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("--force"), "actual error: {message}");
+        assert!(stdout.is_empty());
+    }
+
+    #[test]
+    fn run_rejects_target_path_that_is_not_a_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("deck.md");
+        fs::write(&target, "not a directory").unwrap();
+        let mut stdout = Vec::new();
+
+        let err = run(default_options(target), &mut stdout).unwrap_err();
+        let message = err.to_string();
+
+        assert!(
+            message.contains("target path exists and is not a directory"),
+            "actual error: {message}"
+        );
+        assert!(
+            message.contains("help: choose a directory path for `peitho new`"),
+            "actual error: {message}"
+        );
+        assert!(stdout.is_empty());
+    }
+
+    #[test]
+    fn force_overwrites_scaffold_files_and_leaves_other_files_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("deck");
+        fs::create_dir_all(target.join("layouts")).unwrap();
+        fs::write(target.join("deck.md"), "old deck").unwrap();
+        fs::write(target.join("keep.txt"), "keep me").unwrap();
+        let mut options = default_options(target.clone());
+        options.force = true;
+        let mut stdout = Vec::new();
+
+        run(options, &mut stdout).unwrap();
+
+        assert_ne!(
+            fs::read_to_string(target.join("deck.md")).unwrap(),
+            "old deck"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("keep.txt")).unwrap(),
+            "keep me"
+        );
+    }
+}

--- a/crates/peitho/templates/new/cover.css
+++ b/crates/peitho/templates/new/cover.css
@@ -1,0 +1,28 @@
+.cover {
+  justify-content: center;
+  align-items: center;
+  padding: 96px;
+  text-align: center;
+  background:
+    linear-gradient(135deg, rgba(29, 78, 216, 0.12), transparent 42%),
+    #f7f7f2;
+}
+
+.cover .cover-inner {
+  max-width: 920px;
+}
+
+.cover h1 {
+  font-size: 84px;
+  line-height: 0.98;
+}
+
+.cover h1::after {
+  content: "";
+  display: block;
+  width: 96px;
+  height: 5px;
+  margin: 34px auto 0;
+  border-radius: 999px;
+  background: #1d4ed8;
+}

--- a/crates/peitho/templates/new/cover.html
+++ b/crates/peitho/templates/new/cover.html
@@ -1,0 +1,5 @@
+<section class="cover">
+  <div class="cover-inner">
+    <h1><slot name="title" accepts="inline" arity="1"></slot></h1>
+  </div>
+</section>

--- a/crates/peitho/templates/new/dark-cover.css
+++ b/crates/peitho/templates/new/dark-cover.css
@@ -1,0 +1,9 @@
+.cover {
+  background:
+    linear-gradient(135deg, rgba(96, 165, 250, 0.18), transparent 44%),
+    #181a20;
+}
+
+.cover h1::after {
+  background: #60a5fa;
+}

--- a/crates/peitho/templates/new/dark-two-column.css
+++ b/crates/peitho/templates/new/dark-two-column.css
@@ -1,0 +1,4 @@
+.two-column .column {
+  border-color: rgba(244, 241, 234, 0.18);
+  background: rgba(255, 255, 255, 0.07);
+}

--- a/crates/peitho/templates/new/dark.css
+++ b/crates/peitho/templates/new/dark.css
@@ -1,0 +1,42 @@
+/* Dark scaffold theme overrides. */
+.peitho-slide {
+  background: #181a20;
+  color: #f4f1ea;
+}
+
+.peitho-slide h1 {
+  color: #fffaf0;
+}
+
+.slot-body {
+  color: #e4ded2;
+}
+
+.slot-code {
+  color: #f4f1ea;
+}
+
+.slot-code .hl-comment {
+  color: #8d99ae;
+}
+
+.slot-code .hl-string {
+  color: #8bd49c;
+}
+
+.slot-code .hl-keyword,
+.slot-code .hl-storage {
+  color: #c4a7ff;
+}
+
+.slot-code .hl-constant {
+  color: #f7c37b;
+}
+
+.slot-code .hl-function {
+  color: #8ab4ff;
+}
+
+.slot-code .hl-type {
+  color: #7dd3c7;
+}

--- a/crates/peitho/templates/new/deck-cover.md
+++ b/crates/peitho/templates/new/deck-cover.md
@@ -1,0 +1,30 @@
+---
+time: 15m
+aspect_ratio: 16:9
+---
+
+<!-- {"layout":"cover","section":"Introduction","time":"5m"} -->
+# Starter Deck
+
+---
+
+<!-- {"section":"Details","time":"10m"} -->
+# Shape the Story
+
+- Put one idea on each slide.
+- Use speaker notes for presenter-only prompts.
+- Let layout HTML define the content slots.
+
+<!-- Speaker note: This note appears in presenter view and stays out of published slides. -->
+
+---
+
+# Code Slide
+
+The default layout includes one code slot.
+
+```rust
+fn main() {
+    println!("Hello from Peitho");
+}
+```

--- a/crates/peitho/templates/new/deck-default.md
+++ b/crates/peitho/templates/new/deck-default.md
@@ -1,0 +1,32 @@
+---
+time: 15m
+aspect_ratio: 16:9
+---
+
+<!-- {"section":"Introduction","time":"5m"} -->
+# Starter Deck
+
+A Peitho deck starts as Markdown. Edit `deck.md`, keep layouts in `layouts/`, and style the deck in `css/base.css`.
+
+---
+
+<!-- {"section":"Details","time":"10m"} -->
+# Shape the Story
+
+- Put one idea on each slide.
+- Use speaker notes for presenter-only prompts.
+- Let layout HTML define the content slots.
+
+<!-- Speaker note: This note appears in presenter view and stays out of published slides. -->
+
+---
+
+# Code Slide
+
+The default layout includes one code slot.
+
+```rust
+fn main() {
+    println!("Hello from Peitho");
+}
+```

--- a/crates/peitho/templates/new/deck-split.md
+++ b/crates/peitho/templates/new/deck-split.md
@@ -1,0 +1,56 @@
+---
+time: 15m
+aspect_ratio: 16:9
+---
+
+<!-- {"section":"Introduction","time":"5m"} -->
+# Starter Deck
+
+A Peitho deck starts as Markdown. Edit `deck.md`, keep layouts in `layouts/`, and style the deck in `css/base.css`.
+
+---
+
+<!-- {"section":"Details","time":"10m"} -->
+# Shape the Story
+
+- Put one idea on each slide.
+- Use speaker notes for presenter-only prompts.
+- Let layout HTML define the content slots.
+
+<!-- Speaker note: This note appears in presenter view and stays out of published slides. -->
+
+---
+
+# Compare Options
+
+::: {slot=left}
+
+## Content
+
+- Markdown owns the message.
+- Slide breaks stay readable in Git.
+- Presenter notes live beside the slide.
+
+:::
+
+::: {slot=right}
+
+## Design
+
+- Layout HTML declares slots.
+- CSS owns the visual system.
+- The build checks both before rendering.
+
+:::
+
+---
+
+# Code Slide
+
+The default layout includes one code slot.
+
+```rust
+fn main() {
+    println!("Hello from Peitho");
+}
+```

--- a/crates/peitho/templates/new/gitignore
+++ b/crates/peitho/templates/new/gitignore
@@ -1,0 +1,2 @@
+dist/
+.peitho/

--- a/crates/peitho/templates/new/two-column.css
+++ b/crates/peitho/templates/new/two-column.css
@@ -1,0 +1,37 @@
+.two-column {
+  padding: 56px 64px;
+  gap: 28px;
+}
+
+.two-column h1 {
+  font-size: 44px;
+}
+
+.two-column .columns {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 28px;
+}
+
+.two-column .column {
+  min-width: 0;
+  overflow: hidden;
+  padding: 28px;
+  border: 1px solid rgba(24, 24, 24, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.two-column .slot-left,
+.two-column .slot-right {
+  font-size: 24px;
+  line-height: 1.45;
+}
+
+.two-column h2 {
+  margin: 0 0 16px;
+  font-size: 28px;
+  line-height: 1.15;
+}

--- a/crates/peitho/templates/new/two-column.html
+++ b/crates/peitho/templates/new/two-column.html
@@ -1,0 +1,11 @@
+<section class="two-column">
+  <h1><slot name="title" accepts="inline" arity="1"></slot></h1>
+  <div class="columns">
+    <div class="column column-left">
+      <slot name="left" accepts="blocks" arity="1..*"></slot>
+    </div>
+    <div class="column column-right">
+      <slot name="right" accepts="blocks" arity="1..*"></slot>
+    </div>
+  </div>
+</section>

--- a/docs/plans/2026-07-13-peitho-new-scaffold.md
+++ b/docs/plans/2026-07-13-peitho-new-scaffold.md
@@ -1,0 +1,128 @@
+# peitho new: scaffold a starter deck
+
+Issue #246. Adds `peitho new [<dir>] [--layouts default|split|cover] [--theme light|dark] [--force]`,
+which generates a deck directory where `peitho preview` Just Works with zero
+frontmatter, riding the existing deck-adjacent auto-detect convention.
+
+## Decisions already made in the issue
+
+- Templates are in-tree, embedded via `include_str!`. Nothing is fetched.
+- Refuse to write into an existing non-empty target directory unless `--force`.
+- Generated directory names (`layouts/`, `css/`) match the auto-detect roots,
+  so the generated `deck.md` needs no asset frontmatter.
+
+## Facts from the current codebase that shape the design
+
+- **Deck-adjacent `layouts/` and `css/` fully replace the embedded defaults**
+  (`load_layouts` / `load_css` in `crates/peitho/src/main.rs`): when the
+  directory exists, the built-in `title-body-code` layout and embedded
+  `base.css` are not loaded at all. Therefore the scaffold must emit a
+  *complete* theme and a complete layout set, not deltas.
+- **Root-class size lint (Issue #260)**: layout root `<section>` classes must
+  not declare `width`/`height` at the same specificity as `.peitho-slide`
+  (the renderer adds `.peitho-slide` to the root alongside the layout's own
+  classes). Scaffold CSS never sizes the layout root classes.
+- **Hybrid layout dispatch**: with two layouts present, a heading-only slide
+  matches both `cover` (title only) and `title-body-code` (title + optional
+  body/code) — ambiguity is a build error, so the cover variant's title slide
+  carries an explicit `{"layout":"cover"}`. Slides with body content uniquely
+  match `title-body-code`; slides using `::: {slot=left/right}` uniquely match
+  `two-column`. A slide accepts at most ONE page settings comment, so the
+  cover slide merges `layout` + `section` + `time` into a single JSON comment.
+- **Sections**: if any section marker exists the first slide must carry one,
+  and section times must sum to the frontmatter `time`. The scaffold uses
+  `time: 15m` with `Introduction 5m` + `Details 10m`.
+- **CSS validation**: bare `.slot-*` selectors are checked against the union
+  of provided layouts. `title-body-code.html` is generated in every variant,
+  so the base `.slot-title/.slot-body/.slot-code` rules always validate;
+  `.slot-left/.slot-right` rules are only emitted together with
+  `two-column.html`.
+
+## CLI shape
+
+```
+peitho new [<dir>] [--layouts <default|split|cover>] [--theme <light|dark>] [--force]
+```
+
+- `<dir>` defaults to `.`. Created (with parents) if missing.
+- If the target exists and is non-empty, error with help suggesting `--force`
+  (or a fresh directory). `--force` writes the scaffold files, overwriting
+  same-named files and leaving everything else alone.
+- `--layouts` and `--theme` are clap `ValueEnum`s; defaults `default`/`light`.
+- On success, print the generated file list and a next-steps hint
+  (`cd <dir> && peitho preview` — omit the `cd` when dir is `.`).
+
+## Generated tree
+
+Every variant:
+
+- `deck.md` — frontmatter (`time: 15m`, `aspect_ratio: 16:9`), a title slide,
+  a section-marker example (two sections summing to 15m), a speaker-note
+  comment, and a code-slot slide. Variant `split` appends a two-column slide
+  using `::: {slot=left}` / `::: {slot=right}`; variant `cover` renders the
+  title slide heading-only with `{"layout":"cover", ...}`.
+- `layouts/title-body-code.html` — byte-identical copy of the embedded
+  default (`include_str!` of the same repo file `layouts/title-body-code.html`;
+  single source, cannot drift).
+- `layouts/two-column.html` (split only), `layouts/cover.html` (cover only) —
+  new scaffold templates, simpler than the example decks' versions.
+- `css/base.css` — assembled by concatenation, in order:
+  1. a header comment stating this file replaces peitho's embedded base
+     (`themes/base.css`) and is the author's to edit,
+  2. the embedded base theme (`include_str!` of `themes/base.css`),
+  3. the extra layout's styles (split/cover only; no `width`/`height` on the
+     layout root classes per the #260 lint),
+  4. the dark override blocks (`--theme dark` only): a layout-independent
+     base block flips `.peitho-slide` background/foreground and the `.hl-*`
+     palette via the normal cascade, and a per-layout dark block (split/cover
+     only) restyles that layout's surfaces — dark CSS never references a
+     layout that is not generated. Light emits nothing extra — light *is*
+     the embedded base.
+- `.gitignore` — `dist/` and `.peitho/`.
+
+## Template layout
+
+New scaffold-only template files live under `crates/peitho/templates/new/`
+and are embedded with `include_str!`:
+
+- `deck-default.md`, `deck-split.md`, `deck-cover.md`
+- `two-column.html`, `cover.html`
+- `two-column.css`, `cover.css`, `dark.css`, `dark-two-column.css`,
+  `dark-cover.css` (the appended blocks; the `dark-*` pair are the
+  per-layout dark overrides)
+- `gitignore` (written as `.gitignore`)
+
+The default layout HTML and light base CSS reuse the already-embedded repo
+files — no copies added.
+
+## Implementation seam
+
+A `new` module in the CLI crate (`crates/peitho/src/new_cmd.rs` or similar)
+exposing a pure planning function (variant + theme → list of
+`(relative path, content)`) and a thin `run` that does the directory checks
+and writes. The pure function is the unit-test surface; the emptiness/force
+rules are tested against temp dirs.
+
+## Tests (TDD order)
+
+1. Planning function: default variant yields exactly
+   `deck.md`, `layouts/title-body-code.html`, `css/base.css`, `.gitignore`;
+   split/cover add exactly their layout file; dark appends the override block;
+   generated layout HTML for the default equals the embedded built-in.
+2. Directory rules: missing dir is created; empty existing dir is fine;
+   non-empty dir errors mentioning `--force`; with `--force` files are
+   (over)written and unrelated files survive.
+3. **End-to-end per combination (the issue's acceptance bar)**: for all six
+   `--layouts` × `--theme` combinations, scaffold into a temp dir and run the
+   real build pipeline on the generated deck — it must succeed. This pins
+   dispatch uniqueness, section-time arithmetic, CSS selector validation, and
+   the #260 root-class lint all at once.
+4. CLI wiring: `peitho new` appears in `--help`; the subcommand runs the
+   scaffold (covered via the existing main.rs test patterns).
+
+## Non-goals
+
+- No template fetching, no interactive prompts, no `--title` flag (not in the
+  issue's proposal).
+- No new example deck and no docs-site page in this PR (the guide can gain a
+  "getting started" mention separately if the author wants one).


### PR DESCRIPTION
Closes #246

## What

`peitho new [<dir>] [--layouts default|split|cover] [--theme light|dark] [--force]` scaffolds a starter deck — `deck.md`, `layouts/`, `css/base.css`, and `.gitignore` — such that `peitho preview` Just Works in the generated directory with zero frontmatter asset config, riding the existing deck-adjacent auto-detect roots. Design record: `docs/plans/2026-07-13-peitho-new-scaffold.md`.

## Key decisions

- **Templates are in-tree via `include_str!`** (per the issue). The default layout and light theme reuse the already-embedded `layouts/title-body-code.html` and `themes/base.css` sources, so scaffolded defaults cannot drift from the binary's embedded defaults. Scaffold-only templates live in `crates/peitho/templates/new/`.
- **The generated `css/base.css` is a complete theme, not a delta** — deck-adjacent `css/` *replaces* the embedded base (`load_css`), so the scaffold vendors the base with a header comment pointing at `themes/base.css`, then appends the extra layout's block and (for `--theme dark`) dark override blocks. Dark CSS never references a layout that is not generated.
- **Dispatch stays unambiguous by construction**: `title-body-code.html` ships in every variant; split's slides route via `::: {slot=left/right}`; cover's heading-only title slide carries a single merged `{"layout":"cover","section":"Introduction","time":"5m"}` page comment (one page-settings comment per slide). Section times (5m + 10m) sum to the frontmatter `time: 15m`.
- **`--force` contract**: non-empty targets are refused with a help line; `--force` overwrites scaffold-owned files and leaves everything else alone (flag help documents the owned file set). Generated CSS never sizes layout root classes (#260 lint).
- **Acceptance bar**: `generated_scaffolds_build_for_all_layout_and_theme_combinations` scaffolds all six `--layouts` × `--theme` combos into temp dirs and runs the real in-process build pipeline on each, pinning dispatch uniqueness, section arithmetic, CSS slot validation, and the root-class lint at once. Also smoke-tested a real scaffold under `peitho preview` (index + preview.js served).

## Known edges (deliberate)

- Re-scaffolding the same dir with `--force` and a different `--layouts` leaves the earlier variant's layout file behind — "overwrite scaffold-owned names, leave everything else alone" is the issue's stated contract, and deleting a possibly-user-edited layout would be worse. The mixed tree still builds.
- A directory containing only hidden entries (e.g. `.git` after `git init`) counts as non-empty. Ignoring VCS metadata like `cargo new` does would be a behavior extension beyond the issue; happy to follow up if wanted.

## Gates

`cargo test --workspace` ×3, `clippy -D warnings`, `fmt --check`, bindings drift, ignored e2e tests, `npm run build`/`test`/`typecheck`, and shell/preview embedded-bundle drift — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC