### PR TITLE
Phone remote control via a /remote route on the present server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,6 @@ jobs:
       - run: npm run build
       - run: git diff --exit-code dist/shell.js
       - run: git diff --exit-code dist/preview.js
+      - run: git diff --exit-code dist/remote.js
       - run: npm test
       - run: npm run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ packages/peitho-present/node_modules/
 packages/peitho-present/dist/*
 !packages/peitho-present/dist/shell.js
 !packages/peitho-present/dist/preview.js
+!packages/peitho-present/dist/remote.js
 /.demo-site
 /.demo-site/deck-shots/
 /.screenshots

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ git diff --exit-code bindings/  # contract drift
 cd packages/peitho-present && npm run build && npm test && npm run typecheck
 git diff --exit-code packages/peitho-present/dist/shell.js  # embedded shell drift (after npm run build)
 git diff --exit-code packages/peitho-present/dist/preview.js  # embedded preview drift (after npm run build)
+git diff --exit-code packages/peitho-present/dist/remote.js  # embedded remote drift (after npm run build)
 ```
 
 Always verify UX changes end-to-end in a real browser/real display (jsdom cannot detect layout, flashing, or window behavior. Past incidents — a fully black screen, undelivered SSE, infinite rebuild loops — were only caught via E2E). For checking present, a fixed `--port` + `curl POST /sync` + `screencapture -x -D <n>` is handy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1763,7 @@ dependencies = [
  "base64",
  "clap",
  "clap_complete",
+ "if-addrs",
  "miette",
  "notify",
  "notify-debouncer-mini",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ assert_cmd = "2"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 html-escape = "0.2"
+if-addrs = "0.15.0"
 lol_html = "2"
 merman = { version = "0.7", features = ["render"] }
 miette = { version = "7", features = ["fancy"] }

--- a/crates/peitho-core/src/lib.rs
+++ b/crates/peitho-core/src/lib.rs
@@ -40,6 +40,7 @@ pub use present_config::{present_config_json, PresentConfig};
 pub use render::{
     render_deck, render_distribution_index, render_lint_document, render_pdf_document,
     render_present_index, render_presenter_index, render_preview_error_index, render_preview_index,
+    render_remote_index,
 };
 pub use theme::{build_theme_css, CssFile};
 

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -760,15 +760,15 @@ pub fn render_remote_index() -> String {
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Peitho Remote</title>
   <style>
     :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     html, body { margin: 0; min-height: 100%; background: #101216; color: #f5f7fb; }
-    body { min-height: 100vh; }
-    #peitho-remote-root { min-height: 100vh; display: grid; align-items: stretch; padding: 20px; box-sizing: border-box; }
+    body { min-height: 100vh; min-height: 100svh; }
+    #peitho-remote-root { min-height: 100vh; min-height: 100svh; display: grid; align-items: stretch; padding: 20px; padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
     .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
-    .peitho-remote { width: min(100%, 32rem); margin: 0 auto; display: grid; grid-template-rows: auto 1fr auto; gap: 20px; min-height: calc(100vh - 40px); }
+    .peitho-remote { width: min(100%, 32rem); margin: 0 auto; display: grid; grid-template-rows: auto 1fr auto; gap: 20px; min-height: calc(100vh - 40px); min-height: calc(100svh - 40px); }
     .peitho-remote-counter { align-self: start; justify-self: center; font-size: clamp(2rem, 11vw, 4.5rem); font-weight: 700; }
     .peitho-remote-status { min-height: 1.5em; text-align: center; color: #aab3c2; }
     .peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-self: end; }
@@ -1684,8 +1684,16 @@ Paragraph after heading.
     fn remote_index_mounts_remote_bundle_with_feature_detection() {
         let html = render_remote_index();
 
-        assert!(html
-            .contains(r#"<meta name="viewport" content="width=device-width, initial-scale=1">"#));
+        assert!(html.contains(
+            r#"<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">"#
+        ));
+        assert!(html.contains("100svh"));
+        assert!(html.contains("body { min-height: 100vh; min-height: 100svh; }"));
+        assert!(html.contains("#peitho-remote-root { min-height: 100vh; min-height: 100svh;"));
+        assert!(html.contains(
+            ".peitho-remote { width: min(100%, 32rem); margin: 0 auto; display: grid; grid-template-rows: auto 1fr auto; gap: 20px; min-height: calc(100vh - 40px); min-height: calc(100svh - 40px);"
+        ));
+        assert!(html.contains("env(safe-area-inset-bottom"));
         assert!(html.contains("import * as peitho from './remote.js';"));
         assert!(html.contains("typeof peitho.mountRemoteView === 'function'"));
         assert!(

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -755,6 +755,61 @@ pub fn render_preview_index(aspect_ratio: AspectRatio) -> String {
     fill_canvas_tokens(TEMPLATE, aspect_ratio)
 }
 
+pub fn render_remote_index() -> String {
+    r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Peitho Remote</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    html, body { margin: 0; min-height: 100%; background: #101216; color: #f5f7fb; }
+    body { min-height: 100vh; }
+    #peitho-remote-root { min-height: 100vh; display: grid; align-items: stretch; padding: 20px; box-sizing: border-box; }
+    .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
+    .peitho-remote { width: min(100%, 32rem); margin: 0 auto; display: grid; grid-template-rows: auto 1fr auto; gap: 20px; min-height: calc(100vh - 40px); }
+    .peitho-remote-counter { align-self: start; justify-self: center; font-size: clamp(2rem, 11vw, 4.5rem); font-weight: 700; }
+    .peitho-remote-status { min-height: 1.5em; text-align: center; color: #aab3c2; }
+    .peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-self: end; }
+    .peitho-remote button { min-height: 88px; border: 1px solid #384252; border-radius: 8px; background: #f5f7fb; color: #101216; font: inherit; font-size: 1.4rem; font-weight: 700; touch-action: manipulation; }
+    .peitho-remote button:disabled { opacity: 0.45; }
+  </style>
+</head>
+<body>
+  <main id="peitho-remote-root"></main>
+  <script type="module">
+    import * as peitho from './remote.js';
+
+    function showError(message) {
+      const root = document.getElementById('peitho-remote-root');
+      root.className = 'peitho-remote-error';
+      root.textContent = message;
+    }
+
+    async function main() {
+      const root = document.getElementById('peitho-remote-root');
+      try {
+        if (typeof peitho.mountRemoteView === 'function') {
+          await peitho.mountRemoteView({
+            root,
+            manifestUrl: 'manifest.json'
+          });
+        } else {
+          throw new Error("remote bundle does not provide mountRemoteView; run npm run build");
+        }
+      } catch (error) {
+        showError(error instanceof Error ? error.message : String(error));
+      }
+    }
+
+    main();
+  </script>
+</body>
+</html>"#
+        .to_owned()
+}
+
 pub fn render_preview_error_index(generation: u64, error: &str) -> String {
     format!(
         r#"<!doctype html>
@@ -1623,6 +1678,23 @@ Paragraph after heading.
         assert!(config_fetch_index < mount_index);
         assert!(mount_index < sync_index);
         assert!(sync_index < config_await_index);
+    }
+
+    #[test]
+    fn remote_index_mounts_remote_bundle_with_feature_detection() {
+        let html = render_remote_index();
+
+        assert!(html
+            .contains(r#"<meta name="viewport" content="width=device-width, initial-scale=1">"#));
+        assert!(html.contains("import * as peitho from './remote.js';"));
+        assert!(html.contains("typeof peitho.mountRemoteView === 'function'"));
+        assert!(
+            html.contains(r#""remote bundle does not provide mountRemoteView; run npm run build""#)
+        );
+        assert!(html.contains("showError"));
+        assert!(html.contains("manifestUrl: 'manifest.json'"));
+        assert!(html.contains("await peitho.mountRemoteView({"));
+        assert!(!html.contains("import { mountRemoteView }"));
     }
 
     #[test]

--- a/crates/peitho/Cargo.toml
+++ b/crates/peitho/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 base64.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
+if-addrs.workspace = true
 miette.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true

--- a/crates/peitho/src/lib.rs
+++ b/crates/peitho/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod browser;
 pub mod displays;
+pub mod remote_url;
 pub mod server;

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -4,6 +4,7 @@ use std::{
     ffi::{OsStr, OsString},
     fs,
     io::{self, IsTerminal, Read, Write},
+    net::{IpAddr, Ipv4Addr, UdpSocket},
     path::{Component, Path, PathBuf},
     process::{Child, ExitStatus, Stdio},
     sync::mpsc,
@@ -323,6 +324,7 @@ struct PresentOptions {
     no_serve: bool,
     no_presenter: bool,
     presenter_windowed: bool,
+    host: Option<IpAddr>,
 }
 
 struct PreviewOptions {
@@ -404,6 +406,8 @@ enum Command {
         no_presenter: bool,
         #[arg(long)]
         presenter_windowed: bool,
+        #[arg(long, value_name = "IP")]
+        host: Option<IpAddr>,
     },
     Publish {
         #[arg(long, default_value = "dist")]
@@ -441,11 +445,18 @@ const BUILTIN_BASE_CSS: &str = include_str!("../../../themes/base.css");
 /// discipline as the generated TS types in bindings/.
 const BUILTIN_SHELL_JS: &str = include_str!("../../../packages/peitho-present/dist/shell.js");
 const BUILTIN_PREVIEW_JS: &str = include_str!("../../../packages/peitho-present/dist/preview.js");
+const BUILTIN_REMOTE_JS: &str = include_str!("../../../packages/peitho-present/dist/remote.js");
 
 const PRESENT_CACHE: &str = ".peitho/present-cache";
 const PREVIEW_CACHE: &str = ".peitho/preview-cache";
-const PRESENTATION_ONLY_DIST_FILES: &[&str] =
-    &["present.html", "presenter.html", "notes.json", "shell.js"];
+const PRESENTATION_ONLY_DIST_FILES: &[&str] = &[
+    "present.html",
+    "presenter.html",
+    "remote.html",
+    "notes.json",
+    "shell.js",
+    "remote.js",
+];
 
 fn main() -> miette::Result<()> {
     let cli = Cli::parse();
@@ -512,6 +523,7 @@ fn main() -> miette::Result<()> {
             no_serve,
             no_presenter,
             presenter_windowed,
+            host,
         } => present(PresentOptions {
             input,
             shell,
@@ -520,6 +532,7 @@ fn main() -> miette::Result<()> {
             no_serve,
             no_presenter,
             presenter_windowed,
+            host,
         }),
         Command::Publish { dist, command } => {
             let code = publish(&dist, &command)?;
@@ -2434,6 +2447,8 @@ fn require_slides_dir_with_files(dist: &Path) -> miette::Result<()> {
 }
 
 fn present(options: PresentOptions) -> miette::Result<()> {
+    validate_present_options(&options)?;
+
     let cache = PathBuf::from(PRESENT_CACHE);
     if cache.exists() {
         fs::remove_dir_all(&cache).into_diagnostic()?;
@@ -2447,7 +2462,12 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         return Ok(());
     }
 
-    let server = server::PresentServer::bind(cache.clone(), options.port, "present.html")?;
+    let server = server::PresentServer::bind_with_host(
+        cache.clone(),
+        options.port,
+        "present.html",
+        options.host,
+    )?;
     let url = server.url();
     let presenter_url = browser::presenter_url(&url);
     let browser_plan = if options.no_open {
@@ -2467,6 +2487,17 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         .is_some_and(|plan| plan.opens_presenter);
     emit_present_cache(&cache, &artifacts, options.shell.as_deref(), presenter_open)?;
     println!("serving presentation at {url}");
+    if let Some(host) = options.host {
+        let port = server.addr().port();
+        let target = if host.is_unspecified() {
+            RemoteControlTarget::Candidates(remote_url_candidates_from_interfaces(port, host))
+        } else {
+            RemoteControlTarget::Specific(host)
+        };
+        for line in format_remote_control_lines(target, port) {
+            println!("{line}");
+        }
+    }
     std::io::stdout().flush().into_diagnostic()?;
     if let Some(plan) = browser_plan {
         browser::open_browser_plan(plan);
@@ -2476,6 +2507,72 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         browser::quit_profile_instances();
     }
     result
+}
+
+fn validate_present_options(options: &PresentOptions) -> miette::Result<()> {
+    let Some(host) = options.host else {
+        return Ok(());
+    };
+    if options.no_serve {
+        return Err(miette::miette!(
+            "--host requires the present server\nhelp: remove --no-serve or omit --host"
+        ));
+    }
+    if host.is_loopback() {
+        return Err(miette::miette!(
+            "--host must be non-loopback\nhelp: use the default loopback server without --host, or pass a reachable Tailscale/LAN IP address"
+        ));
+    }
+    Ok(())
+}
+
+enum RemoteControlTarget {
+    Specific(IpAddr),
+    Candidates(Vec<peitho::remote_url::RemoteUrlCandidate>),
+}
+
+fn format_remote_control_lines(target: RemoteControlTarget, port: u16) -> Vec<String> {
+    match target {
+        RemoteControlTarget::Specific(host) => vec![format!(
+            "remote control: {}",
+            peitho::remote_url::remote_url_for_addr(host, port)
+        )],
+        RemoteControlTarget::Candidates(candidates) if candidates.is_empty() => {
+            vec!["remote control: no non-loopback network addresses found".to_owned()]
+        }
+        RemoteControlTarget::Candidates(candidates) => candidates
+            .iter()
+            .map(|candidate| match candidate.label {
+                Some(label) => format!("remote control ({}): {}", label.as_str(), candidate.url),
+                None => format!("remote control: {}", candidate.url),
+            })
+            .collect(),
+    }
+}
+
+fn remote_url_candidates_from_interfaces(
+    port: u16,
+    bound_wildcard: IpAddr,
+) -> Vec<peitho::remote_url::RemoteUrlCandidate> {
+    let addrs = match if_addrs::get_if_addrs() {
+        Ok(addrs) => addrs.into_iter().map(|addr| addr.ip()).collect::<Vec<_>>(),
+        Err(err) => {
+            eprintln!("warning: failed to enumerate network interfaces for remote URL: {err}");
+            Vec::new()
+        }
+    };
+    peitho::remote_url::remote_url_candidates(
+        &addrs,
+        default_route_ipv4(),
+        port,
+        Some(bound_wildcard),
+    )
+}
+
+fn default_route_ipv4() -> Option<IpAddr> {
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+    socket.connect((Ipv4Addr::new(8, 8, 8, 8), 80)).ok()?;
+    Some(socket.local_addr().ok()?.ip())
 }
 
 fn preview(options: PreviewOptions) -> miette::Result<()> {
@@ -2690,6 +2787,12 @@ fn emit_present_cache(
         peitho_core::render_presenter_index(artifacts.rendered.settings().aspect_ratio()),
     )
     .into_diagnostic()?;
+    fs::write(
+        cache.join("remote.html"),
+        peitho_core::render_remote_index(),
+    )
+    .into_diagnostic()?;
+    fs::write(cache.join("remote.js"), BUILTIN_REMOTE_JS).into_diagnostic()?;
     match shell {
         Some(shell) => {
             fs::copy(shell, cache.join("shell.js")).into_diagnostic()?;
@@ -4720,6 +4823,135 @@ contexts:
     }
 
     #[test]
+    fn present_command_accepts_host_flag() {
+        let cli = Cli::parse_from(["peitho", "present", "deck.md", "--host", "100.64.0.5"]);
+
+        match cli.command {
+            Command::Present { input, host, .. } => {
+                assert_eq!(input, PathBuf::from("deck.md"));
+                assert_eq!(host, Some("100.64.0.5".parse().unwrap()));
+            }
+            Command::Build { .. }
+            | Command::Lint { .. }
+            | Command::New { .. }
+            | Command::Layouts { .. }
+            | Command::Doctor { .. }
+            | Command::Preview { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected present command");
+            }
+        }
+    }
+
+    #[test]
+    fn present_command_rejects_invalid_host_ip() {
+        let err = Cli::try_parse_from(["peitho", "present", "deck.md", "--host", "not-an-ip"])
+            .unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn present_options_reject_host_with_no_serve() {
+        let options = PresentOptions {
+            input: PathBuf::from("deck.md"),
+            shell: None,
+            port: 0,
+            no_open: true,
+            no_serve: true,
+            no_presenter: false,
+            presenter_windowed: false,
+            host: Some("100.64.0.5".parse().unwrap()),
+        };
+
+        let err = validate_present_options(&options).unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("--host requires the present server"));
+        assert!(err.to_string().contains("--no-serve"));
+    }
+
+    #[test]
+    fn present_options_reject_loopback_host() {
+        let options = PresentOptions {
+            input: PathBuf::from("deck.md"),
+            shell: None,
+            port: 0,
+            no_open: true,
+            no_serve: false,
+            no_presenter: false,
+            presenter_windowed: false,
+            host: Some("127.0.0.1".parse().unwrap()),
+        };
+
+        let err = validate_present_options(&options).unwrap_err();
+
+        assert!(err.to_string().contains("--host must be non-loopback"));
+        assert!(err.to_string().contains("use the default loopback server"));
+    }
+
+    #[test]
+    fn remote_control_lines_format_specific_host() {
+        let lines = format_remote_control_lines(
+            RemoteControlTarget::Specific("100.64.0.5".parse().unwrap()),
+            3000,
+        );
+
+        assert_eq!(lines, vec!["remote control: http://100.64.0.5:3000/remote"]);
+    }
+
+    #[test]
+    fn remote_control_lines_bracket_specific_ipv6_host() {
+        let lines = format_remote_control_lines(
+            RemoteControlTarget::Specific("2001:db8::5".parse().unwrap()),
+            3000,
+        );
+
+        assert_eq!(
+            lines,
+            vec!["remote control: http://[2001:db8::5]:3000/remote"]
+        );
+    }
+
+    #[test]
+    fn remote_control_lines_format_unspecified_host_candidates_with_labels() {
+        let candidates = peitho::remote_url::remote_url_candidates(
+            &[
+                "192.168.1.20".parse().unwrap(),
+                "100.100.10.5".parse().unwrap(),
+                "10.0.0.15".parse().unwrap(),
+            ],
+            Some("10.0.0.15".parse().unwrap()),
+            3000,
+            None,
+        );
+
+        let lines = format_remote_control_lines(RemoteControlTarget::Candidates(candidates), 3000);
+
+        assert_eq!(
+            lines,
+            vec![
+                "remote control: http://10.0.0.15:3000/remote",
+                "remote control (Tailscale): http://100.100.10.5:3000/remote",
+                "remote control: http://192.168.1.20:3000/remote"
+            ]
+        );
+    }
+
+    #[test]
+    fn remote_control_lines_show_when_unspecified_host_has_no_candidates() {
+        let lines = format_remote_control_lines(RemoteControlTarget::Candidates(Vec::new()), 3000);
+
+        assert_eq!(
+            lines,
+            vec!["remote control: no non-loopback network addresses found"]
+        );
+    }
+
+    #[test]
     fn lint_command_defaults_input_to_deck_md() {
         let cli = Cli::parse_from(["peitho", "lint"]);
 
@@ -5539,6 +5771,8 @@ printf '0 bytes written to file %s\n' "$out" >&2
         assert!(!generation_dir.join("presenter.html").exists());
         assert!(!generation_dir.join("present.json").exists());
         assert!(!generation_dir.join("shell.js").exists());
+        assert!(!generation_dir.join("remote.html").exists());
+        assert!(!generation_dir.join("remote.js").exists());
 
         let index = fs::read_to_string(generation_dir.join("index.html")).unwrap();
         assert!(index.contains("./preview.js"));
@@ -5704,6 +5938,16 @@ printf '0 bytes written to file %s\n' "$out" >&2
         .unwrap();
 
         assert_eq!(BUILTIN_PREVIEW_JS, committed);
+    }
+
+    #[test]
+    fn builtin_remote_shell_matches_committed_bundle() {
+        let committed = fs::read_to_string(
+            workspace_root_for_tests().join("packages/peitho-present/dist/remote.js"),
+        )
+        .unwrap();
+
+        assert_eq!(BUILTIN_REMOTE_JS, committed);
     }
 
     #[test]

--- a/crates/peitho/src/remote_url.rs
+++ b/crates/peitho/src/remote_url.rs
@@ -1,0 +1,279 @@
+use std::{collections::HashSet, net::IpAddr};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteUrlCandidate {
+    pub address: IpAddr,
+    pub label: Option<RemoteUrlLabel>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteUrlLabel {
+    Tailscale,
+}
+
+impl RemoteUrlLabel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tailscale => "Tailscale",
+        }
+    }
+}
+
+pub fn remote_url_candidates(
+    addrs: &[IpAddr],
+    default_route: Option<IpAddr>,
+    port: u16,
+    bound_wildcard: Option<IpAddr>,
+) -> Vec<RemoteUrlCandidate> {
+    let mut seen = HashSet::new();
+    let mut candidates = addrs
+        .iter()
+        .copied()
+        .filter(|addr| !is_excluded_addr(*addr))
+        .filter(|addr| matches_bound_wildcard_family(*addr, bound_wildcard))
+        .filter(|addr| seen.insert(*addr))
+        .map(|address| RemoteUrlCandidate {
+            address,
+            label: remote_url_label(address),
+            url: remote_url_for_addr(address, port),
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|candidate| candidate_rank(candidate.address, default_route));
+    candidates
+}
+
+fn matches_bound_wildcard_family(address: IpAddr, bound_wildcard: Option<IpAddr>) -> bool {
+    match bound_wildcard {
+        Some(IpAddr::V4(wildcard)) if wildcard.is_unspecified() => address.is_ipv4(),
+        Some(IpAddr::V6(wildcard)) if wildcard.is_unspecified() => {
+            // macOS and stock Linux default to dual-stack IPv6 wildcard listeners
+            // (IPV6_V6ONLY off), so IPv4-mapped clients can still connect.
+            true
+        }
+        _ => true,
+    }
+}
+
+fn candidate_rank(address: IpAddr, default_route: Option<IpAddr>) -> u8 {
+    if Some(address) == default_route {
+        0
+    } else if is_tailscale_addr(address) {
+        1
+    } else {
+        2
+    }
+}
+
+fn remote_url_label(address: IpAddr) -> Option<RemoteUrlLabel> {
+    is_tailscale_addr(address).then_some(RemoteUrlLabel::Tailscale)
+}
+
+pub fn remote_url_for_addr(address: IpAddr, port: u16) -> String {
+    match address {
+        IpAddr::V4(address) => format!("http://{address}:{port}/remote"),
+        IpAddr::V6(address) => format!("http://[{address}]:{port}/remote"),
+    }
+}
+
+fn is_excluded_addr(address: IpAddr) -> bool {
+    address.is_loopback() || is_link_local_addr(address)
+}
+
+fn is_link_local_addr(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            let octets = address.octets();
+            octets[0] == 169 && octets[1] == 254
+        }
+        IpAddr::V6(address) => {
+            let octets = address.octets();
+            octets[0] == 0xfe && (octets[1] & 0xc0) == 0x80
+        }
+    }
+}
+
+fn is_tailscale_addr(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            let octets = address.octets();
+            octets[0] == 100 && (64..=127).contains(&octets[1])
+        }
+        IpAddr::V6(address) => {
+            let segments = address.segments();
+            segments[0] == 0xfd7a && segments[1] == 0x115c && segments[2] == 0xa1e0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    fn v4(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+    }
+
+    #[test]
+    fn remote_url_candidates_exclude_loopback_and_link_local() {
+        let candidates = remote_url_candidates(
+            &[
+                v4(127, 0, 0, 1),
+                v4(169, 254, 10, 20),
+                IpAddr::V6(Ipv6Addr::LOCALHOST),
+                "fe80::1".parse().unwrap(),
+                v4(192, 168, 1, 20),
+            ],
+            None,
+            4321,
+            None,
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec!["http://192.168.1.20:4321/remote"]
+        );
+    }
+
+    #[test]
+    fn remote_url_candidates_label_cgnat_as_tailscale() {
+        let candidates =
+            remote_url_candidates(&[v4(100, 64, 0, 1), v4(100, 127, 255, 254)], None, 80, None);
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+        assert_eq!(candidates[1].label, Some(RemoteUrlLabel::Tailscale));
+    }
+
+    #[test]
+    fn remote_url_candidates_label_tailscale_ipv6_ula() {
+        let candidates =
+            remote_url_candidates(&["fd7a:115c:a1e0::1".parse().unwrap()], None, 80, None);
+
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+    }
+
+    #[test]
+    fn remote_url_candidates_order_default_route_then_tailscale_then_rest() {
+        let candidates = remote_url_candidates(
+            &[v4(192, 168, 1, 20), v4(100, 100, 10, 5), v4(10, 0, 0, 15)],
+            Some(v4(10, 0, 0, 15)),
+            3000,
+            None,
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "http://10.0.0.15:3000/remote",
+                "http://100.100.10.5:3000/remote",
+                "http://192.168.1.20:3000/remote"
+            ]
+        );
+        assert_eq!(candidates[1].label, Some(RemoteUrlLabel::Tailscale));
+    }
+
+    #[test]
+    fn remote_url_candidates_order_tailscale_ipv6_before_rest() {
+        let candidates = remote_url_candidates(
+            &[
+                "2001:db8::5".parse().unwrap(),
+                "fd7a:115c:a1e0::1".parse().unwrap(),
+            ],
+            None,
+            3000,
+            None,
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "http://[fd7a:115c:a1e0::1]:3000/remote",
+                "http://[2001:db8::5]:3000/remote"
+            ]
+        );
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+    }
+
+    #[test]
+    fn remote_url_candidates_for_ipv4_wildcard_keep_only_ipv4_candidates() {
+        let candidates = remote_url_candidates(
+            &[v4(192, 168, 1, 20), "2001:db8::5".parse().unwrap()],
+            None,
+            3000,
+            Some(v4(0, 0, 0, 0)),
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec!["http://192.168.1.20:3000/remote"]
+        );
+    }
+
+    #[test]
+    fn remote_url_candidates_for_ipv6_wildcard_keep_both_address_families() {
+        let candidates = remote_url_candidates(
+            &[v4(192, 168, 1, 20), "2001:db8::5".parse().unwrap()],
+            None,
+            3000,
+            Some("::".parse().unwrap()),
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "http://192.168.1.20:3000/remote",
+                "http://[2001:db8::5]:3000/remote"
+            ]
+        );
+    }
+
+    #[test]
+    fn remote_url_candidates_deduplicates_addresses() {
+        let candidates = remote_url_candidates(
+            &[
+                v4(192, 168, 1, 20),
+                v4(192, 168, 1, 20),
+                v4(100, 64, 0, 5),
+                v4(100, 64, 0, 5),
+            ],
+            None,
+            3000,
+            None,
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "http://100.64.0.5:3000/remote",
+                "http://192.168.1.20:3000/remote"
+            ]
+        );
+    }
+
+    #[test]
+    fn remote_url_candidates_bracket_ipv6_urls() {
+        let candidates = remote_url_candidates(&["2001:db8::5".parse().unwrap()], None, 8080, None);
+
+        assert_eq!(candidates[0].url, "http://[2001:db8::5]:8080/remote");
+    }
+}

--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     io::{Read, Write},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     path::{Component, Path, PathBuf},
     sync::{Arc, Condvar, Mutex, RwLock},
     thread,
@@ -117,6 +117,7 @@ pub(crate) fn resolve_request_path(
     match trimmed {
         "presenter" | "presenter-swapped" => return Some(root.join("presenter.html")),
         "present-swapped" => return Some(root.join("present.html")),
+        "remote" => return Some(root.join("remote.html")),
         _ => {}
     }
 
@@ -150,24 +151,94 @@ pub(crate) fn content_type(path: &Path) -> &'static str {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BindPlan {
+    LoopbackOnly,
+    WildcardOnly(IpAddr),
+    LoopbackPlusExtra(IpAddr),
+}
+
+fn bind_plan(host: Option<IpAddr>) -> BindPlan {
+    match host {
+        None => BindPlan::LoopbackOnly,
+        Some(host) if host.is_unspecified() => BindPlan::WildcardOnly(host),
+        Some(host) => BindPlan::LoopbackPlusExtra(host),
+    }
+}
+
 #[derive(Clone)]
 pub struct PresentServer {
     root: Arc<RwLock<PathBuf>>,
     default_document: String,
     server: Arc<Server>,
+    listeners: Arc<Mutex<Vec<Arc<Server>>>>,
     sync: SyncHub,
 }
 
 impl PresentServer {
     pub fn bind(root: PathBuf, port: u16, default_document: &'static str) -> miette::Result<Self> {
-        let server = Server::http(("127.0.0.1", port))
-            .map_err(|err| miette::miette!("failed to bind present server: {err}"))?;
+        Self::bind_with_host(root, port, default_document, None)
+    }
+
+    pub fn bind_with_host(
+        root: PathBuf,
+        port: u16,
+        default_document: &'static str,
+        host: Option<IpAddr>,
+    ) -> miette::Result<Self> {
+        match bind_plan(host) {
+            BindPlan::LoopbackOnly => Self::bind_addr(
+                root,
+                SocketAddr::from(([127, 0, 0, 1], port)),
+                default_document,
+            ),
+            BindPlan::WildcardOnly(host) => {
+                Self::bind_addr(root, SocketAddr::new(host, port), default_document)
+            }
+            BindPlan::LoopbackPlusExtra(host) => {
+                let server = Self::bind_addr(
+                    root,
+                    SocketAddr::from(([127, 0, 0, 1], port)),
+                    default_document,
+                )?;
+                server.add_listener(host)?;
+                Ok(server)
+            }
+        }
+    }
+
+    fn bind_addr(
+        root: PathBuf,
+        addr: SocketAddr,
+        default_document: &'static str,
+    ) -> miette::Result<Self> {
+        let server = Server::http(addr)
+            .map_err(|err| miette::miette!("failed to bind present server at {addr}: {err}"))?;
+        let server = Arc::new(server);
         Ok(Self {
             root: Arc::new(RwLock::new(root)),
             default_document: default_document.to_owned(),
-            server: Arc::new(server),
+            server: server.clone(),
+            listeners: Arc::new(Mutex::new(vec![server])),
             sync: SyncHub::default(),
         })
+    }
+
+    fn add_listener(&self, host: IpAddr) -> miette::Result<SocketAddr> {
+        validate_extra_listener_host(host)?;
+        let addr = SocketAddr::new(host, self.addr().port());
+        let server = Server::http(addr)
+            .map_err(|err| miette::miette!("failed to bind present server at {addr}: {err}"))?;
+        let server = Arc::new(server);
+        let bound_addr = server
+            .server_addr()
+            .to_ip()
+            .expect("present server binds TCP");
+        self.listeners
+            .lock()
+            .expect("present server listeners mutex")
+            .push(server);
+        Ok(bound_addr)
     }
 
     pub fn addr(&self) -> SocketAddr {
@@ -198,8 +269,25 @@ impl PresentServer {
     }
 
     pub fn serve_forever(self) -> miette::Result<()> {
-        for request in self.server.incoming_requests() {
-            self.respond(request, Some(ShutdownHandle::new(self.server.clone())));
+        let listeners = self
+            .listeners
+            .lock()
+            .expect("present server listeners mutex")
+            .clone();
+        let mut handles = Vec::new();
+        for listener in listeners.iter().skip(1).cloned() {
+            let server = self.clone();
+            handles.push(thread::spawn(move || server.serve_listener(listener)));
+        }
+        self.serve_listener(self.server.clone());
+        let mut listener_panicked = false;
+        for handle in handles {
+            if handle.join().is_err() {
+                listener_panicked = true;
+            }
+        }
+        if listener_panicked {
+            return Err(miette::miette!("present server listener panicked"));
         }
         let _ = writeln!(std::io::stdout(), "presentation ended");
         Ok(())
@@ -208,6 +296,12 @@ impl PresentServer {
     pub fn handle_one(&self) {
         if let Some(request) = self.server.incoming_requests().next() {
             self.respond(request, None);
+        }
+    }
+
+    fn serve_listener(&self, server: Arc<Server>) {
+        for request in server.incoming_requests() {
+            self.respond(request, Some(ShutdownHandle::new(self.listeners.clone())));
         }
     }
 
@@ -321,19 +415,35 @@ impl PresentServer {
     }
 }
 
+fn validate_extra_listener_host(host: IpAddr) -> miette::Result<()> {
+    if host.is_unspecified() {
+        return Err(miette::miette!(
+            "extra listener must be specific\nhelp: bind the wildcard as the primary listener"
+        ));
+    }
+    Ok(())
+}
+
 struct ShutdownHandle {
-    server: Arc<Server>,
+    listeners: Arc<Mutex<Vec<Arc<Server>>>>,
 }
 
 impl ShutdownHandle {
-    fn new(server: Arc<Server>) -> Self {
-        Self { server }
+    fn new(listeners: Arc<Mutex<Vec<Arc<Server>>>>) -> Self {
+        Self { listeners }
     }
 
     fn start(self) {
         thread::spawn(move || {
             thread::sleep(Duration::from_millis(500));
-            self.server.unblock();
+            let listeners = self
+                .listeners
+                .lock()
+                .expect("present server listeners mutex")
+                .clone();
+            for server in listeners {
+                server.unblock();
+            }
         });
     }
 }
@@ -458,6 +568,57 @@ mod tests {
             resolve_request_path(Path::new("/cache"), "/presenter?seq=1", "present.html").unwrap(),
             Path::new("/cache").join("presenter.html")
         );
+    }
+
+    #[test]
+    fn resolves_extensionless_remote_route() {
+        assert_eq!(
+            resolve_request_path(Path::new("/cache"), "/remote", "present.html").unwrap(),
+            Path::new("/cache").join("remote.html")
+        );
+        assert_eq!(
+            resolve_request_path(Path::new("/cache"), "/remote?seq=1", "present.html").unwrap(),
+            Path::new("/cache").join("remote.html")
+        );
+    }
+
+    #[test]
+    fn bind_plan_defaults_to_loopback_only() {
+        assert_eq!(bind_plan(None), BindPlan::LoopbackOnly);
+    }
+
+    #[test]
+    fn bind_plan_uses_wildcard_only_for_unspecified_host() {
+        assert_eq!(
+            bind_plan(Some("0.0.0.0".parse().unwrap())),
+            BindPlan::WildcardOnly("0.0.0.0".parse().unwrap())
+        );
+        assert_eq!(
+            bind_plan(Some("::".parse().unwrap())),
+            BindPlan::WildcardOnly("::".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn bind_plan_uses_loopback_plus_extra_for_specific_host() {
+        assert_eq!(
+            bind_plan(Some("100.64.0.5".parse().unwrap())),
+            BindPlan::LoopbackPlusExtra("100.64.0.5".parse().unwrap())
+        );
+        assert_eq!(
+            bind_plan(Some("::1".parse().unwrap())),
+            BindPlan::LoopbackPlusExtra("::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn extra_listener_guard_rejects_unspecified_host() {
+        let err = validate_extra_listener_host("0.0.0.0".parse().unwrap()).unwrap_err();
+
+        assert!(err.to_string().contains("extra listener must be specific"));
+        assert!(err
+            .to_string()
+            .contains("bind the wildcard as the primary listener"));
     }
 
     #[test]

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -2,7 +2,7 @@ use std::{
     ffi::OsString,
     fs,
     io::{BufRead, BufReader, Read, Write},
-    net::TcpStream,
+    net::{IpAddr, Ipv6Addr, SocketAddr, TcpStream},
     path::{Path, PathBuf},
     sync::mpsc,
     thread,
@@ -49,7 +49,9 @@ fn present_no_serve_writes_clean_present_cache() {
     let cache = dir.path().join(".peitho/present-cache");
     assert!(!stale.exists());
     assert!(cache.join("present.html").exists());
+    assert!(cache.join("remote.html").exists());
     assert!(cache.join("shell.js").exists());
+    assert!(cache.join("remote.js").exists());
     assert!(cache.join("peitho.css").exists());
     assert!(cache.join("manifest.json").exists());
     assert!(cache.join("notes.json").exists());
@@ -191,6 +193,35 @@ fn present_server_serves_manifest_over_http() {
     assert!(response.contains("200 OK"));
     assert!(response.contains("application/json"));
     assert!(response.contains(r#"{"version":1}"#));
+}
+
+#[test]
+fn present_server_extra_listener_serves_manifest_over_http() {
+    let dir = tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("present.html"), "<!doctype html>").unwrap();
+    fs::write(cache.join("manifest.json"), r#"{"version":1}"#).unwrap();
+
+    let host = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let server =
+        peitho::server::PresentServer::bind_with_host(cache, 0, "present.html", Some(host))
+            .unwrap();
+    let primary_addr = server.addr();
+    let extra_addr = SocketAddr::new(host, primary_addr.port());
+    let handle = thread::spawn(move || server.serve_forever());
+
+    let primary = get_http(primary_addr, "/manifest.json");
+    let extra = get_http(extra_addr, "/manifest.json");
+    assert!(post_sync(primary_addr, r#"{"close":true}"#).contains("204 No Content"));
+    join_present_server(handle, Duration::from_secs(3));
+
+    assert!(primary.contains("200 OK"));
+    assert!(primary.contains("application/json"));
+    assert!(primary.contains(r#"{"version":1}"#));
+    assert!(extra.contains("200 OK"));
+    assert!(extra.contains("application/json"));
+    assert!(extra.contains(r#"{"version":1}"#));
 }
 
 #[test]
@@ -412,6 +443,16 @@ fn present_server_shuts_down_after_close_sync_post() {
     assert!(post_response.contains("204 No Content"));
 
     join_present_server(handle, Duration::from_secs(3));
+}
+
+#[test]
+fn present_server_with_extra_listener_shuts_down_after_primary_close_sync_post() {
+    assert_dual_listener_shutdown(DualListenerCloseTarget::Primary);
+}
+
+#[test]
+fn present_server_with_extra_listener_shuts_down_after_extra_close_sync_post() {
+    assert_dual_listener_shutdown(DualListenerCloseTarget::Extra);
 }
 
 #[test]
@@ -711,6 +752,35 @@ fn present_process_exits_after_close_sync_post() {
     reader.join().unwrap();
 }
 
+enum DualListenerCloseTarget {
+    Primary,
+    Extra,
+}
+
+fn assert_dual_listener_shutdown(target: DualListenerCloseTarget) {
+    let dir = tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    fs::create_dir_all(&cache).unwrap();
+    fs::write(cache.join("present.html"), "<!doctype html>").unwrap();
+
+    let host = IpAddr::V6(Ipv6Addr::LOCALHOST);
+    let server =
+        peitho::server::PresentServer::bind_with_host(cache, 0, "present.html", Some(host))
+            .unwrap();
+    let primary_addr = server.addr();
+    let extra_addr = SocketAddr::new(host, primary_addr.port());
+    let close_addr = match target {
+        DualListenerCloseTarget::Primary => primary_addr,
+        DualListenerCloseTarget::Extra => extra_addr,
+    };
+    let handle = thread::spawn(move || server.serve_forever());
+
+    let post_response = post_sync(close_addr, r#"{"close":true}"#);
+    assert!(post_response.contains("204 No Content"));
+
+    join_present_server(handle, Duration::from_secs(3));
+}
+
 #[test]
 fn repository_example_present_no_serve_smoke() {
     let shell = workspace_root().join("packages/peitho-present/dist/shell.js");
@@ -857,7 +927,7 @@ fn read_until_contains(stream: &mut TcpStream, needle: &str) -> String {
     out
 }
 
-fn post_sync(addr: std::net::SocketAddr, body: &str) -> String {
+fn post_sync(addr: SocketAddr, body: &str) -> String {
     let mut post = TcpStream::connect(addr).unwrap();
     write!(
         post,
@@ -871,7 +941,7 @@ fn post_sync(addr: std::net::SocketAddr, body: &str) -> String {
     response
 }
 
-fn get_http(addr: std::net::SocketAddr, path: &str) -> String {
+fn get_http(addr: SocketAddr, path: &str) -> String {
     let mut stream = TcpStream::connect(addr).unwrap();
     write!(stream, "GET {path} HTTP/1.0\r\nHost: localhost\r\n\r\n").unwrap();
     let mut response = String::new();
@@ -898,7 +968,7 @@ fn join_present_server(handle: thread::JoinHandle<miette::Result<()>>, timeout: 
     handle.join().unwrap().unwrap();
 }
 
-fn serving_addr(line: &str) -> std::net::SocketAddr {
+fn serving_addr(line: &str) -> SocketAddr {
     let prefix = "serving presentation at http://";
     let rest = line
         .strip_prefix(prefix)

--- a/crates/peitho/tests/publish.rs
+++ b/crates/peitho/tests/publish.rs
@@ -112,6 +112,25 @@ fn publish_rejects_presentation_only_files() {
 }
 
 #[test]
+fn publish_rejects_remote_presentation_only_file() {
+    let dir = tempdir().unwrap();
+    let dist = dir.path().join("dist");
+    write_valid_dist(&dist);
+    fs::write(dist.join("remote.js"), "export {}").unwrap();
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args(["publish", "--dist"])
+        .arg(&dist)
+        .args(["--", "true"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "distribution contains presentation-only file: remote.js",
+        ));
+}
+
+#[test]
 fn publish_rejects_missing_manifest_slide_reference() {
     let dir = tempdir().unwrap();
     let dist = dir.path().join("dist");

--- a/docs/plans/2026-07-16-phone-remote.md
+++ b/docs/plans/2026-07-16-phone-remote.md
@@ -1,0 +1,193 @@
+# Phone remote control via a `/remote` route (Issue #289)
+
+Date: 2026-07-16
+Issue: #289
+
+## Goal
+
+Serve a phone-friendly `/remote` page from the `peitho present` server with
+prev/next buttons and a slide counter, driving navigation through the existing
+`/sync` long-polling channel. Add an opt-in `--host` flag so the server is
+reachable from a phone (the recommended pattern is binding the Tailscale
+address; see the issue comment).
+
+## Decisions taken from the issue + author comment
+
+- **Route naming**: `/remote` — extensionless and dot-free, consistent with
+  `/presenter` / `/present-swapped` (Chrome app-name dot pitfall).
+- **Reachability is the opt-in, not the route**: `remote.html` is always
+  emitted and `/remote` is always served; without `--host` the server binds
+  loopback only, so nothing new is exposed. `--host <addr>` is the explicit
+  opt-in that changes exposure.
+- **Binding a specific address (e.g. Tailscale `100.x.y.z`) is strictly better
+  than `0.0.0.0`** when available — the flag accepts any IP address, so no
+  Tailscale-specific code is needed for binding.
+- **Skipped-slide semantics** on the remote's prev/next must match present-mode
+  `next`/`prev`: resolve to the next non-skipped slide or no-op
+  (`nextNonSkippedIndex` in `packages/peitho-present/src/skipnav.ts`).
+- **Printed URL candidates**: prefer the default-route interface's IPv4,
+  exclude loopback and link-local, keep CGNAT-range (`100.64.0.0/10`)
+  addresses labeled as Tailscale, and print **all** candidates so the user can
+  pick manually when the heuristic guesses wrong (better than Slidev, which
+  has no priority logic).
+
+## Out of scope (v1)
+
+- **QR code** — the author comment classifies it as a first-run convenience
+  once MagicDNS + a fixed `--port` make the URL bookmarkable. Follow-up.
+- **Speaker notes on the remote** — the open question is explicitly
+  undecided; the remote shows no notes and fetches only `manifest.json`.
+- **Swap / close controls on the remote** — a phone remote is a clicker;
+  accidentally ending or swapping the talk from a pocket is worse than not
+  having the buttons. The remote reacts to an inbound `{close:true}` by
+  showing an "ended" state, but never emits one.
+
+## Design
+
+### 1. Dual-bind server (`crates/peitho/src/server.rs`)
+
+Binding *only* the `--host` address would break the local slides/presenter
+windows: they open `http://localhost:<port>/...` (the dot-free app-name
+convention, which cannot change), and a server bound only to `100.x.y.z` does
+not listen on loopback. The invariant is: **local behavior is unchanged;
+`--host` only adds exposure.**
+
+- `PresentServer::bind` stays loopback-only and unchanged (preview keeps using
+  it as-is).
+- A pure decision function `bind_plan(host: Option<IpAddr>) -> BindPlan`
+  (unit-tested, no I/O) selects the listener topology:
+  - `None` → `LoopbackOnly` (unchanged default),
+  - unspecified host (`0.0.0.0` / `::`) → `WildcardOnly`: the wildcard is the
+    **single** listener — it already covers loopback, so dual-binding would
+    only create a same-port overlap that needs `SO_REUSEPORT`-style socket
+    flags, and those flags would let a second `peitho present --port N`
+    process bind the same active port silently. No reuse flags, ever.
+  - specific host → `LoopbackPlusExtra`: loopback primary (resolves the
+    port), then an extra listener at `(host, resolved_port)` sharing the same
+    `root` and `SyncHub` — two disjoint specific addresses on one port need
+    no socket flags on any platform.
+- `add_listener` rejects unspecified addresses (help: bind the wildcard as
+  the primary listener) so the overlap cannot be reintroduced; specific
+  loopback addresses stay accepted at the server API level (the loopback ban
+  is CLI policy, and tests use `::1` as the extra listener).
+- Known tradeoff: `--host ::` relies on the platform dual-stack default
+  (IPV6_V6ONLY off, dual-stack true on macOS and stock Linux) so local
+  windows' `127.0.0.1` URLs keep working; v6only platforms are out of scope.
+- `serve_forever` runs all accept loops (extra listener on a thread).
+- **Shutdown must unblock every listener**: `ShutdownHandle` used to hold the
+  one `Arc<Server>` that received the `{close:true}`. With two listeners, a
+  close arriving on either must unblock both, or the process never exits —
+  the shutdown path owns the shared listener list.
+- `--host` with a loopback address is a line-of-help error (it adds nothing);
+  unspecified addresses (`0.0.0.0` / `::`) are allowed.
+
+### 2. CLI flag (`crates/peitho/src/main.rs`)
+
+- `peitho present --host <IP>` — clap arg parsed as `IpAddr`, new
+  `PresentOptions::host: Option<IpAddr>`.
+- `--host` combined with `--no-serve` is an error (no server, nothing to
+  bind — no silent ignoring).
+- After binding, print the remote URL(s) next to the existing
+  `serving presentation at {url}` line:
+  - specific `--host` → one line: `remote control: http://<host>:<port>/remote`
+    (IPv6 bracketed).
+  - unspecified (`0.0.0.0`/`::`) → enumerate candidates (below), one line
+    each, default-route candidate first, Tailscale candidates labeled.
+
+### 3. Candidate URL enumeration (new, `crates/peitho/src/`)
+
+- Add the `if-addrs` crate to enumerate interface addresses.
+- Default-route IPv4 detection via the std-only UDP-connect trick
+  (`UdpSocket::connect("8.8.8.8:80")` + `local_addr()` — no packet is sent);
+  failure degrades to unordered candidates, never an error.
+- Pure function (unit-tested, no I/O):
+  `remote_url_candidates(addrs, default_route, port) -> Vec<RemoteUrlCandidate>`
+  - excludes loopback and link-local (`169.254.0.0/16`, `fe80::/10`),
+  - keeps and labels `100.64.0.0/10` as Tailscale,
+  - orders: default-route address first, then Tailscale, then the rest,
+  - formats `http://<ip>:<port>/remote`.
+
+### 4. Remote page (TS + template + embed)
+
+Follows the existing two-bundle pattern exactly, as a third bundle:
+
+- `packages/peitho-present/src/remote.ts` → `dist/remote.js` (new esbuild
+  entry in `esbuild.config.mjs`).
+- `BUILTIN_REMOTE_JS = include_str!(...)` next to `BUILTIN_SHELL_JS`
+  (`main.rs`), written into the present cache by `emit_present_cache` as
+  `remote.js`, with a drift test alongside the existing shell/preview drift
+  tests and the `git diff --exit-code` gate.
+- `render_remote_index()` template in `crates/peitho-core/src/render.rs`
+  (exported via `lib.rs`), written as `remote.html` into the present cache.
+  Namespace import + feature detection (`import * as peitho from
+  './remote.js'`), phone viewport meta, large touch targets.
+- Server: `/remote` alias → `remote.html` in `resolve_request_path`
+  (`server.rs`), next to the `/presenter` aliases.
+- Preview cache does **not** get remote assets (preview has no phone story).
+
+### 5. Remote page behavior (`src/remote.ts`)
+
+§16 holds: buttons only dispatch request events; the remote shell executes.
+
+- Buttons dispatch `peitho:navigate` `{to:"next"|"prev"}` (reuses the existing
+  event vocabulary).
+- A remote controller (`mountRemoteView` + `installRemoteSyncBridge`-style
+  seam, mirroring `shell.ts`/`sync.ts` structure):
+  - fetches `manifest.json` for slide count + `skip` flags; fetch failure is a
+    visible error state, never a blank page;
+  - joins `/sync` via the existing `serverSyncChannelFactory` (handshake +
+    poll); replayed `index` updates the local current index and the counter;
+  - `next`/`prev` resolve to an absolute index with `nextNonSkippedIndex`
+    from the current index (a `null` index — nobody has navigated yet —
+    resolves from the first non-skipped slide, matching present's initial
+    slide), then `POST /sync {"index":N}`; no-op at the ends;
+  - out-of-range replayed indexes are clamped, never crash;
+  - counter renders `current+1 / total` (indexes include skipped slides, same
+    as everywhere else);
+  - inbound `{close:true}` disables the buttons and shows an "ended" state;
+    `swapped` and `generation` are ignored (no reload story for present).
+- Exports added to `src/index.ts`? **No** — `remote.ts` is its own entry;
+  `shell.js` must not grow remote code.
+
+### 6. Docs
+
+- `site/content/guide/cli.md` `peitho present` section: document `--host`,
+  the `/remote` route, and the Tailscale recommendation (short — link the
+  thinking, don't duplicate the issue).
+
+## TDD task list
+
+Each step is red → green → refactor; production code only after a failing test.
+
+1. **`/remote` alias** — `server.rs` unit test: `resolve_request_path` maps
+   `/remote` → `remote.html`.
+2. **CLI parsing** — `main.rs` tests: `present --host 100.64.0.5` parses;
+   invalid IP fails; `--host` + `--no-serve` errors; loopback `--host` errors.
+3. **Dual bind + shutdown** — `crates/peitho/tests/present.rs` integration:
+   server with extra listener serves `manifest.json` on both addresses
+   (use `127.0.0.1` + a second loopback-reachable bind for CI safety — bind
+   extra on `127.0.0.1` is rejected, so exercise via `0.0.0.0` guarded or via
+   unit-level listener plumbing); `{close:true}` posted to either listener
+   unblocks both accept loops.
+4. **Candidate enumeration** — unit tests for `remote_url_candidates`:
+   loopback/link-local excluded, CGNAT labeled Tailscale, default-route
+   ordering, IPv6 bracket formatting.
+5. **Cache emit + embed** — `tests/present.rs`: present cache contains
+   `remote.html` + `remote.js`; drift test for `BUILTIN_REMOTE_JS`; preview
+   cache does not contain them.
+6. **Template** — render test: `render_remote_index` output uses namespace
+   import + feature detection, fetches `manifest.json`, has viewport meta.
+7. **Remote TS** — vitest `test/remote.test.ts`: buttons dispatch
+   `peitho:navigate`; controller resolves next/prev across skip flags;
+   posts `{index}`; null-index initial resolution; end no-ops; replay updates
+   counter; clamping; close → ended state; manifest fetch failure → error
+   state. Add to `generated.test.ts` export-presence checks if applicable.
+8. **URL printing** — present integration or unit seam: specific host prints
+   one URL; unspecified prints ordered labeled candidates.
+9. **Docs** — `cli.md` update (no test; reviewed by reading).
+
+## Gates
+
+All of `CLAUDE.md`'s gates, including the two dist drift checks plus the new
+`git diff --exit-code packages/peitho-present/dist/remote.js` once the bundle
+is committed, and `cargo test` × 3.

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -233,6 +233,10 @@ function nextNonSkippedIndex(slides, from, direction) {
   }
   return null;
 }
+function initialSlideIndex(slides) {
+  if (slides.length === 0) return null;
+  return nextNonSkippedIndex(slides, -1, 1) ?? 0;
+}
 
 // src/swap.ts
 var SWAP_ROUTES = Object.freeze({
@@ -248,8 +252,14 @@ var SWAP_ROUTES = Object.freeze({
 function isRecord(value) {
   return typeof value === "object" && value !== null;
 }
+function isIndexSyncMessage(value) {
+  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
+}
+function isSwappedSyncMessage(value) {
+  return isRecord(value) && typeof value.swapped === "boolean";
+}
 function isGenerationSyncMessage(value) {
-  return isRecord(value) && typeof value.generation === "number";
+  return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
 function serverSyncChannelFactory(options = {}) {
   const url = options.url ?? "/sync";
@@ -265,13 +275,13 @@ function serverSyncChannelFactory(options = {}) {
     let abortController = null;
     let retryTimer = null;
     const deliverReplayState = (body) => {
-      if (typeof body.index === "number") {
+      if (isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (typeof body.swapped === "boolean") {
+      if (isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
-      if (typeof body.generation === "number") {
+      if (isGenerationSyncMessage(body)) {
         onmessage?.({ data: { generation: body.generation } });
       }
     };
@@ -545,7 +555,7 @@ var PreviewShellController = class {
         this.slides.push(view);
       }
       const restored = this.restoredState;
-      const restoredIndex = restored === null ? this.clampIndex(nextNonSkippedIndex(pending.map((view) => view.meta), -1, 1) ?? 0) : this.clampIndex(restored.index);
+      const restoredIndex = restored === null ? this.clampIndex(initialSlideIndex(pending.map((view) => view.meta)) ?? 0) : this.clampIndex(restored.index);
       this.currentIndex = restoredIndex;
       this.selectedIndex = restoredIndex;
       this.mode = restored?.mode ?? "single";

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1,0 +1,361 @@
+// src/skipnav.ts
+function nextNonSkippedIndex(slides, from, direction) {
+  let index = from + direction;
+  while (index >= 0 && index < slides.length) {
+    if (slides[index].skip !== true) return index;
+    index += direction;
+  }
+  return null;
+}
+function initialSlideIndex(slides) {
+  if (slides.length === 0) return null;
+  return nextNonSkippedIndex(slides, -1, 1) ?? 0;
+}
+
+// src/keyboard.ts
+var navigationKeyMap = /* @__PURE__ */ new Map([
+  ["ArrowRight", "next"],
+  ["PageDown", "next"],
+  ["ArrowLeft", "prev"],
+  ["PageUp", "prev"],
+  ["Home", "first"],
+  ["End", "last"]
+]);
+var keyMap = new Map([...navigationKeyMap, [" ", "next"]]);
+
+// src/swap.ts
+var SWAP_ROUTES = Object.freeze({
+  "/present.html": Object.freeze({ swapped: false, counterpart: "presenter-swapped" }),
+  "/": Object.freeze({ swapped: false, counterpart: "presenter-swapped" }),
+  "/presenter": Object.freeze({ swapped: false, counterpart: "present-swapped" }),
+  "/presenter.html": Object.freeze({ swapped: false, counterpart: "present-swapped" }),
+  "/present-swapped": Object.freeze({ swapped: true, counterpart: "presenter" }),
+  "/presenter-swapped": Object.freeze({ swapped: true, counterpart: "present.html" })
+});
+
+// src/sync.ts
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function isCloseSyncMessage(value) {
+  return isRecord(value) && value.close === true;
+}
+function isIndexSyncMessage(value) {
+  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
+}
+function isSwappedSyncMessage(value) {
+  return isRecord(value) && typeof value.swapped === "boolean";
+}
+function isGenerationSyncMessage(value) {
+  return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
+}
+function serverSyncChannelFactory(options = {}) {
+  const url = options.url ?? "/sync";
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const retryMs = options.retryMs ?? 1e3;
+  const setTimeoutFn = options.setTimeoutFn ?? window.setTimeout.bind(window);
+  const clearTimeoutFn = options.clearTimeoutFn ?? window.clearTimeout.bind(window);
+  const AbortControllerCtor = options.AbortControllerCtor ?? AbortController;
+  return () => {
+    let onmessage = null;
+    let closed = false;
+    let seq = 0;
+    let abortController = null;
+    let retryTimer = null;
+    const deliverReplayState = (body) => {
+      if (isIndexSyncMessage(body)) {
+        onmessage?.({ data: { index: body.index } });
+      }
+      if (isSwappedSyncMessage(body)) {
+        onmessage?.({ data: { swapped: body.swapped } });
+      }
+      if (isGenerationSyncMessage(body)) {
+        onmessage?.({ data: { generation: body.generation } });
+      }
+    };
+    const delay = () => new Promise((resolve) => {
+      retryTimer = setTimeoutFn(() => {
+        retryTimer = null;
+        resolve();
+      }, retryMs);
+    });
+    const handshake = async () => {
+      try {
+        const response = await fetcher(url);
+        if (closed) return false;
+        if (!response.ok) {
+          console.error(`Failed to start sync polling: ${response.status}`);
+          await delay();
+          return false;
+        }
+        const body = await response.json();
+        if (typeof body.seq !== "number") {
+          console.error("Invalid peitho sync handshake");
+          await delay();
+          return false;
+        }
+        seq = body.seq;
+        deliverReplayState(body);
+        return true;
+      } catch (error) {
+        if (!closed) {
+          console.error(`Failed to start sync polling: ${String(error)}`);
+          await delay();
+        }
+        return false;
+      }
+    };
+    const poll = async () => {
+      let needsHandshake = true;
+      while (!closed) {
+        while (!closed && needsHandshake && !await handshake()) {
+          continue;
+        }
+        if (closed) return;
+        needsHandshake = false;
+        abortController = new AbortControllerCtor();
+        try {
+          const response = await fetcher(`${url}?seq=${seq}`, {
+            signal: abortController.signal
+          });
+          if (closed) return;
+          if (response.status === 204) continue;
+          if (!response.ok) {
+            console.error(`Failed to poll sync message: ${response.status}`);
+            await delay();
+            continue;
+          }
+          const body = await response.json();
+          if (typeof body.seq !== "number" || !("message" in body)) {
+            console.error("Invalid peitho server sync message");
+            await delay();
+            continue;
+          }
+          seq = body.seq;
+          if (body.message != null) {
+            onmessage?.({ data: body.message });
+          }
+          deliverReplayState(body);
+        } catch (error) {
+          if (!closed) {
+            console.error(`Failed to poll sync message: ${String(error)}`);
+            needsHandshake = true;
+            await delay();
+          }
+        }
+      }
+    };
+    void poll();
+    return {
+      get onmessage() {
+        return onmessage;
+      },
+      set onmessage(next) {
+        onmessage = next;
+      },
+      postMessage(message) {
+        void fetcher(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(message),
+          keepalive: true
+        }).then((response) => {
+          if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
+        }).catch((error) => {
+          console.error(`Failed to post sync message: ${String(error)}`);
+        });
+      },
+      close() {
+        closed = true;
+        abortController?.abort();
+        if (retryTimer !== null) {
+          clearTimeoutFn(retryTimer);
+          retryTimer = null;
+        }
+      }
+    };
+  };
+}
+
+// src/remote.ts
+async function mountRemoteView(options) {
+  const view = new RemoteController(options);
+  await view.load();
+  return view;
+}
+function installRemoteControls(options) {
+  const doc = options.document ?? document;
+  const bus = options.bus ?? window;
+  const root = options.root;
+  root.classList.remove("peitho-remote-error");
+  root.replaceChildren();
+  const container = doc.createElement("section");
+  container.className = "peitho-remote";
+  const counter = doc.createElement("div");
+  counter.className = "peitho-remote-counter";
+  counter.dataset.peithoRemote = "counter";
+  counter.textContent = "\u2013 / \u2013";
+  const status = doc.createElement("div");
+  status.className = "peitho-remote-status";
+  status.dataset.peithoRemote = "status";
+  const actions = doc.createElement("div");
+  actions.className = "peitho-remote-actions";
+  const prev = remoteButton(doc, "prev", "Previous");
+  const next = remoteButton(doc, "next", "Next");
+  const onPrev = () => dispatchNavigate(bus, "prev");
+  const onNext = () => dispatchNavigate(bus, "next");
+  prev.addEventListener("click", onPrev);
+  next.addEventListener("click", onNext);
+  actions.append(prev, next);
+  container.append(counter, status, actions);
+  root.append(container);
+  return () => {
+    prev.removeEventListener("click", onPrev);
+    next.removeEventListener("click", onNext);
+    container.remove();
+  };
+}
+function installRemoteSyncBridge(options) {
+  const bus = options.bus ?? window;
+  const log = options.console ?? console;
+  const channel = (options.channelFactory ?? serverSyncChannelFactory())("peitho-sync");
+  const onNavigate = (event) => {
+    const to = event.detail?.to;
+    if (to !== "next" && to !== "prev") return;
+    const target = resolveRemoteTarget(options.slides, options.getCurrentIndex(), to);
+    if (target === null) return;
+    channel.postMessage({ index: target });
+    options.setCurrentIndex(target);
+  };
+  channel.onmessage = (event) => {
+    const data = event.data;
+    if (isCloseSyncMessage(data)) {
+      options.setEnded();
+      return;
+    }
+    if (isIndexSyncMessage(data)) {
+      options.setCurrentIndex(data.index);
+      return;
+    }
+    if (isSwappedSyncMessage(data) || isGenerationSyncMessage(data)) return;
+    log.error("Invalid peitho remote sync message");
+  };
+  bus.addEventListener("peitho:navigate", onNavigate);
+  return () => {
+    bus.removeEventListener("peitho:navigate", onNavigate);
+    channel.onmessage = null;
+    channel.close();
+  };
+}
+var RemoteController = class {
+  manifest = null;
+  currentIndex = null;
+  root;
+  manifestUrl;
+  fetcher;
+  channelFactory;
+  win;
+  doc;
+  bus;
+  log;
+  slides = [];
+  controlsCleanup = null;
+  syncCleanup = null;
+  constructor(options) {
+    this.root = options.root;
+    this.manifestUrl = options.manifestUrl ?? "manifest.json";
+    this.fetcher = options.fetcher ?? fetch.bind(globalThis);
+    this.channelFactory = options.channelFactory;
+    this.win = options.window ?? window;
+    this.doc = options.document ?? document;
+    this.bus = options.bus ?? this.win;
+    this.log = options.console ?? console;
+  }
+  async load() {
+    try {
+      const manifest = await this.fetchJson(this.manifestUrl);
+      this.manifest = manifest;
+      this.slides = manifest.slides.map((slide) => ({ skip: slide.skip === true }));
+      this.currentIndex = initialSlideIndex(this.slides);
+      this.controlsCleanup = installRemoteControls({
+        root: this.root,
+        document: this.doc,
+        bus: this.bus
+      });
+      this.renderCounter();
+      this.syncCleanup = installRemoteSyncBridge({
+        slides: this.slides,
+        channelFactory: this.channelFactory,
+        bus: this.bus,
+        getCurrentIndex: () => this.currentIndex,
+        setCurrentIndex: (index) => this.setCurrentIndex(index),
+        setEnded: () => this.setEnded(),
+        console: this.log
+      });
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : String(error));
+    }
+  }
+  destroy() {
+    this.syncCleanup?.();
+    this.syncCleanup = null;
+    this.controlsCleanup?.();
+    this.controlsCleanup = null;
+  }
+  async fetchJson(url) {
+    const response = await this.fetcher(url);
+    if (!response.ok) throw new Error(`Failed to load ${url}: ${response.status}`);
+    return response.json();
+  }
+  setCurrentIndex(index) {
+    this.currentIndex = clampIndex(index, this.slides.length);
+    this.renderCounter();
+  }
+  setEnded() {
+    const cleanup = this.syncCleanup;
+    this.syncCleanup = null;
+    cleanup?.();
+    for (const button of this.root.querySelectorAll("[data-peitho-action]")) {
+      button.disabled = true;
+    }
+    const status = this.root.querySelector('[data-peitho-remote="status"]');
+    if (status != null) status.textContent = "Ended";
+  }
+  renderCounter() {
+    const counter = this.root.querySelector('[data-peitho-remote="counter"]');
+    if (counter == null) return;
+    const total = this.slides.length;
+    counter.textContent = this.currentIndex === null ? `\u2013 / ${total}` : `${this.currentIndex + 1} / ${total}`;
+  }
+  showError(message) {
+    this.destroy();
+    this.root.replaceChildren();
+    this.root.className = "peitho-remote-error";
+    this.root.textContent = message;
+  }
+};
+function remoteButton(doc, action, label) {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.dataset.peithoAction = action;
+  button.textContent = label;
+  return button;
+}
+function dispatchNavigate(bus, to) {
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+}
+function resolveRemoteTarget(slides, currentIndex, to) {
+  const base = currentIndex ?? initialSlideIndex(slides);
+  if (base === null) return null;
+  return nextNonSkippedIndex(slides, base, to === "next" ? 1 : -1);
+}
+function clampIndex(index, total) {
+  if (total === 0) return null;
+  return Math.max(0, Math.min(Math.trunc(index), total - 1));
+}
+export {
+  installRemoteControls,
+  installRemoteSyncBridge,
+  mountRemoteView
+};
+//# sourceMappingURL=remote.js.map

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -741,6 +741,10 @@ function nextNonSkippedIndex(slides, from, direction) {
   }
   return null;
 }
