### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.7.0"
+version = "1.8.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
## Summary
- Bump workspace version to 1.8.0 for release

## Changes since v1.7.0
- #293 feat(cli): add peitho lint to detect slide content overflow at build time
- #295 fix(examples): stop peitho-tour preview/present slides from overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC