### PR TITLE
fix(examples): stop peitho-tour preview/present slides from overflowing

### DIFF
--- a/examples/peitho-tour/css/base.css
+++ b/examples/peitho-tour/css/base.css
@@ -215,6 +215,13 @@ samp {
   justify-content: center;
 }
 
+/* Passthrough the slot wrapper so the flex shrink from `.shot-frame`
+   reaches `.shot-frame img`. Scoped to `.shot-frame`: other `.slot-*`
+   wrappers keep their box (see docs/plans/2026-07-12-code-images-svg-intrinsic-size.md). */
+.shot-frame .slot-shot {
+  display: contents;
+}
+
 .shot-frame img {
   max-width: 100%;
   max-height: 100%;


### PR DESCRIPTION
Closes #294

## What

`peitho lint` (added in #293) flagged the peitho-tour demo deck's `preview` and `present` slides as overflowing 720px by 50px and 104px vertically. This PR makes both slides fit, and the deck is now clean:

Before:
```
warning: slide 16 content overflows the slide box vertically by 50px  (content 770px, box 720px)
warning: slide 18 content overflows the slide box vertically by 104px (content 824px, box 720px)
checked 20 slide(s): 2 overflow warning(s)
```

After:
```
checked 20 slide(s): no overflow
```

## Root cause (found by measurement)

Both slides use the tour deck's `shot` layout — title + body + screenshot. The screenshot lives in `<figure class="shot-frame">` which is `display: flex; flex: 1; min-height: 0`, and `.shot-frame img` has `max-height: 100%; object-fit: contain`. In theory the img should shrink to the available height. In practice it did not, and shortening the body text had no effect on the overflow (I verified this: replacing the body with a single-character sentence still overflowed by the same amount).

The reason: peitho-core's slot renderer inserts a `<div class="slot-shot">` wrapper between the layout's `<figure>` and the img. That intermediate div was **unstyled**, so it took the img's intrinsic block size and blocked the flex-shrink chain. All the `min-height: 0` / `max-height: 100%` gymnastics on `.shot-frame` and `.shot-frame img` couldn't reach the img through the unstyled wrapper.

## Fix

One rule, one comment:

```css
/* Passthrough the slot wrapper so the flex shrink from `.shot-frame`
   reaches `.shot-frame img`. Scoped to `.shot-frame`: other `.slot-*`
   wrappers keep their box (see docs/plans/2026-07-12-code-images-svg-intrinsic-size.md). */
.shot-frame .slot-shot {
  display: contents;
}
```

`display: contents` makes the wrapper a layout passthrough — the img becomes a direct flex child of `.shot-frame` and its existing `object-fit: contain` sizing now honors the flex-derived height. The rule is scoped to `.shot-frame` on purpose: the design record for #261 explicitly rejected making `.slot-*` wrappers layout-transparent at the peitho-core level because that would break keyed overrides like `.slot-body { border: ... }`. This PR keeps that invariant intact — only `.slot-shot` inside `.shot-frame` is affected.

## Verification

- `peitho lint examples/peitho-tour/deck.md` → `checked 20 slide(s): no overflow`
- All 13 other example decks still lint clean (no regression)
- Screenshots of all 3 shot-layout slides (preview / overview / present) at 1280×720 — bodies fully visible, mock screenshots fully contained, no visible layout shift on the previously-clean overview slide
- `cargo test --workspace`, `cargo clippy -D warnings`, `cargo fmt --check`, bindings/dist drift — all green

Process: brief attempt at body-text shortening (which cannot fix this, verified by measurement) → CSS root-cause investigation → simplify to `display: contents` (reviewed as strictly better than a 6-declaration flex-centering rule with identical rendering) → 5 fresh review rounds, all CLEAN by round 3.

## Known gap (for a future issue, not blocking)

Only `peitho lint` catches this class of regression today. A visual-regression harness for the demo decks would prevent silent recurrence, but that's broader tooling work outside this fix's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