+function initialSlideIndex(slides) {
+  if (slides.length === 0) return null;
+  return nextNonSkippedIndex(slides, -1, 1) ?? 0;
+}
 
 // src/shell.ts
 async function mountPresentShell(options) {
@@ -825,7 +829,7 @@ var PresentShellController = class {
         this.root.appendChild(view.host);
         this.slides.push(view);
       }
-      this.show(nextNonSkippedIndex(pending.map((view) => view.meta), -1, 1) ?? 0);
+      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
     } catch (error) {
       this.clearCanvasRootProperties();
       this.root.replaceChildren();
@@ -1030,13 +1034,13 @@ function isCloseSyncMessage(value) {
   return isRecord(value) && value.close === true;
 }
 function isIndexSyncMessage(value) {
-  return isRecord(value) && typeof value.index === "number";
+  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
 }
 function isSwappedSyncMessage(value) {
   return isRecord(value) && typeof value.swapped === "boolean";
 }
 function isGenerationSyncMessage(value) {
-  return isRecord(value) && typeof value.generation === "number";
+  return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
 function defaultChannelFactory(name) {
   const channel = new BroadcastChannel(name);
@@ -1073,13 +1077,13 @@ function serverSyncChannelFactory(options = {}) {
     let abortController = null;
     let retryTimer = null;
     const deliverReplayState = (body) => {
-      if (typeof body.index === "number") {
+      if (isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (typeof body.swapped === "boolean") {
+      if (isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
-      if (typeof body.generation === "number") {
+      if (isGenerationSyncMessage(body)) {
         onmessage?.({ data: { generation: body.generation } });
       }
     };

--- a/packages/peitho-present/esbuild.config.mjs
+++ b/packages/peitho-present/esbuild.config.mjs
@@ -20,3 +20,10 @@ await build({
   outfile: "dist/preview.js",
   sourcemap: true
 });
+
+await build({
+  ...shared,
+  entryPoints: ["src/remote.ts"],
+  outfile: "dist/remote.js",
+  sourcemap: true
+});

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -5,7 +5,7 @@ import { createClickNavigationGuard } from "./clickNavigationGuard";
 import { installDocumentFontScope } from "./fontscope";
 import { hasChordModifier } from "./keyboard";
 import type { NavigateTarget, SlideChangeDetail } from "./shell";
-import { nextNonSkippedIndex } from "./skipnav";
+import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
 import {
   isGenerationSyncMessage,
   serverSyncChannelFactory,
@@ -240,7 +240,7 @@ class PreviewShellController implements PreviewShell {
       const restored = this.restoredState;
       const restoredIndex =
         restored === null
-          ? this.clampIndex(nextNonSkippedIndex(pending.map((view) => view.meta), -1, 1) ?? 0)
+          ? this.clampIndex(initialSlideIndex(pending.map((view) => view.meta)) ?? 0)
           : this.clampIndex(restored.index);
       this.currentIndex = restoredIndex;
       this.selectedIndex = restoredIndex;

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -1,0 +1,251 @@
+import type { Manifest } from "../../../bindings/Manifest";
+import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
+import {
+  isCloseSyncMessage,
+  isGenerationSyncMessage,
+  isIndexSyncMessage,
+  isSwappedSyncMessage,
+  serverSyncChannelFactory,
+  type SyncChannelFactory
+} from "./sync";
+
+type RemoteSlide = { skip: boolean };
+
+export type RemoteView = {
+  manifest: Manifest | null;
+  currentIndex: number | null;
+  destroy(): void;
+};
+
+export type RemoteViewOptions = {
+  root: HTMLElement;
+  manifestUrl?: string;
+  fetcher?: typeof fetch;
+  channelFactory?: SyncChannelFactory;
+  window?: Window;
+  document?: Document;
+  bus?: EventTarget;
+  console?: Pick<Console, "error">;
+};
+
+export type RemoteControlsOptions = {
+  root: HTMLElement;
+  document?: Document;
+  bus?: EventTarget;
+};
+
+export type RemoteSyncBridgeOptions = {
+  slides: ReadonlyArray<RemoteSlide>;
+  channelFactory?: SyncChannelFactory;
+  bus?: EventTarget;
+  getCurrentIndex(): number | null;
+  setCurrentIndex(index: number): void;
+  setEnded(): void;
+  console?: Pick<Console, "error">;
+};
+
+export async function mountRemoteView(options: RemoteViewOptions): Promise<RemoteView> {
+  const view = new RemoteController(options);
+  await view.load();
+  return view;
+}
+
+export function installRemoteControls(options: RemoteControlsOptions): () => void {
+  const doc = options.document ?? document;
+  const bus = options.bus ?? window;
+  const root = options.root;
+  root.classList.remove("peitho-remote-error");
+  root.replaceChildren();
+
+  const container = doc.createElement("section");
+  container.className = "peitho-remote";
+
+  const counter = doc.createElement("div");
+  counter.className = "peitho-remote-counter";
+  counter.dataset.peithoRemote = "counter";
+  counter.textContent = "– / –";
+
+  const status = doc.createElement("div");
+  status.className = "peitho-remote-status";
+  status.dataset.peithoRemote = "status";
+
+  const actions = doc.createElement("div");
+  actions.className = "peitho-remote-actions";
+
+  const prev = remoteButton(doc, "prev", "Previous");
+  const next = remoteButton(doc, "next", "Next");
+
+  const onPrev = (): void => dispatchNavigate(bus, "prev");
+  const onNext = (): void => dispatchNavigate(bus, "next");
+  prev.addEventListener("click", onPrev);
+  next.addEventListener("click", onNext);
+
+  actions.append(prev, next);
+  container.append(counter, status, actions);
+  root.append(container);
+
+  return () => {
+    prev.removeEventListener("click", onPrev);
+    next.removeEventListener("click", onNext);
+    container.remove();
+  };
+}
+
+export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () => void {
+  const bus = options.bus ?? window;
+  const log = options.console ?? console;
+  const channel = (options.channelFactory ?? serverSyncChannelFactory())("peitho-sync");
+
+  const onNavigate = (event: Event): void => {
+    const to = (event as CustomEvent<{ to?: unknown }>).detail?.to;
+    if (to !== "next" && to !== "prev") return;
+    const target = resolveRemoteTarget(options.slides, options.getCurrentIndex(), to);
+    if (target === null) return;
+    channel.postMessage({ index: target });
+    options.setCurrentIndex(target);
+  };
+
+  channel.onmessage = (event: { data: unknown }): void => {
+    const data = event.data;
+    if (isCloseSyncMessage(data)) {
+      options.setEnded();
+      return;
+    }
+    if (isIndexSyncMessage(data)) {
+      options.setCurrentIndex(data.index);
+      return;
+    }
+    if (isSwappedSyncMessage(data) || isGenerationSyncMessage(data)) return;
+    log.error("Invalid peitho remote sync message");
+  };
+
+  bus.addEventListener("peitho:navigate", onNavigate);
+  return () => {
+    bus.removeEventListener("peitho:navigate", onNavigate);
+    channel.onmessage = null;
+    channel.close();
+  };
+}
+
+class RemoteController implements RemoteView {
+  manifest: Manifest | null = null;
+  currentIndex: number | null = null;
+  private readonly root: HTMLElement;
+  private readonly manifestUrl: string;
+  private readonly fetcher: typeof fetch;
+  private readonly channelFactory?: SyncChannelFactory;
+  private readonly win: Window;
+  private readonly doc: Document;
+  private readonly bus: EventTarget;
+  private readonly log: Pick<Console, "error">;
+  private slides: RemoteSlide[] = [];
+  private controlsCleanup: (() => void) | null = null;
+  private syncCleanup: (() => void) | null = null;
+
+  constructor(options: RemoteViewOptions) {
+    this.root = options.root;
+    this.manifestUrl = options.manifestUrl ?? "manifest.json";
+    this.fetcher = options.fetcher ?? fetch.bind(globalThis);
+    this.channelFactory = options.channelFactory;
+    this.win = options.window ?? window;
+    this.doc = options.document ?? document;
+    this.bus = options.bus ?? this.win;
+    this.log = options.console ?? console;
+  }
+
+  async load(): Promise<void> {
+    try {
+      const manifest = await this.fetchJson<Manifest>(this.manifestUrl);
+      this.manifest = manifest;
+      this.slides = manifest.slides.map((slide) => ({ skip: slide.skip === true }));
+      this.currentIndex = initialSlideIndex(this.slides);
+      this.controlsCleanup = installRemoteControls({
+        root: this.root,
+        document: this.doc,
+        bus: this.bus
+      });
+      this.renderCounter();
+      this.syncCleanup = installRemoteSyncBridge({
+        slides: this.slides,
+        channelFactory: this.channelFactory,
+        bus: this.bus,
+        getCurrentIndex: () => this.currentIndex,
+        setCurrentIndex: (index) => this.setCurrentIndex(index),
+        setEnded: () => this.setEnded(),
+        console: this.log
+      });
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  destroy(): void {
+    this.syncCleanup?.();
+    this.syncCleanup = null;
+    this.controlsCleanup?.();
+    this.controlsCleanup = null;
+  }
+
+  private async fetchJson<T>(url: string): Promise<T> {
+    const response = await this.fetcher(url);
+    if (!response.ok) throw new Error(`Failed to load ${url}: ${response.status}`);
+    return response.json() as Promise<T>;
+  }
+
+  private setCurrentIndex(index: number): void {
+    this.currentIndex = clampIndex(index, this.slides.length);
+    this.renderCounter();
+  }
+
+  private setEnded(): void {
+    const cleanup = this.syncCleanup;
+    this.syncCleanup = null;
+    cleanup?.();
+    for (const button of this.root.querySelectorAll<HTMLButtonElement>("[data-peitho-action]")) {
+      button.disabled = true;
+    }
+    const status = this.root.querySelector<HTMLElement>('[data-peitho-remote="status"]');
+    if (status != null) status.textContent = "Ended";
+  }
+
+  private renderCounter(): void {
+    const counter = this.root.querySelector<HTMLElement>('[data-peitho-remote="counter"]');
+    if (counter == null) return;
+    const total = this.slides.length;
+    counter.textContent = this.currentIndex === null ? `– / ${total}` : `${this.currentIndex + 1} / ${total}`;
+  }
+
+  private showError(message: string): void {
+    this.destroy();
+    this.root.replaceChildren();
+    this.root.className = "peitho-remote-error";
+    this.root.textContent = message;
+  }
+}
+
+function remoteButton(doc: Document, action: "prev" | "next", label: string): HTMLButtonElement {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.dataset.peithoAction = action;
+  button.textContent = label;
+  return button;
+}
+
+function dispatchNavigate(bus: EventTarget, to: "prev" | "next"): void {
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+}
+
+function resolveRemoteTarget(
+  slides: ReadonlyArray<RemoteSlide>,
+  currentIndex: number | null,
+  to: "prev" | "next"
+): number | null {
+  const base = currentIndex ?? initialSlideIndex(slides);
+  if (base === null) return null;
+  return nextNonSkippedIndex(slides, base, to === "next" ? 1 : -1);
+}
+
+function clampIndex(index: number, total: number): number | null {
+  if (total === 0) return null;
+  return Math.max(0, Math.min(Math.trunc(index), total - 1));
+}

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -2,7 +2,7 @@ import type { Manifest } from "../../../bindings/Manifest";
 import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { installCanvasScaler, type CanvasViewport } from "./canvas";
 import { installDocumentFontScope } from "./fontscope";
-import { nextNonSkippedIndex } from "./skipnav";
+import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
 
 export type NavigateTarget =
   | "next"
@@ -141,7 +141,7 @@ class PresentShellController implements PresentShell {
         this.root.appendChild(view.host);
         this.slides.push(view);
       }
-      this.show(nextNonSkippedIndex(pending.map((view) => view.meta), -1, 1) ?? 0);
+      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
     } catch (error) {
       this.clearCanvasRootProperties();
       this.root.replaceChildren();

--- a/packages/peitho-present/src/skipnav.ts
+++ b/packages/peitho-present/src/skipnav.ts
@@ -10,3 +10,8 @@ export function nextNonSkippedIndex(
   }
   return null;
 }
+
+export function initialSlideIndex(slides: ReadonlyArray<{ skip: boolean }>): number | null {
+  if (slides.length === 0) return null;
+  return nextNonSkippedIndex(slides, -1, 1) ?? 0;
+}

--- a/packages/peitho-present/src/sync.ts
+++ b/packages/peitho-present/src/sync.ts
@@ -31,20 +31,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isCloseSyncMessage(value: unknown): value is { close: true } {
+export function isCloseSyncMessage(value: unknown): value is { close: true } {
   return isRecord(value) && value.close === true;
 }
 
-function isIndexSyncMessage(value: unknown): value is { index: number } {
-  return isRecord(value) && typeof value.index === "number";
+export function isIndexSyncMessage(value: unknown): value is { index: number } {
+  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
 }
 
-function isSwappedSyncMessage(value: unknown): value is { swapped: boolean } {
+export function isSwappedSyncMessage(value: unknown): value is { swapped: boolean } {
   return isRecord(value) && typeof value.swapped === "boolean";
 }
 
 export function isGenerationSyncMessage(value: unknown): value is { generation: number } {
-  return isRecord(value) && typeof value.generation === "number";
+  return (
+    isRecord(value) &&
+    typeof value.generation === "number" &&
+    Number.isFinite(value.generation)
+  );
 }
 
 function defaultChannelFactory(name: string): SyncChannel {
@@ -85,13 +89,13 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
     let retryTimer: number | null = null;
 
     const deliverReplayState = (body: Partial<ServerSyncPollResponse>): void => {
-      if (typeof body.index === "number") {
+      if (isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (typeof body.swapped === "boolean") {
+      if (isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
-      if (typeof body.generation === "number") {
+      if (isGenerationSyncMessage(body)) {
         onmessage?.({ data: { generation: body.generation } });
       }
     };

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, expect, it, vi } from "vitest";
+import type { Manifest } from "../../../bindings/Manifest";
+import { installRemoteControls, mountRemoteView, type RemoteView } from "../src/remote";
+import type { SyncChannel } from "../src/sync";
+
+type MockChannel = SyncChannel & {
+  sent: unknown[];
+  closed: boolean;
+  deliver(message: unknown): void;
+};
+
+function okJson(value: unknown): Response {
+  return { ok: true, status: 200, json: async () => value } as Response;
+}
+
+function fail(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as Response;
+}
+
+function manifestWithSlides(slides: Array<{ key: string; skip?: boolean }>): Manifest {
+  return {
+    version: 1,
+    peithoVersion: "0.1.0",
+    title: "Remote Demo",
+    slideCount: slides.length,
+    plannedDurationMs: null,
+    aspectRatio: "16:9",
+    canvasWidth: 1280,
+    canvasHeight: 720,
+    sections: [],
+    slides: slides.map((slide, index) => ({
+      index,
+      key: slide.key,
+      src: `slides/${String(index).padStart(3, "0")}-${slide.key}.html`,
+      hasNotes: false,
+      skip: slide.skip ?? false,
+      text: { title: "", body: "", code: "" }
+    })),
+    images: []
+  };
+}
+
+function fetchManifest(manifest: Manifest): typeof fetch {
+  return vi.fn(async (url: string) => {
+    if (url === "manifest.json") return okJson(manifest);
+    return fail(404);
+  }) as typeof fetch;
+}
+
+function mockChannel(): MockChannel {
+  const channel: MockChannel = {
+    sent: [],
+    closed: false,
+    onmessage: null,
+    postMessage(message: unknown) {
+      this.sent.push(message);
+    },
+    close() {
+      this.closed = true;
+    },
+    deliver(message: unknown) {
+      this.onmessage?.({ data: message });
+    }
+  };
+  return channel;
+}
+
+const cleanups: Array<() => void> = [];
+const views: RemoteView[] = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.();
+  while (views.length > 0) views.pop()?.destroy();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+function button(root: HTMLElement, action: "prev" | "next"): HTMLButtonElement {
+  const el = root.querySelector<HTMLButtonElement>(`[data-peitho-action="${action}"]`);
+  if (el == null) throw new Error(`missing ${action} button`);
+  return el;
+}
+
+async function mountRemoteForTest(
+  manifest: Manifest,
+  channel = mockChannel()
+): Promise<{ root: HTMLElement; channel: MockChannel; view: RemoteView }> {
+  const root = document.createElement("main");
+  document.body.appendChild(root);
+  const view = await mountRemoteView({
+    root,
+    manifestUrl: "manifest.json",
+    fetcher: fetchManifest(manifest),
+    channelFactory: () => channel,
+    window,
+    document,
+    bus: window
+  });
+  views.push(view);
+  return { root, channel, view };
+}
+
+it("remote buttons dispatch navigate request events only", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const requests: unknown[] = [];
+  bus.addEventListener("peitho:navigate", (event) => {
+    requests.push((event as CustomEvent).detail);
+  });
+  cleanups.push(installRemoteControls({ root, document, bus }));
+
+  button(root, "prev").click();
+  button(root, "next").click();
+
+  expect(requests).toEqual([{ to: "prev" }, { to: "next" }]);
+});
+
+it("remote controller resolves next and prev across skipped slides and posts absolute indexes", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "skip", skip: true }, { key: "end" }])
+  );
+
+  button(root, "next").click();
+  channel.deliver({ index: 2 });
+  button(root, "prev").click();
+
+  expect(channel.sent).toEqual([{ index: 2 }, { index: 0 }]);
+});
+
+it("remote controller advances optimistically across rapid taps", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "middle" }, { key: "end" }])
+  );
+
+  button(root, "next").click();
+  button(root, "next").click();
+
+  expect(channel.sent).toEqual([{ index: 1 }, { index: 2 }]);
+});
+
+it("remote controller treats a null replay index as the first non-skipped slide", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "skip", skip: true }, { key: "intro" }, { key: "end" }])
+  );
+
+  expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("2 / 3");
+  button(root, "next").click();
+
+  expect(channel.sent).toEqual([{ index: 2 }]);
+});
+
+it("remote controller no-ops at the ends", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "middle" }, { key: "end" }])
+  );
+
+  channel.deliver({ index: 2 });
+  button(root, "next").click();
+  channel.deliver({ index: 0 });
+  button(root, "prev").click();
+
+  expect(channel.sent).toEqual([]);
+});
+
+it("remote controller replays and clamps out-of-range indexes into the counter", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "middle" }, { key: "end" }])
+  );
+
+  channel.deliver({ index: 99 });
+  expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("3 / 3");
+
+  channel.deliver({ index: -10 });
+  expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("1 / 3");
+});
+
+it("remote controller disables buttons and shows ended state on close", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }])
+  );
+
+  channel.deliver({ close: true });
+
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(true);
+  expect(root.querySelector('[data-peitho-remote="status"]')?.textContent).toBe("Ended");
+});
+
+it("remote controller closes the sync channel and ignores clicks after ended", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }])
+  );
+
+  channel.deliver({ close: true });
+  button(root, "next").click();
+  button(root, "prev").click();
+
+  expect(channel.closed).toBe(true);
+  expect(channel.sent).toEqual([]);
+});
+
+it("remote manifest fetch failure is visible", async () => {
+  const root = document.createElement("main");
+  document.body.appendChild(root);
+
+  const view = await mountRemoteView({
+    root,
+    manifestUrl: "manifest.json",
+    fetcher: vi.fn(async () => fail(500)) as typeof fetch,
+    channelFactory: () => mockChannel(),
+    window,
+    document,
+    bus: window
+  });
+  views.push(view);
+
+  expect(root.textContent).toContain("Failed to load manifest.json: 500");
+  expect(root.className).toContain("peitho-remote-error");
+});

--- a/packages/peitho-present/test/skipnav.test.ts
+++ b/packages/peitho-present/test/skipnav.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from "vitest";
+import { initialSlideIndex, nextNonSkippedIndex } from "../src/skipnav";
+
+it("finds the next non-skipped slide in a direction", () => {
+  const slides = [{ skip: false }, { skip: true }, { skip: false }];
+
+  expect(nextNonSkippedIndex(slides, 0, 1)).toBe(2);
+  expect(nextNonSkippedIndex(slides, 2, -1)).toBe(0);
+});
+
+it("returns the first non-skipped slide as the initial slide", () => {
+  expect(initialSlideIndex([{ skip: true }, { skip: false }, { skip: false }])).toBe(1);
+});
+
+it("falls back to the first slide when every slide is skipped", () => {
+  expect(initialSlideIndex([{ skip: true }, { skip: true }])).toBe(0);
+});

--- a/packages/peitho-present/test/sync.test.ts
+++ b/packages/peitho-present/test/sync.test.ts
@@ -6,7 +6,13 @@ import {
   serverSyncChannelFactory
 } from "../src/index";
 import type { PresentShell } from "../src/index";
-import type { SyncChannel } from "../src/sync";
+import {
+  isCloseSyncMessage,
+  isGenerationSyncMessage,
+  isIndexSyncMessage,
+  isSwappedSyncMessage,
+  type SyncChannel
+} from "../src/sync";
 
 function okJson(value: unknown): Response {
   return { ok: true, status: 200, json: async () => value } as Response;
@@ -68,6 +74,21 @@ function mockChannel() {
   };
   return channel;
 }
+
+it("exports strict sync message guards", () => {
+  expect(isCloseSyncMessage({ close: true })).toBe(true);
+  expect(isCloseSyncMessage({ close: false })).toBe(false);
+
+  expect(isIndexSyncMessage({ index: 1 })).toBe(true);
+  expect(isIndexSyncMessage({ index: Number.NaN })).toBe(false);
+  expect(isIndexSyncMessage({ index: Number.POSITIVE_INFINITY })).toBe(false);
+
+  expect(isSwappedSyncMessage({ swapped: true })).toBe(true);
+  expect(isSwappedSyncMessage({ swapped: "true" })).toBe(false);
+
+  expect(isGenerationSyncMessage({ generation: 1 })).toBe(true);
+  expect(isGenerationSyncMessage({ generation: Number.NaN })).toBe(false);
+});
 
 it("server sync channel posts local messages to /sync", async () => {
   const fetcher = vi.fn((url: string, init?: RequestInit) => {

--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -68,6 +68,18 @@ Use windowed presenter mode while debugging:
 peitho present --presenter-windowed
 ```
 
+Use a phone as a clicker by exposing the present server on a reachable IP:
+
+```sh
+peitho present --host 100.64.0.5
+```
+
+The local slides and presenter windows still use loopback. A specific
+`--host` adds a listener for that address and prints exactly one `/remote`
+URL. A wildcard host (`0.0.0.0`/`::`) becomes the single listener, still
+covering loopback, and prints non-loopback `/remote` URL candidates for the
+phone. A Tailscale address is the recommended host when available.
+
 ## `peitho export`
 
 Export a PDF:


### PR DESCRIPTION
Closes #289

## What

A phone becomes the clicker: `peitho present --host <IP>` opts into non-loopback exposure, and the present server serves a phone-friendly `/remote` page (Previous/Next + slide counter) that drives navigation through the existing `/sync` long-polling channel with absolute `{index}` posts.

## Design

- **Listener topology is fixed at construction** (`PresentServer::bind_with_host`), executing a pure, unit-tested `bind_plan`:
  - no `--host` → loopback only (byte-identical to the previous behavior),
  - specific host (e.g. a Tailscale `100.x.y.z`) → loopback primary + extra listener on the resolved port — two disjoint specific addresses need no socket reuse flags,
  - wildcard host (`0.0.0.0`/`::`) → the wildcard is the **single** listener, since it already covers loopback. Dual-binding here would require `SO_REUSEPORT`-style flags, which would silently let a second `peitho present --port N` bind the same active port — rejected.
  - No public API can add listeners after construction, so a listener that never gets an accept loop is unrepresentable.
- **Shutdown owns all listeners**: `{close:true}` posted to either listener unblocks every accept loop (integration-tested in both directions), so the process always exits.
- **§16 event contract holds**: remote buttons only dispatch `peitho:navigate` request events; the remote controller resolves them with `nextNonSkippedIndex` (skipped-slide semantics match present-mode next/prev) and posts `{index}`. Inbound `{close:true}` tears down the poll channel (no polling a dead server from a phone) and shows an "ended" state. Manifest fetch failure is a visible error, never a blank page.
- **Printed remote URLs**: a specific `--host` prints exactly one URL; a wildcard host enumerates interface candidates (`if-addrs`) filtered to the bound address family, deduplicated, loopback/link-local excluded, Tailscale addresses (`100.64.0.0/10` and `fd7a:115c:a1e0::/48`) labeled, default-route address first — all candidates printed so the user can pick manually (per the issue comment's host-selection notes).
- **Third embedded bundle** `dist/remote.js` follows the shell/preview pattern exactly: esbuild entry, `include_str!` embed, drift test, new CI `git diff --exit-code dist/remote.js` gate, and the publish contamination check now rejects `remote.html`/`remote.js` in dist.
- `--host` with loopback, and `--host` + `--no-serve`, are line-of-help errors. Local slides/presenter windows keep their `127.0.0.1`/`localhost` URLs (Chrome app-name dot pitfall untouched).

## Out of scope (v1, per the issue's open questions)

- QR code (the issue comment classifies it as a first-run convenience under MagicDNS + fixed `--port`)
- Speaker notes on the remote (explicitly undecided)
- Swap/close controls on the remote (a pocket should not be able to end the talk)

Known tradeoffs are recorded in the design doc `docs/plans/2026-07-16-phone-remote.md` (`--host ::` relies on platform dual-stack defaults; optimistic counter update self-corrects via server echo replay).

## Verification

- All gates: `cargo test --workspace` ×3, clippy `-D warnings`, `fmt --check`, bindings drift, `npm run build && npm test && npm run typecheck` (213 tests), all three dist drift checks
- E2E on a real network + real Chrome: `--host <LAN IP>` serves `/remote` on both listeners, a POST on the LAN listener relays to loopback pollers, tapping Previous in Chrome skipped over a `skip:true` slide, `{close:true}` on the extra listener showed the "Ended" state and the process exited cleanly; `--host 0.0.0.0` single-listener path verified the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC