### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.6.0"
+version = "1.7.0"
 
 [workspace.dependencies]
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }


### PR DESCRIPTION
## What

Bump the workspace version to 1.7.0 for release.

Changes since v1.6.0:

- #283 Add a built-in Mermaid renderer for code_images (feat → minor bump)
- #284 docs: sync README, CLAUDE.md, and site guide with the current CLI and examples

`Cargo.lock` is updated via `cargo update --workspace` so the `--locked` release build stays green.

## Verification

- `cargo test --workspace` ×3 (all green, three consecutive runs)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --exit-code bindings/`
- `npm ci && npm run build && npm test (200 passed) && npm run typecheck`
- `git diff --exit-code` on `dist/shell.js` and `dist/preview.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
