### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,7 +790,7 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "peitho"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.5.0"
+version = "1.6.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
Version bump for the v1.6.0 release.

Changes since v1.5.0: `peitho new` starter deck scaffold (#281), root-class width/height override lint (#276), four new example decks (#271 #272 #273 #279), keynote breaks demo (#280), landing gallery auto-derivation (#275), and two docs-site fixes (#269 #270).

All gates green: cargo test ×3, clippy, fmt, bindings drift, npm build/test/typecheck, embedded shell/preview drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC