### PR TITLE
feat(remote): richer /remote page with preview, pace, notes, and timer control

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -781,13 +781,19 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote[data-peitho-ended="true"] .peitho-remote-dim-on-end { opacity: 0.35; }
     .peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0; }
     .peitho-remote-preview > * { position: absolute; inset: 0; }
-    .peitho-remote-titlebar, .peitho-remote-progress, .peitho-remote-pace, .peitho-remote-status { flex: none; }
+    .peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-status { flex: none; }
     .peitho-remote-titlebar { display: flex; align-items: baseline; gap: 12px; }
     .peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700; line-height: 1.2; color: #f5f7fb; }
     .peitho-remote-counter { flex: 0 0 auto; margin-left: auto; font-size: 16px; font-weight: 700; line-height: 1.2; color: #aab3c2; font-variant-numeric: tabular-nums; }
-    .peitho-remote-progress { position: relative; height: 5px; border-radius: 3px; background: #232935; overflow: visible; }
-    .peitho-remote-progress-fill { position: absolute; inset: 0 auto 0 0; width: 0%; border-radius: 3px; background: #38bdf8; }
-    .peitho-remote-plan-tick { position: absolute; top: -4px; width: 2px; height: 12px; background: #5a6473; opacity: 0.7; transform: translateX(-1px); }
+    .peitho-remote-chase { position: relative; height: 34px; overflow: visible; }
+    .peitho-remote-chase[data-peitho-chase="slide"] { height: 6px; }
+    .peitho-remote-chase-track { position: absolute; left: 0; right: 0; bottom: 0; height: 6px; border-radius: 999px; background: #232935; overflow: hidden; }
+    .peitho-remote-chase-fill { position: absolute; inset: 0 auto 0 0; width: 0%; border-radius: inherit; background: #38bdf8; }
+    .peitho-remote-chase[data-peitho-chase="time"] .peitho-remote-chase-fill { background: rgba(56,189,248,0.55); }
+    .peitho-remote-chase-overrun .peitho-remote-chase-track { box-shadow: 0 0 0 1px rgba(239,68,68,0.35); }
+    .peitho-remote-chase.peitho-remote-chase-overrun .peitho-remote-chase-fill { background: rgba(239,68,68,0.6); }
+    .peitho-remote-chase-marker { position: absolute; bottom: 8px; font-size: 17px; line-height: 1; filter: saturate(0.9); transition: left 120ms linear, transform 120ms linear; }
+    .peitho-remote-chase-marker[hidden] { display: none; }
     .peitho-remote-pace { display: flex; align-items: center; gap: 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
     .peitho-remote-timer-button { width: 44px; height: 44px; border-radius: 50%; border: 0; background: #232935; color: #fff; display: inline-grid; place-items: center; flex: 0 0 auto; touch-action: manipulation; }
     .peitho-remote-timer-button[data-peitho-running="true"] { background: rgba(56,189,248,0.18); color: #38bdf8; }
@@ -801,11 +807,11 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-elapsed { font-weight: 600; }
     .peitho-remote-time-separator { color: #6b7484; margin: 0 4px; }
     .peitho-remote-planned { color: #c3ccd9; font-weight: 500; }
-    .peitho-remote-pace-chip { border-radius: 999px; padding: 3px 9px; font-size: 12px; font-weight: 600; line-height: 1.35; white-space: nowrap; }
-    .peitho-remote-pace-chip[data-peitho-pace="behind"] { background: rgba(232,192,122,0.12); color: #e8c07a; }
-    .peitho-remote-pace-chip[data-peitho-pace="ahead"] { background: rgba(143,217,160,0.12); color: #8fd9a0; }
-    .peitho-remote-pace-chip[data-peitho-pace="paused"] { background: rgba(170,179,194,0.12); color: #aab3c2; }
-    .peitho-remote-pace-chip [data-peitho-pace-emoji] { font-size: 13px; filter: saturate(0.85); }
+    .peitho-remote-pace-delta { flex: 0 0 auto; font-size: 13px; font-weight: 600; line-height: 1.2; white-space: nowrap; color: #aab3c2; }
+    .peitho-remote-pace-delta[data-peitho-pace="behind"],
+    .peitho-remote-pace-delta[data-peitho-pace="overrun"] { color: #e8c07a; }
+    .peitho-remote-pace-delta[data-peitho-pace="ahead"] { color: #8fd9a0; }
+    .peitho-remote-pace-delta[data-peitho-pace="paused"] { color: #aab3c2; }
     .peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }
     .peitho-remote-section b { color: #dde3ec; font-weight: 600; }
     .peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
@@ -1752,19 +1758,32 @@ Paragraph after heading.
         assert!(html.contains("body { height: 100vh; height: 100svh; overflow: hidden; }"));
         assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px;"));
         assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
-        assert!(html.contains(".peitho-remote-titlebar, .peitho-remote-progress, .peitho-remote-pace, .peitho-remote-status { flex: none; }"));
+        assert!(html.contains(".peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-status { flex: none; }"));
         assert!(html.contains(
             ".peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700;"
         ));
-        assert!(html.contains(".peitho-remote-progress { position: relative; height: 5px; border-radius: 3px; background: #232935;"));
-        assert!(html.contains(".peitho-remote-plan-tick { position: absolute; top: -4px; width: 2px; height: 12px; background: #5a6473; opacity: 0.7;"));
+        assert!(html.contains(".peitho-remote-chase { position: relative; height: 34px;"));
+        assert!(html.contains(".peitho-remote-chase[data-peitho-chase=\"slide\"] { height: 6px;"));
+        assert!(html.contains(".peitho-remote-chase-track { position: absolute; left: 0; right: 0; bottom: 0; height: 6px; border-radius: 999px; background: #232935;"));
+        assert!(html.contains(".peitho-remote-chase-fill { position: absolute; inset: 0 auto 0 0; width: 0%; border-radius: inherit; background: #38bdf8;"));
+        assert!(html.contains(".peitho-remote-chase[data-peitho-chase=\"time\"] .peitho-remote-chase-fill { background: rgba(56,189,248,0.55);"));
+        assert!(html.contains(".peitho-remote-chase-overrun .peitho-remote-chase-track { box-shadow: 0 0 0 1px rgba(239,68,68,0.35);"));
+        assert!(html.contains(".peitho-remote-chase.peitho-remote-chase-overrun .peitho-remote-chase-fill { background: rgba(239,68,68,0.6);"));
+        assert!(html.contains(".peitho-remote-chase-marker { position: absolute; bottom: 8px; font-size: 17px; line-height: 1; filter: saturate(0.9);"));
         assert!(html.contains(
             ".peitho-remote-timer-button { width: 44px; height: 44px; border-radius: 50%;"
         ));
         assert!(html.contains(".peitho-remote-timer-button[data-peitho-running=\"true\"] { background: rgba(56,189,248,0.18);"));
-        assert!(html.contains(".peitho-remote-pace-chip[data-peitho-pace=\"behind\"] { background: rgba(232,192,122,0.12); color: #e8c07a;"));
-        assert!(html.contains(".peitho-remote-pace-chip[data-peitho-pace=\"ahead\"] { background: rgba(143,217,160,0.12); color: #8fd9a0;"));
-        assert!(html.contains(".peitho-remote-pace-chip[data-peitho-pace=\"paused\"] { background: rgba(170,179,194,0.12); color: #aab3c2;"));
+        assert!(html.contains(
+            ".peitho-remote-pace-delta { flex: 0 0 auto; font-size: 13px; font-weight: 600;"
+        ));
+        assert!(html.contains(".peitho-remote-pace-delta[data-peitho-pace=\"behind\"],"));
+        assert!(html
+            .contains(".peitho-remote-pace-delta[data-peitho-pace=\"overrun\"] { color: #e8c07a;"));
+        assert!(html
+            .contains(".peitho-remote-pace-delta[data-peitho-pace=\"ahead\"] { color: #8fd9a0;"));
+        assert!(html
+            .contains(".peitho-remote-pace-delta[data-peitho-pace=\"paused\"] { color: #aab3c2;"));
         assert!(html.contains(".peitho-remote-section { font-size: 12.5px; color: #aab3c2;"));
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -667,7 +667,15 @@ pub fn render_present_index(aspect_ratio: AspectRatio) -> String {
         peitho.installSwipeNavigation({ root, window });
         peitho.installFullscreenShortcut({ window, document });
         const shell = await peitho.mountPresentShell({ root });
-        peitho.installSyncBridge(window, peitho.serverSyncChannelFactory());
+        if (typeof shell.adoptTimerState !== 'function') {
+          throw new Error("shell bundle does not provide adoptTimerState; run npm run build or provide a current --shell bundle");
+        }
+        peitho.installSyncBridge(
+          window,
+          peitho.serverSyncChannelFactory(),
+          window,
+          { adoptTimerState: (state) => shell.adoptTimerState(state) }
+        );
         const config = await configPromise;
         if (config != null && config.presenterOpen) {
           if (typeof peitho.installSwapShortcut === 'function') {
@@ -755,25 +763,63 @@ pub fn render_preview_index(aspect_ratio: AspectRatio) -> String {
     fill_canvas_tokens(TEMPLATE, aspect_ratio)
 }
 
-pub fn render_remote_index() -> String {
-    r#"<!doctype html>
+pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
+    const TEMPLATE: &str = r#"<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Peitho Remote</title>
   <style>
-    :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-    html, body { margin: 0; min-height: 100%; background: #101216; color: #f5f7fb; }
-    body { min-height: 100vh; min-height: 100svh; }
-    #peitho-remote-root { min-height: 100vh; min-height: 100svh; display: grid; align-items: stretch; padding: 20px; padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
+    :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --peitho-canvas-width: __PEITHO_CANVAS_WIDTH__px; --peitho-canvas-height: __PEITHO_CANVAS_HEIGHT__px; --peitho-canvas-aspect: __PEITHO_CANVAS_ASPECT__; }
+    html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }
+    body { height: 100vh; height: 100svh; overflow: hidden; }
+    #peitho-remote-root { height: 100vh; height: 100svh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px; padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
     .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
-    .peitho-remote { width: min(100%, 32rem); margin: 0 auto; display: grid; grid-template-rows: auto 1fr auto; gap: 20px; min-height: calc(100vh - 40px); min-height: calc(100svh - 40px); }
-    .peitho-remote-counter { align-self: start; justify-self: center; font-size: clamp(2rem, 11vw, 4.5rem); font-weight: 700; }
-    .peitho-remote-status { min-height: 1.5em; text-align: center; color: #aab3c2; }
-    .peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-self: end; }
-    .peitho-remote button { min-height: 88px; border: 1px solid #384252; border-radius: 8px; background: #f5f7fb; color: #101216; font: inherit; font-size: 1.4rem; font-weight: 700; touch-action: manipulation; }
-    .peitho-remote button:disabled { opacity: 0.45; }
+    .peitho-remote { width: 100%; max-width: 32rem; margin: 0 auto; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 12px; }
+    .peitho-remote-dim-on-end { transition: opacity 120ms ease; }
+    .peitho-remote[data-peitho-ended="true"] .peitho-remote-dim-on-end { opacity: 0.35; }
+    .peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0; }
+    .peitho-remote-preview > * { position: absolute; inset: 0; }
+    .peitho-remote-titlebar, .peitho-remote-progress, .peitho-remote-pace, .peitho-remote-status { flex: none; }
+    .peitho-remote-titlebar { display: flex; align-items: baseline; gap: 12px; }
+    .peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700; line-height: 1.2; color: #f5f7fb; }
+    .peitho-remote-counter { flex: 0 0 auto; margin-left: auto; font-size: 16px; font-weight: 700; line-height: 1.2; color: #aab3c2; font-variant-numeric: tabular-nums; }
+    .peitho-remote-progress { position: relative; height: 5px; border-radius: 3px; background: #232935; overflow: visible; }
+    .peitho-remote-progress-fill { position: absolute; inset: 0 auto 0 0; width: 0%; border-radius: 3px; background: #38bdf8; }
+    .peitho-remote-plan-tick { position: absolute; top: -4px; width: 2px; height: 12px; background: #5a6473; opacity: 0.7; transform: translateX(-1px); }
+    .peitho-remote-pace { display: flex; align-items: center; gap: 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+    .peitho-remote-timer-button { width: 44px; height: 44px; border-radius: 50%; border: 0; background: #232935; color: #fff; display: inline-grid; place-items: center; flex: 0 0 auto; touch-action: manipulation; }
+    .peitho-remote-timer-button[data-peitho-running="true"] { background: rgba(56,189,248,0.18); color: #38bdf8; }
+    .peitho-remote-timer-icon { display: inline-block; position: relative; width: 16px; height: 16px; }
+    .peitho-remote-timer-icon[data-peitho-icon="play"] { width: 0; height: 0; margin-left: 3px; border-top: 8px solid transparent; border-bottom: 8px solid transparent; border-left: 11px solid currentColor; }
+    .peitho-remote-timer-icon[data-peitho-icon="pause"]::before,
+    .peitho-remote-timer-icon[data-peitho-icon="pause"]::after { content: ""; position: absolute; top: 1px; width: 3px; height: 13px; border-radius: 2px; background: currentColor; }
+    .peitho-remote-timer-icon[data-peitho-icon="pause"]::before { left: 4px; }
+    .peitho-remote-timer-icon[data-peitho-icon="pause"]::after { right: 4px; }
+    .peitho-remote-elapsed-row { flex: 1; min-width: 0; color: #f5f7fb; }
+    .peitho-remote-elapsed { font-weight: 600; }
+    .peitho-remote-time-separator { color: #6b7484; margin: 0 4px; }
+    .peitho-remote-planned { color: #c3ccd9; font-weight: 500; }
+    .peitho-remote-pace-chip { border-radius: 999px; padding: 3px 9px; font-size: 12px; font-weight: 600; line-height: 1.35; white-space: nowrap; }
+    .peitho-remote-pace-chip[data-peitho-pace="behind"] { background: rgba(232,192,122,0.12); color: #e8c07a; }
+    .peitho-remote-pace-chip[data-peitho-pace="ahead"] { background: rgba(143,217,160,0.12); color: #8fd9a0; }
+    .peitho-remote-pace-chip[data-peitho-pace="paused"] { background: rgba(170,179,194,0.12); color: #aab3c2; }
+    .peitho-remote-pace-chip [data-peitho-pace-emoji] { font-size: 13px; filter: saturate(0.85); }
+    .peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }
+    .peitho-remote-section b { color: #dde3ec; font-weight: 600; }
+    .peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
+    .peitho-remote-notes-caption { flex: 0 0 auto; font-size: 11px; font-weight: 600; line-height: 1.2; letter-spacing: 0.08em; color: #6b7484; text-transform: uppercase; }
+    .peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto; min-height: 0; }
+    .peitho-remote-notes-body[data-peitho-empty="true"] { color: #5a6473; font-size: 14px; font-style: italic; }
+    .peitho-remote-status { min-height: 1.4em; text-align: center; color: #aab3c2; font-size: 13px; line-height: 1.4; }
+    .peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; flex: none; }
+    .peitho-remote-actions button { min-height: 60px; border-radius: 999px; font: 600 17px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; touch-action: manipulation; }
+    .peitho-remote-actions [data-peitho-direction="prev"] { border: 1px solid #2f3644; background: transparent; color: #dde3ec; }
+    .peitho-remote-actions [data-peitho-direction="next"] { border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; }
+    .peitho-remote-actions button:disabled,
+    .peitho-remote-timer-button:disabled { opacity: 0.32; }
+    .peitho-remote-action-arrow { font-size: 20px; font-weight: 400; line-height: 1; opacity: 0.85; }
   </style>
 </head>
 <body>
@@ -790,10 +836,17 @@ pub fn render_remote_index() -> String {
     async function main() {
       const root = document.getElementById('peitho-remote-root');
       try {
-        if (typeof peitho.mountRemoteView === 'function') {
+        if (
+          typeof peitho.mountRemoteView === 'function' &&
+          typeof peitho.mountPresentShell === 'function' &&
+          typeof peitho.serverSyncChannelFactory === 'function'
+        ) {
           await peitho.mountRemoteView({
             root,
-            manifestUrl: 'manifest.json'
+            manifestUrl: 'manifest.json',
+            notesUrl: 'notes.json',
+            mountPresentShell: peitho.mountPresentShell,
+            syncChannelFactory: peitho.serverSyncChannelFactory()
           });
         } else {
           throw new Error("remote bundle does not provide mountRemoteView; run npm run build");
@@ -806,8 +859,9 @@ pub fn render_remote_index() -> String {
     main();
   </script>
 </body>
-</html>"#
-        .to_owned()
+</html>"#;
+
+    fill_canvas_tokens(TEMPLATE, aspect_ratio)
 }
 
 pub fn render_preview_error_index(generation: u64, error: &str) -> String {
@@ -1607,8 +1661,13 @@ Paragraph after heading.
         assert!(html.contains("installCloseOnEscape(window)"));
         assert!(html.contains("fetchOk('notes.json')"));
         assert!(html.contains("await peitho.mountPresentShell({ root })"));
+        assert!(html.contains("typeof shell.adoptTimerState !== 'function'"));
+        assert!(html.contains(
+            r#""shell bundle does not provide adoptTimerState; run npm run build or provide a current --shell bundle""#
+        ));
         assert!(html.contains("installKeyboardNavigation(window)"));
-        assert!(html.contains("installSyncBridge(window, peitho.serverSyncChannelFactory())"));
+        assert!(html.contains("peitho.installSyncBridge("));
+        assert!(html.contains("adoptTimerState: (state) => shell.adoptTimerState(state)"));
         assert!(html.contains("typeof peitho.installSwapShortcut === 'function'"));
         assert!(html.contains("config != null && config.presenterOpen"));
         assert!(html.contains("peitho.installSwapShortcut(window)"));
@@ -1622,9 +1681,7 @@ Paragraph after heading.
         let mount_index = html
             .find("await peitho.mountPresentShell({ root })")
             .unwrap();
-        let sync_index = html
-            .find("peitho.installSyncBridge(window, peitho.serverSyncChannelFactory())")
-            .unwrap();
+        let sync_index = html.find("peitho.installSyncBridge(").unwrap();
         let swap_index = html.find("peitho.installSwapShortcut(window)").unwrap();
         assert!(controls_index < mount_index);
         assert!(mount_index < sync_index);
@@ -1668,9 +1725,7 @@ Paragraph after heading.
         let mount_index = html
             .find("await peitho.mountPresentShell({ root })")
             .unwrap();
-        let sync_index = html
-            .find("peitho.installSyncBridge(window, peitho.serverSyncChannelFactory())")
-            .unwrap();
+        let sync_index = html.find("peitho.installSyncBridge(").unwrap();
         let config_fetch_index = html
             .find("const configPromise = fetchOk('present.json')")
             .unwrap();
@@ -1681,17 +1736,44 @@ Paragraph after heading.
     }
 
     #[test]
-    fn remote_index_mounts_remote_bundle_with_feature_detection() {
-        let html = render_remote_index();
+    fn remote_index_mounts_remote_bundle_with_feature_detection_and_canvas_tokens() {
+        let html = render_remote_index(AspectRatio::Ratio4To3);
 
         assert!(html.contains(
             r#"<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">"#
         ));
+        assert!(html.contains("--peitho-canvas-width: 960px;"));
+        assert!(html.contains("--peitho-canvas-height: 720px;"));
+        assert!(html.contains("--peitho-canvas-aspect: 4 / 3;"));
         assert!(html.contains("100svh"));
-        assert!(html.contains("body { min-height: 100vh; min-height: 100svh; }"));
-        assert!(html.contains("#peitho-remote-root { min-height: 100vh; min-height: 100svh;"));
         assert!(html.contains(
-            ".peitho-remote { width: min(100%, 32rem); margin: 0 auto; display: grid; grid-template-rows: auto 1fr auto; gap: 20px; min-height: calc(100vh - 40px); min-height: calc(100svh - 40px);"
+            "html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }"
+        ));
+        assert!(html.contains("body { height: 100vh; height: 100svh; overflow: hidden; }"));
+        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px;"));
+        assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
+        assert!(html.contains(".peitho-remote-titlebar, .peitho-remote-progress, .peitho-remote-pace, .peitho-remote-status { flex: none; }"));
+        assert!(html.contains(
+            ".peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700;"
+        ));
+        assert!(html.contains(".peitho-remote-progress { position: relative; height: 5px; border-radius: 3px; background: #232935;"));
+        assert!(html.contains(".peitho-remote-plan-tick { position: absolute; top: -4px; width: 2px; height: 12px; background: #5a6473; opacity: 0.7;"));
+        assert!(html.contains(
+            ".peitho-remote-timer-button { width: 44px; height: 44px; border-radius: 50%;"
+        ));
+        assert!(html.contains(".peitho-remote-timer-button[data-peitho-running=\"true\"] { background: rgba(56,189,248,0.18);"));
+        assert!(html.contains(".peitho-remote-pace-chip[data-peitho-pace=\"behind\"] { background: rgba(232,192,122,0.12); color: #e8c07a;"));
+        assert!(html.contains(".peitho-remote-pace-chip[data-peitho-pace=\"ahead\"] { background: rgba(143,217,160,0.12); color: #8fd9a0;"));
+        assert!(html.contains(".peitho-remote-pace-chip[data-peitho-pace=\"paused\"] { background: rgba(170,179,194,0.12); color: #aab3c2;"));
+        assert!(html.contains(".peitho-remote-section { font-size: 12.5px; color: #aab3c2;"));
+        assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
+        assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));
+        assert!(html.contains(
+            ".peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; flex: none;"
+        ));
+        assert!(html.contains(".peitho-remote-actions button { min-height: 60px; border-radius: 999px; font: 600 17px"));
+        assert!(html.contains(
+            ".peitho-remote[data-peitho-ended=\"true\"] .peitho-remote-dim-on-end { opacity: 0.35;"
         ));
         assert!(html.contains("env(safe-area-inset-bottom"));
         assert!(html.contains("import * as peitho from './remote.js';"));
@@ -1699,8 +1781,12 @@ Paragraph after heading.
         assert!(
             html.contains(r#""remote bundle does not provide mountRemoteView; run npm run build""#)
         );
+        assert!(html.contains("typeof peitho.mountPresentShell === 'function'"));
         assert!(html.contains("showError"));
         assert!(html.contains("manifestUrl: 'manifest.json'"));
+        assert!(html.contains("notesUrl: 'notes.json'"));
+        assert!(html.contains("mountPresentShell: peitho.mountPresentShell"));
+        assert!(html.contains("syncChannelFactory: peitho.serverSyncChannelFactory()"));
         assert!(html.contains("await peitho.mountRemoteView({"));
         assert!(!html.contains("import { mountRemoteView }"));
     }
@@ -1888,7 +1974,8 @@ Paragraph after heading.
         let html = render_present_index(AspectRatio::Ratio16To9);
 
         assert!(html.contains("serverSyncChannelFactory"));
-        assert!(html.contains("installSyncBridge(window, peitho.serverSyncChannelFactory())"));
+        assert!(html.contains("peitho.installSyncBridge("));
+        assert!(html.contains("adoptTimerState: (state) => shell.adoptTimerState(state)"));
         assert!(!html.contains("installSyncBridge(window);"));
     }
 

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -794,9 +794,10 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-chase.peitho-remote-chase-overrun .peitho-remote-chase-fill { background: rgba(239,68,68,0.6); }
     .peitho-remote-chase-marker { position: absolute; bottom: 8px; font-size: 17px; line-height: 1; filter: saturate(0.9); transition: left 120ms linear, transform 120ms linear; }
     .peitho-remote-chase-marker[hidden] { display: none; }
-    .peitho-remote-pace { display: flex; align-items: center; gap: 12px; font-size: 14px; font-variant-numeric: tabular-nums; }
+    .peitho-remote-pace { display: flex; align-items: center; gap: 10px; font-size: 14px; font-variant-numeric: tabular-nums; }
     .peitho-remote-timer-button { width: 44px; height: 44px; border-radius: 50%; border: 0; background: #232935; color: #fff; display: inline-grid; place-items: center; flex: 0 0 auto; touch-action: manipulation; }
     .peitho-remote-timer-button[data-peitho-running="true"] { background: rgba(56,189,248,0.18); color: #38bdf8; }
+    .peitho-remote-reset-button { width: 40px; height: 40px; border-radius: 50%; border: 1px solid #2f3644; background: transparent; color: #aab3c2; font-size: 18px; display: inline-grid; place-items: center; flex: 0 0 auto; touch-action: manipulation; }
     .peitho-remote-timer-icon { display: inline-block; position: relative; width: 16px; height: 16px; }
     .peitho-remote-timer-icon[data-peitho-icon="play"] { width: 0; height: 0; margin-left: 3px; border-top: 8px solid transparent; border-bottom: 8px solid transparent; border-left: 11px solid currentColor; }
     .peitho-remote-timer-icon[data-peitho-icon="pause"]::before,
@@ -812,6 +813,7 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-pace-delta[data-peitho-pace="overrun"] { color: #e8c07a; }
     .peitho-remote-pace-delta[data-peitho-pace="ahead"] { color: #8fd9a0; }
     .peitho-remote-pace-delta[data-peitho-pace="paused"] { color: #aab3c2; }
+    .peitho-remote-pace-delta[data-peitho-pace="onpace"] { color: #aab3c2; }
     .peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }
     .peitho-remote-section b { color: #dde3ec; font-weight: 600; }
     .peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
@@ -824,7 +826,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-actions [data-peitho-direction="prev"] { border: 1px solid #2f3644; background: transparent; color: #dde3ec; }
     .peitho-remote-actions [data-peitho-direction="next"] { border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; }
     .peitho-remote-actions button:disabled,
-    .peitho-remote-timer-button:disabled { opacity: 0.32; }
+    .peitho-remote-timer-button:disabled,
+    .peitho-remote-reset-button:disabled { opacity: 0.32; }
     .peitho-remote-action-arrow { font-size: 20px; font-weight: 400; line-height: 1; opacity: 0.85; }
   </style>
 </head>
@@ -1770,10 +1773,14 @@ Paragraph after heading.
         assert!(html.contains(".peitho-remote-chase-overrun .peitho-remote-chase-track { box-shadow: 0 0 0 1px rgba(239,68,68,0.35);"));
         assert!(html.contains(".peitho-remote-chase.peitho-remote-chase-overrun .peitho-remote-chase-fill { background: rgba(239,68,68,0.6);"));
         assert!(html.contains(".peitho-remote-chase-marker { position: absolute; bottom: 8px; font-size: 17px; line-height: 1; filter: saturate(0.9);"));
+        assert!(
+            html.contains(".peitho-remote-pace { display: flex; align-items: center; gap: 10px;")
+        );
         assert!(html.contains(
             ".peitho-remote-timer-button { width: 44px; height: 44px; border-radius: 50%;"
         ));
         assert!(html.contains(".peitho-remote-timer-button[data-peitho-running=\"true\"] { background: rgba(56,189,248,0.18);"));
+        assert!(html.contains(".peitho-remote-reset-button { width: 40px; height: 40px; border-radius: 50%; border: 1px solid #2f3644; background: transparent; color: #aab3c2; font-size: 18px;"));
         assert!(html.contains(
             ".peitho-remote-pace-delta { flex: 0 0 auto; font-size: 13px; font-weight: 600;"
         ));
@@ -1784,6 +1791,8 @@ Paragraph after heading.
             .contains(".peitho-remote-pace-delta[data-peitho-pace=\"ahead\"] { color: #8fd9a0;"));
         assert!(html
             .contains(".peitho-remote-pace-delta[data-peitho-pace=\"paused\"] { color: #aab3c2;"));
+        assert!(html
+            .contains(".peitho-remote-pace-delta[data-peitho-pace=\"onpace\"] { color: #aab3c2;"));
         assert!(html.contains(".peitho-remote-section { font-size: 12.5px; color: #aab3c2;"));
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -2789,7 +2789,7 @@ fn emit_present_cache(
     .into_diagnostic()?;
     fs::write(
         cache.join("remote.html"),
-        peitho_core::render_remote_index(),
+        peitho_core::render_remote_index(artifacts.rendered.settings().aspect_ratio()),
     )
     .into_diagnostic()?;
     fs::write(cache.join("remote.js"), BUILTIN_REMOTE_JS).into_diagnostic()?;

--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -3,13 +3,16 @@ use std::{
     io::{Read, Write},
     net::{IpAddr, SocketAddr},
     path::{Component, Path, PathBuf},
-    sync::{Arc, Condvar, Mutex, RwLock},
+    sync::{Arc, Condvar, Mutex, OnceLock, RwLock},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tiny_http::{Header, Method, Response, Server, StatusCode};
+
+static SERVER_CLOCK_START: OnceLock<Instant> = OnceLock::new();
 
 #[derive(Clone, Default)]
 pub(crate) struct SyncHub {
@@ -22,7 +25,16 @@ struct SyncState {
     latest: Option<String>,
     index: Option<usize>,
     swapped: bool,
+    timer: Option<TimerSyncState>,
     generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TimerSyncState {
+    running: bool,
+    elapsed_ms: u64,
+    at_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,6 +48,7 @@ struct SyncSnapshot {
     seq: u64,
     index: Option<usize>,
     swapped: bool,
+    timer: Option<TimerSyncState>,
     generation: u64,
 }
 
@@ -46,6 +59,13 @@ impl SyncHub {
         match message {
             SyncMessage::Index(message) => state.index = Some(message.index),
             SyncMessage::Swap(message) => state.swapped = message.swapped,
+            SyncMessage::Timer(message) => {
+                state.timer = Some(TimerSyncState {
+                    running: message.timer.running,
+                    elapsed_ms: message.timer.elapsed_ms,
+                    at_ms: server_clock_ms(),
+                });
+            }
             SyncMessage::Close(_) => {}
         }
         let json = serde_json::to_string(message).expect("SyncMessage serializes");
@@ -81,6 +101,7 @@ impl SyncHub {
                 seq: state.seq,
                 index: state.index,
                 swapped: state.swapped,
+                timer: state.timer,
                 generation: state.generation,
             },
             message: state.latest.clone(),
@@ -94,6 +115,7 @@ impl SyncHub {
             seq: state.seq,
             index: state.index,
             swapped: state.swapped,
+            timer: state.timer,
             generation: state.generation,
         }
     }
@@ -375,8 +397,8 @@ impl PresentServer {
             );
             return;
         }
-        self.sync.broadcast_sync_message(&message);
-        send_response(request, Response::empty(StatusCode(204)));
+        let seq = self.sync.broadcast_sync_message(&message);
+        send_json_response(request, sync_post_response_body(seq));
         if matches!(message, SyncMessage::Close(_)) {
             if let Some(shutdown) = shutdown {
                 shutdown.start();
@@ -453,6 +475,7 @@ impl ShutdownHandle {
 enum SyncMessage {
     Index(SyncIndexMessage),
     Swap(SyncSwapMessage),
+    Timer(SyncTimerMessage),
     Close(SyncCloseMessage),
 }
 
@@ -470,6 +493,19 @@ struct SyncSwapMessage {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+struct SyncTimerMessage {
+    timer: SyncTimerPayload,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SyncTimerPayload {
+    running: bool,
+    elapsed_ms: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SyncCloseMessage {
     close: bool,
 }
@@ -478,7 +514,7 @@ impl SyncMessage {
     fn is_valid(&self) -> bool {
         match self {
             Self::Close(message) => message.close,
-            Self::Index(_) | Self::Swap(_) => true,
+            Self::Index(_) | Self::Swap(_) | Self::Timer(_) => true,
         }
     }
 }
@@ -510,17 +546,44 @@ fn sync_get(url: &str) -> Option<SyncGet> {
 }
 
 fn sync_response_body(snapshot: SyncSnapshot, message: Option<&str>) -> String {
-    let index = snapshot
-        .index
-        .map_or_else(|| "null".to_owned(), |index| index.to_string());
-    format!(
-        r#"{{"seq":{},"message":{},"index":{},"swapped":{},"generation":{}}}"#,
-        snapshot.seq,
-        message.unwrap_or("null"),
-        index,
-        snapshot.swapped,
-        snapshot.generation
-    )
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct SyncResponseBody {
+        seq: u64,
+        message: Option<Value>,
+        index: Option<usize>,
+        swapped: bool,
+        generation: u64,
+        timer: Option<TimerSyncState>,
+        now_ms: u64,
+    }
+
+    let message = message
+        .map(|message| serde_json::from_str(message).expect("sync message is serialized JSON"));
+    serde_json::to_string(&SyncResponseBody {
+        seq: snapshot.seq,
+        message,
+        index: snapshot.index,
+        swapped: snapshot.swapped,
+        generation: snapshot.generation,
+        timer: snapshot.timer,
+        now_ms: server_clock_ms(),
+    })
+    .expect("sync response serializes")
+}
+
+fn sync_post_response_body(seq: u64) -> String {
+    #[derive(Serialize)]
+    struct SyncPostResponseBody {
+        seq: u64,
+    }
+
+    serde_json::to_string(&SyncPostResponseBody { seq }).expect("sync post response serializes")
+}
+
+fn server_clock_ms() -> u64 {
+    let duration = SERVER_CLOCK_START.get_or_init(Instant::now).elapsed();
+    u64::try_from(duration.as_millis()).expect("monotonic milliseconds fit in u64")
 }
 
 fn send_json_response(request: tiny_http::Request, body: String) {
@@ -718,12 +781,77 @@ mod tests {
                     seq: 1,
                     index: Some(2),
                     swapped: false,
+                    timer: None,
                     generation: 0
                 },
                 message: Some(r#"{"index":2}"#.to_owned())
             }
         );
         assert!(hub.wait_after(1, Duration::from_millis(1)).is_none());
+    }
+
+    #[test]
+    fn sync_hub_stores_and_replays_timer_state() {
+        let hub = SyncHub::default();
+
+        let message = SyncMessage::Timer(SyncTimerMessage {
+            timer: SyncTimerPayload {
+                running: true,
+                elapsed_ms: 12_345,
+            },
+        });
+        let seq = hub.broadcast_sync_message(&message);
+
+        assert_eq!(seq, 1);
+        let poll = hub.wait_after(0, Duration::from_secs(1)).unwrap();
+        assert_eq!(
+            poll.snapshot
+                .timer
+                .map(|timer| (timer.running, timer.elapsed_ms)),
+            Some((true, 12_345))
+        );
+        assert!(poll.snapshot.timer.unwrap().at_ms <= server_clock_ms());
+        assert_eq!(
+            poll.message,
+            Some(r#"{"timer":{"running":true,"elapsedMs":12345}}"#.to_owned())
+        );
+        assert_eq!(
+            hub.snapshot()
+                .timer
+                .map(|timer| (timer.running, timer.elapsed_ms)),
+            Some((true, 12_345))
+        );
+    }
+
+    #[test]
+    fn sync_hub_coalesces_to_latest_absolute_timer_state() {
+        let hub = SyncHub::default();
+
+        hub.broadcast_sync_message(&SyncMessage::Timer(SyncTimerMessage {
+            timer: SyncTimerPayload {
+                running: true,
+                elapsed_ms: 1_000,
+            },
+        }));
+        hub.broadcast_sync_message(&SyncMessage::Timer(SyncTimerMessage {
+            timer: SyncTimerPayload {
+                running: false,
+                elapsed_ms: 4_000,
+            },
+        }));
+
+        let poll = hub.wait_after(0, Duration::from_secs(1)).unwrap();
+        assert_eq!(poll.snapshot.seq, 2);
+        assert_eq!(
+            poll.snapshot
+                .timer
+                .map(|timer| (timer.running, timer.elapsed_ms)),
+            Some((false, 4_000))
+        );
+        assert_eq!(
+            poll.message,
+            Some(r#"{"timer":{"running":false,"elapsedMs":4000}}"#.to_owned())
+        );
     }
 
     #[test]
@@ -740,6 +868,7 @@ mod tests {
                     seq: 1,
                     index: None,
                     swapped: false,
+                    timer: None,
                     generation: 1
                 },
                 message: None
@@ -751,6 +880,7 @@ mod tests {
                 seq: 1,
                 index: None,
                 swapped: false,
+                timer: None,
                 generation: 1
             }
         );
@@ -763,20 +893,72 @@ mod tests {
                 seq: 4,
                 index: Some(2),
                 swapped: true,
+                timer: Some(TimerSyncState {
+                    running: true,
+                    elapsed_ms: 12_000,
+                    at_ms: 98_000,
+                }),
                 generation: 9,
             },
             None,
         );
 
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert!(body.contains(r#""generation":9"#));
         assert!(body.contains(r#""message":null"#));
         assert!(body.contains(r#""index":2"#));
         assert!(body.contains(r#""swapped":true"#));
+        assert_eq!(json["timer"]["running"], true);
+        assert_eq!(json["timer"]["elapsedMs"], 12_000);
+        assert_eq!(json["timer"]["atMs"], 98_000);
+        assert!(json["nowMs"].as_u64().unwrap() < 24 * 60 * 60 * 1000);
+    }
+
+    #[test]
+    fn sync_response_body_preserves_message_as_json() {
+        let body = sync_response_body(
+            SyncSnapshot {
+                seq: 7,
+                index: Some(2),
+                swapped: false,
+                timer: None,
+                generation: 0,
+            },
+            Some(r#"{"close":true}"#),
+        );
+
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["message"], serde_json::json!({"close": true}));
+    }
+
+    #[test]
+    fn sync_post_response_body_carries_assigned_sequence() {
+        let body = sync_post_response_body(42);
+
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["seq"], 42);
     }
 
     #[test]
     fn reload_is_not_accepted_as_a_posted_sync_message() {
         assert!(serde_json::from_str::<SyncMessage>(r#"{"reload":true}"#).is_err());
+    }
+
+    #[test]
+    fn invalid_timer_sync_messages_are_rejected() {
+        assert!(serde_json::from_str::<SyncMessage>(r#"{"timer":{"running":true}}"#).is_err());
+        assert!(serde_json::from_str::<SyncMessage>(
+            r#"{"timer":{"running":true,"elapsedMs":1000,"extra":1}}"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<SyncMessage>(
+            r#"{"timer":{"running":true,"elapsedMs":-1}}"#
+        )
+        .is_err());
+        assert!(serde_json::from_str::<SyncMessage>(
+            r#"{"timer":{"running":true,"elapsedMs":1000},"index":1}"#
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -63,9 +63,9 @@ fn present_no_serve_writes_clean_present_cache() {
     assert!(fs::read_to_string(cache.join("present.json"))
         .unwrap()
         .contains(r#""presenterOpen": false"#));
-    assert!(fs::read_to_string(cache.join("present.html"))
-        .unwrap()
-        .contains("installSyncBridge(window, peitho.serverSyncChannelFactory())"));
+    let present_html = fs::read_to_string(cache.join("present.html")).unwrap();
+    assert!(present_html.contains("peitho.installSyncBridge("));
+    assert!(present_html.contains("adoptTimerState: (state) => shell.adoptTimerState(state)"));
     assert!(fs::read_to_string(cache.join("present.html"))
         .unwrap()
         .contains("installCloseOnEscape(window)"));
@@ -213,7 +213,8 @@ fn present_server_extra_listener_serves_manifest_over_http() {
 
     let primary = get_http(primary_addr, "/manifest.json");
     let extra = get_http(extra_addr, "/manifest.json");
-    assert!(post_sync(primary_addr, r#"{"close":true}"#).contains("204 No Content"));
+    let close_response = post_sync(primary_addr, r#"{"close":true}"#);
+    assert_sync_post_ack(&close_response, 1);
     join_present_server(handle, Duration::from_secs(3));
 
     assert!(primary.contains("200 OK"));
@@ -270,7 +271,7 @@ fn present_server_relays_sync_post_to_long_poll_subscriber() {
         .unwrap();
 
     let post_response = post_sync(addr, r#"{"index":1}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     let event = read_until_contains(&mut poll, r#""swapped":false"#);
     assert!(event.contains("200 OK"));
@@ -296,14 +297,16 @@ fn present_server_poll_response_includes_current_replay_state() {
     let addr = server.addr();
     let handle = thread::spawn(move || server.serve_forever());
 
-    assert!(post_sync(addr, r#"{"swapped":true}"#).contains("204 No Content"));
+    let swap_response = post_sync(addr, r#"{"swapped":true}"#);
+    assert_sync_post_ack(&swap_response, 1);
 
     let mut poll = TcpStream::connect(addr).unwrap();
     poll.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
     poll.write_all(b"GET /sync?seq=1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
         .unwrap();
 
-    assert!(post_sync(addr, r#"{"index":3}"#).contains("204 No Content"));
+    let index_response = post_sync(addr, r#"{"index":3}"#);
+    assert_sync_post_ack(&index_response, 2);
 
     let event = read_until_contains(&mut poll, r#""swapped":true"#);
     assert!(event.contains("200 OK"));
@@ -335,7 +338,7 @@ fn present_server_relays_swap_sync_post_to_long_poll_subscriber() {
         .unwrap();
 
     let post_response = post_sync(addr, r#"{"swapped":true}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     let event = read_until_contains(&mut poll, r#""index":null"#);
     assert!(event.contains("200 OK"));
@@ -367,7 +370,7 @@ fn present_server_relays_close_sync_post_to_long_poll_subscriber() {
         .unwrap();
 
     let post_response = post_sync(addr, r#"{"close":true}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     let event = read_until_contains(&mut poll, r#""message":{"close":true}"#);
     assert!(event.contains("200 OK"));
@@ -440,7 +443,7 @@ fn present_server_shuts_down_after_close_sync_post() {
     let handle = thread::spawn(move || server.serve_forever());
 
     let post_response = post_sync(addr, r#"{"close":true}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     join_present_server(handle, Duration::from_secs(3));
 }
@@ -470,7 +473,7 @@ fn present_server_sync_handshake_returns_current_seq_without_replaying_latest_me
     });
 
     let post_response = post_sync(addr, r#"{"close":true}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     let mut stream = TcpStream::connect(addr).unwrap();
     stream
@@ -526,8 +529,10 @@ fn present_server_sync_handshake_replays_index_and_swapped_after_broadcasts() {
         server.handle_one();
     });
 
-    assert!(post_sync(addr, r#"{"index":2}"#).contains("204 No Content"));
-    assert!(post_sync(addr, r#"{"swapped":true}"#).contains("204 No Content"));
+    let index_response = post_sync(addr, r#"{"index":2}"#);
+    assert_sync_post_ack(&index_response, 1);
+    let swap_response = post_sync(addr, r#"{"swapped":true}"#);
+    assert_sync_post_ack(&swap_response, 2);
     let response = get_http(addr, "/sync");
     let body: serde_json::Value = serde_json::from_str(response_body(&response)).unwrap();
 
@@ -555,9 +560,12 @@ fn present_server_sync_close_does_not_clobber_replay_state() {
         server.handle_one();
     });
 
-    assert!(post_sync(addr, r#"{"index":2}"#).contains("204 No Content"));
-    assert!(post_sync(addr, r#"{"swapped":true}"#).contains("204 No Content"));
-    assert!(post_sync(addr, r#"{"close":true}"#).contains("204 No Content"));
+    let index_response = post_sync(addr, r#"{"index":2}"#);
+    assert_sync_post_ack(&index_response, 1);
+    let swap_response = post_sync(addr, r#"{"swapped":true}"#);
+    assert_sync_post_ack(&swap_response, 2);
+    let close_response = post_sync(addr, r#"{"close":true}"#);
+    assert_sync_post_ack(&close_response, 3);
     let response = get_http(addr, "/sync?seq=");
     let body: serde_json::Value = serde_json::from_str(response_body(&response)).unwrap();
 
@@ -735,7 +743,7 @@ fn present_process_exits_after_close_sync_post() {
     let addr = serving_addr(&line);
 
     let post_response = post_sync(addr, r#"{"close":true}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     let deadline = Instant::now() + Duration::from_secs(3);
     loop {
@@ -776,7 +784,7 @@ fn assert_dual_listener_shutdown(target: DualListenerCloseTarget) {
     let handle = thread::spawn(move || server.serve_forever());
 
     let post_response = post_sync(close_addr, r#"{"close":true}"#);
-    assert!(post_response.contains("204 No Content"));
+    assert_sync_post_ack(&post_response, 1);
 
     join_present_server(handle, Duration::from_secs(3));
 }
@@ -939,6 +947,13 @@ fn post_sync(addr: SocketAddr, body: &str) -> String {
     let mut response = String::new();
     post.read_to_string(&mut response).unwrap();
     response
+}
+
+fn assert_sync_post_ack(response: &str, seq: u64) {
+    assert!(response.contains("200 OK"));
+    assert!(response.contains("application/json"));
+    let body: serde_json::Value = serde_json::from_str(response_body(response)).unwrap();
+    assert_eq!(body["seq"], seq);
 }
 
 fn get_http(addr: SocketAddr, path: &str) -> String {

--- a/docs/plans/2026-07-16-remote-rich-view.md
+++ b/docs/plans/2026-07-16-remote-rich-view.md
@@ -259,13 +259,35 @@ presenter-style chase track, mirroring the PC presenter's time tracker
   positioned with `left: X%; transform: translateX(-X%)` — the same
   edge-safe placement as the presenter's `setMarker`).
 - **Fill follows 🐢 (time)**, like the presenter: `rgba(56,189,248,0.55)`.
-- **🐰 position** = slide fraction `index / (slideCount - 1)` (unchanged).
-  **🐢 position** = the existing `plannedProgressAtElapsed` fraction (the old
-  plan tick's position). Deliberate deviation from the presenter's linear
-  `elapsed / planned`: the piecewise mapping is what the behind/ahead number
-  uses, so markers and text can never contradict each other on decks with
-  uneven section times; without sections both definitions coincide at the
-  endpoints and the piecewise one is used throughout.
+- **Marker semantics: presenter-exact, by deliberate division of labor**
+  (settled 2026-07-17 after two live-tested iterations on the author's phone).
+  **🐰 position** = slide-consumption fraction `index / (slideCount - 1)`;
+  **🐢 position** = time-consumption fraction `elapsed / planned` — both
+  linear, identical to the PC presenter's time tracker. 🐰 reaches the flag on
+  the last slide; 🐢 reaches it exactly when the planned time is up.
+  The two channels intentionally measure different things: the **markers** are
+  the macro volume comparison (share of slides shown vs share of time used,
+  the same mental model as the presenter), while the **delta text** is the
+  section-aware pace figure built on the piecewise `expectedElapsedAtSlide`.
+  **Delta anchoring: the current slide's planned window is a neutral band**
+  (settled 2026-07-17, third live iteration — arrival anchoring read "behind"
+  the whole time you legitimately spent on a slide, even from second one of
+  the talk). With `window = [expected(index), expected(index + 1)]` (closed at
+  both ends; `expected(slideCount)` = the full planned time): elapsed before
+  the window → green `m:ss ahead` (early by that much); elapsed inside the
+  window → neutral gray `on pace`; elapsed strictly past the window → amber
+  `m:ss behind` (overstayed by that much). Overrun (`elapsed > planned`) still wins with `+m:ss over`, and
+  Paused still wins over everything while stopped. On decks with uneven section budgets the marker
+  order and the delta sign can therefore disagree — that is two indicators
+  reporting two truths (e.g. "half the slides shown but only a quarter of the
+  time used" while "3:00 behind on the light section"), not a contradiction.
+  Marker order must NOT be read as behind/ahead; the number owns that.
+  Rejected alternatives, both live-tested: a slide-arrival axis (🐢 reached
+  the flag before time was up — "turtle at the flag" must mean time is up) and
+  a time axis with 🐰 at the current slide's planned start (🐰 trailed 🐢 even
+  when perfectly on pace, and hopped unevenly). `plannedProgressAtElapsed`
+  (used by the old plan tick and the first chase cut) has no remaining
+  consumer and stays removed.
 - **Overrun** (`isOverrun`, i.e. elapsed > planned): the fill turns red
   (`rgba(239,68,68,0.6)`), the track gets a red ring
   (`box-shadow: 0 0 0 1px rgba(239,68,68,0.35)`), 🐢 pins at 100%.
@@ -273,6 +295,19 @@ presenter-style chase track, mirroring the PC presenter's time tracker
   the right end of the pace row (`13px/600`): behind = `#e8c07a`
   `m:ss behind`, ahead = `#8fd9a0` `m:ss ahead`, overrun = `#e8c07a`
   `+m:ss over` (delta = elapsed − planned), paused = `#aab3c2` `Paused`.
+- **Timer reset button** (added 2026-07-17, author-approved mock update): a
+  40px ghost circle (`border: 1px solid #2f3644`, transparent background,
+  `#aab3c2`, ↺ U+21BA at 18px) right of the play/pause button, pace-row gap
+  10px. Deliberately quieter than the tonal play/pause because reset zeroes
+  the shared timer on every window. One-tap for now (author decision; a
+  two-step confirm state is the fallback if accidental taps prove common).
+  Emits `peitho:timercontrol {action:"reset"}` (§16); the remote bridge posts
+  the absolute `{timer:{running:false,elapsedMs:0}}`. Disabled while
+  pre-synced, ended, or the timer is stopped at 0 (nothing to reset).
+  A reset adopted from sync (running:false, elapsedMs:0 — the same shape the
+  shell already treats as full reset) also zeroes the presenter agenda's
+  per-section actuals, matching what a presenter-local reset does — the two
+  reset paths must stay equivalent.
 - **No time-scale labels** (presenter has them; too cramped on a phone).
 - **Decks without `time`**: the chase degrades to the plain slide-progress
   fill (solid accent, as before) with no markers and no delta text.

--- a/docs/plans/2026-07-16-remote-rich-view.md
+++ b/docs/plans/2026-07-16-remote-rich-view.md
@@ -248,6 +248,37 @@ below are part of the design, not incidental patches:
   `navigate`/`adoptTimerState`) instead of positional defaults restated at
   every caller.
 
+## Amendment: hare-and-tortoise chase track (2026-07-17, author-approved "Remote v3" mock)
+
+The separate progress bar (+ plan tick) and pace chip merge into one
+presenter-style chase track, mirroring the PC presenter's time tracker
+(🐰 = slide position marker, 🐢 = time position marker) on the phone:
+
+- **Track**: a 34px-tall zone; the 6px rounded track sits at the bottom
+  (`#232935`), markers ride above it (17px emoji, `filter: saturate(0.9)`,
+  positioned with `left: X%; transform: translateX(-X%)` — the same
+  edge-safe placement as the presenter's `setMarker`).
+- **Fill follows 🐢 (time)**, like the presenter: `rgba(56,189,248,0.55)`.
+- **🐰 position** = slide fraction `index / (slideCount - 1)` (unchanged).
+  **🐢 position** = the existing `plannedProgressAtElapsed` fraction (the old
+  plan tick's position). Deliberate deviation from the presenter's linear
+  `elapsed / planned`: the piecewise mapping is what the behind/ahead number
+  uses, so markers and text can never contradict each other on decks with
+  uneven section times; without sections both definitions coincide at the
+  endpoints and the piecewise one is used throughout.
+- **Overrun** (`isOverrun`, i.e. elapsed > planned): the fill turns red
+  (`rgba(239,68,68,0.6)`), the track gets a red ring
+  (`box-shadow: 0 0 0 1px rgba(239,68,68,0.35)`), 🐢 pins at 100%.
+- **The pace chip is removed.** The number lives on as small colored text at
+  the right end of the pace row (`13px/600`): behind = `#e8c07a`
+  `m:ss behind`, ahead = `#8fd9a0` `m:ss ahead`, overrun = `#e8c07a`
+  `+m:ss over` (delta = elapsed − planned), paused = `#aab3c2` `Paused`.
+- **No time-scale labels** (presenter has them; too cramped on a phone).
+- **Decks without `time`**: the chase degrades to the plain slide-progress
+  fill (solid accent, as before) with no markers and no delta text.
+- 1 s tick updates stay in place: fill width, 🐢 `left/transform`, delta
+  text; 🐰 moves only on index change. Ended dims the whole track as before.
+
 ## Non-goals
 
 - Markdown rendering of notes (undecided item — plaintext only).

--- a/docs/plans/2026-07-16-remote-rich-view.md
+++ b/docs/plans/2026-07-16-remote-rich-view.md
@@ -1,0 +1,256 @@
+# Richer /remote page: preview, title/progress, sections, notes, pace, timer controls (Issue #299)
+
+Design finalized in Claude Design ("Sky Tonal Pill", 2026-07-16, author-approved).
+Scope decided by the author: all four candidate elements from the issue, plus a
+hare-and-tortoise pace indicator and start/pause/resume timer control. Notes get
+no gating beyond the existing `--host` opt-in. Layout is notes-first. The full
+agenda list is intentionally excluded (phone real estate); only a one-line
+current-section indicator is shown.
+
+## Final visual spec (from the approved mock)
+
+Phone-portrait column, top to bottom (page `gap: 12px`, padding `14px 14px 18px`,
+background `#101216`, text `#f5f7fb`):
+
+1. **Slide preview** — 16:9 box, `border-radius: 10px`, `border: 1px solid #2a3240`,
+   white background; renders the *current* slide via the same canvas approach as
+   the presenter's preview pane (scaled real slide, not a screenshot).
+2. **Title bar** — flex row: slide title (`16px/700`, nowrap + ellipsis) left,
+   counter `8 / 24` (`16px/700`, `#aab3c2`, tabular-nums) right.
+3. **Progress bar** — track `height: 5px`, `border-radius: 3px`, `#232935`;
+   fill = accent `#38bdf8` (no glow — tonal style), `border-radius: 3px`;
+   **plan tick**: absolute 2px×12px bar (`#5a6473`, opacity 0.7, `top: -4px`)
+   marking where the plan says you should be.
+4. **Pace row** — flex row, `gap: 12px`, `font-size: 14px`, tabular-nums:
+   - **Timer button** 44px circle. Running: background `rgba(56,189,248,0.18)`,
+     pause icon (two 3×13px bars) in accent. Stopped/paused: background `#232935`,
+     white play triangle (CSS border triangle, 11px wide, `margin-left: 3px`).
+   - **Elapsed / planned** — elapsed white `600`, `/` separator `#6b7484` with
+     4px side margins, planned `#c3ccd9 500`. Fills remaining width.
+   - **Pace chip** — pill (`border-radius: 999px`, `padding: 3px 9px`, `12px/600`,
+     no border): behind = 🐢 + `3:10 behind` on `rgba(232,192,122,0.12)` /
+     `#e8c07a`; ahead = 🐇 + `0:50 ahead` on `rgba(143,217,160,0.12)` / `#8fd9a0`;
+     paused = text `Paused` (no emoji) on `rgba(170,179,194,0.12)` / `#aab3c2`.
+     Emoji spans get `font-size: 13px` and `filter: saturate(0.85)`.
+5. **Section line** — `12.5px`, `#aab3c2`: `<b>Architecture</b> · slide 3 / 6 in section`
+   (name `#dde3ec 600`). Hidden entirely when the deck has no sections.
+6. **Notes panel** — flexible remainder (`flex: 1; min-height: 0`), background
+   `#181c23`, `border: 1px solid #2a3240`, `border-radius: 12px`, padding
+   `14px 16px`. Caption `NOTES` (`11px/600`, uppercase, `letter-spacing: 0.08em`,
+   `#6b7484`). Body `15px/1.65 #dde3ec`, `white-space: pre-wrap`, scrollable
+   (`overflow-y: auto`), rendered as plaintext `textContent` (same v1 policy as
+   the presenter; Markdown notes remain a separate undecided item). Empty note:
+   dimmed italic placeholder `No notes for this slide` (`#5a6473`, 14px).
+7. **Status line** — center, `13px #aab3c2`; shows `Ended` after close.
+8. **Prev/Next buttons** — grid `1fr 1fr`, `gap: 10px`, pill
+   (`border-radius: 999px`), `min-height: 60px`, `font: 600 17px`, with `‹`/`›`
+   arrow spans (`20px/400`, opacity 0.85). Previous: transparent background,
+   `1px solid #2f3644`, `#dde3ec`. Next: `rgba(56,189,248,0.14)` background,
+   accent text. Disabled: `opacity: 0.32` + `disabled` attribute.
+
+Button/row states (author-reviewed):
+
+- First navigable slide → Previous disabled; last navigable slide → Next disabled.
+  Disabled means "no non-skipped slide exists in that direction" (skip-aware,
+  recomputed on every index change).
+- Ended (close message received): everything disabled, status `Ended`, panels
+  dimmed to 0.35 opacity, sync channel closed. This is the "server is gone"
+  state, distinct from end-of-deck.
+- Deck without `time` frontmatter (`plannedDurationMs: null`): pace chip, plan
+  tick, and `/ planned` are omitted; timer button + elapsed still render.
+- Deck without sections: section line omitted (no empty row).
+- Timer states mirror the presenter's `TimerState` machine: stopped → play icon,
+  no chip; running → pause icon + ahead/behind chip; paused → play icon +
+  neutral `Paused` chip.
+
+## Architecture
+
+### Timer state must ride /sync (the one protocol change)
+
+The timer currently lives inside each window's `PresentShell`
+(`startedAtValue`/`pausedAtValue`/`pausedTotalMs`, transitions via
+`peitho:timercontrol` request events). Nothing about it crosses the server, so
+the remote can neither display elapsed time nor control the timer.
+
+Chosen design — **absolute timer state as a third sync state**, exactly like
+`index`/`swapped` (the alternative, forwarding `timercontrol` commands, is
+ruled out by the documented invariant that sync state must be absolute because
+the channel coalesces):
+
+- `POST /sync` additionally accepts `{"timer":{"running":bool,"elapsedMs":u64}}`
+  — the poster's elapsed at the moment of the transition. The server stamps it
+  with its own clock (`atMs`, epoch ms) when storing.
+- `SyncState` gains `timer: Option<TimerSyncState { running, elapsed_ms, at_ms }>`.
+- Every `/sync` JSON GET response (handshake and 200 poll) carries
+  `"timer":{...}|null` **and** `"nowMs":<server clock at response time>` on top
+  of the existing `seq`/`message`/`index`/`swapped`/`generation`.
+- Client rendering never compares clocks across devices: displayed elapsed =
+  `elapsedMs + (running ? (nowMs - atMs) + millis since the response arrived : 0)`.
+  Only the server's clock is compared with itself; the local advance between
+  polls uses the client's own clock for at most one poll cycle, and every
+  response re-anchors. Last-write-wins on concurrent transitions; replay is
+  idempotent (same convergence story as `swapped`).
+- Timer transitions may be executed by any client. The presenter keeps owning
+  its local shell transition (Space / buttons) but its sync bridge now also
+  posts the resulting absolute state; incoming timer state is applied to the
+  shell. The remote computes transitions from its last-synced state and posts
+  the new absolute state. The shell needs one new capability: adopt an absolute
+  external timer state (elapsed + running) instead of only deriving from local
+  `Date.now()` bookkeeping.
+
+### Slide preview
+
+Reuse the presenter's preview-pane approach: `mountPresentShell` onto a pane
+with `interactive: false`-equivalent options and a viewport sized to the pane
+(see `presenter.ts` `previewRoot` + `paneViewport`). The present cache already
+serves `slides/*.html`, `peitho.css`, and fonts; `remote.html` needs the same
+canvas CSS custom properties as `present.html`/`presenter.html`, so
+`render_remote_index()` takes the aspect ratio and runs through
+`fill_canvas_tokens` like the other templates. The preview shell follows
+`currentIndex` via the same bus events the remote already handles (no second
+sync channel; drive it locally like the presenter drives its preview pane).
+
+### Notes / titles / sections / progress
+
+All from already-served static assets: `manifest.json`
+(`slides[].text.title`, `slideCount`, `sections`, `plannedDurationMs`,
+`slides[].key`) and `notes.json` (`Notes.notes` keyed by slide key). Fetch both
+at mount (`notes.json` failure degrades to empty notes with a console error —
+the file always exists in the present cache, but the remote must not die on it).
+Current section = the `ManifestSection` whose `startIndex..=endIndex` contains
+the index (reuse `sectionIndexForSlide` from `sections.ts`).
+
+### Pace math (hare and tortoise)
+
+Only when `plannedDurationMs` is non-null. Expected-elapsed mapping over slide
+positions, piecewise by sections when present:
+
+- With sections: expected elapsed *at the start of* slide `i` = sum of
+  `plannedDurationMs` of all sections fully before the section containing `i`,
+  plus that section's duration × `(i - startIndex) / sectionSlideCount`.
+- Without sections: `plannedDurationMs × i / slideCount`.
+- Delta = actual elapsed − expected(currentIndex). Positive → behind (🐢),
+  negative → ahead (🐇), formatted `m:ss` via the existing
+  `formatMinuteSeconds`. Zero-planned decks can't happen (`PlannedTime` is
+  validated nonzero at construction).
+- Plan tick position = the inverse mapping: given elapsed, walk the same
+  piecewise curve to find the slide-position fraction the plan expects,
+  clamped to [0, 1]. Progress fill = `index / (slideCount - 1)` (100% on the
+  last slide; guard slideCount == 1).
+
+## Implementation tasks (TDD, in order)
+
+Each task: failing test first, then implementation, then the full gate list.
+
+### 1. peitho-core / server: timer sync state
+
+- `crates/peitho/src/server.rs`: `SyncTimerMessage { running, elapsed_ms }`
+  accepted by `POST /sync` (serde, same rejection rules as existing messages —
+  unknown shapes are still 400); `SyncState.timer: Option<TimerSyncState>`
+  stamped with server epoch ms on receipt; `SyncSnapshot` + `sync_response_body`
+  emit `"timer":{"running":…,"elapsedMs":…,"atMs":…}|null` and `"nowMs":…` in
+  **every** JSON GET response (handshake and 200 poll). Tests: hub stores/replays
+  timer state; response body includes `timer`/`nowMs` on handshake and poll;
+  invalid timer POST is rejected; coalescing keeps the latest absolute state.
+
+### 2. render.rs: remote template
+
+- `render_remote_index(aspect_ratio)` — canvas tokens + full final CSS from the
+  visual spec above + the same namespace-import/feature-detection loader
+  (feature-detect the new mount signature). Update `main.rs`/`server.rs` callers
+  and the existing template tests.
+
+### 3. peitho-present: sync plumbing
+
+- `sync.ts`: `SyncMessage` gains `{ timer: { running, elapsedMs } }`;
+  `isTimerSyncMessage` guard; the server channel's poll handler surfaces
+  `timer`/`nowMs` absolute state the same way it replays `index`/`swapped`
+  (per-poll replay is load-bearing — a window that misses a coalesced-away
+  transition converges on the next poll). Tests in `sync.test.ts` mirror the
+  swapped-replay ones.
+- `shell.ts`: new method to adopt absolute timer state (set elapsed base +
+  running flag from an external snapshot) — keeps `elapsedMs()` semantics;
+  `deriveTimerState` in the presenter must see the adopted state. Tests: adopt
+  while stopped/running/paused; elapsed advances only when running.
+- `presenter.ts` sync bridge: post `{timer}` after every local transition;
+  apply incoming timer state to the shell (idempotent replay). Tests via the
+  existing presenter test harness.
+
+### 4. peitho-present: remote view rebuild (`remote.ts` + `remote.test.ts`)
+
+- Fetch manifest + notes; mount preview shell; render title/counter, progress
+  fill + plan tick, pace row (timer button, elapsed/planned, chip), section
+  line, notes panel, status, prev/next pills per the spec and state rules above.
+- Timer button dispatches `peitho:timercontrol`-style request events on the
+  remote bus; the remote sync bridge executes the transition (compute new
+  absolute state from last-synced state + local advance) and posts `{timer}`
+  (§16: components emit requests; the bridge owns transitions).
+- Skip-aware disabled recomputation on every index change; ended state per
+  spec. A 1s interval re-renders elapsed/pace while running (cleared on
+  destroy/ended; no interval when stopped and nothing running).
+- jsdom tests for every state row in "Button/row states" above, plus pace math
+  unit tests (sections piecewise, no sections, clamping, ahead/behind/paused
+  chip selection, null planned time).
+
+### 5. Embedded bundles + gates
+
+- `npm run build` → commit `dist/remote.js` (+ `shell.js`/`preview.js` if they
+  drift); all gates from CLAUDE.md including the 3× `cargo test --workspace`.
+
+### 6. E2E (manual, before PR)
+
+- `peitho present --host --port <fixed>` on an example deck with sections +
+  notes; phone-simulated browser window on `/remote`: verify preview follows
+  navigation, notes/title/section update, timer start on remote reflects on
+  presenter (and vice versa), pace chip flips ahead/behind, first/last slide
+  button disabling, Esc → Ended. Screenshot evidence.
+
+## Review-driven design amendments (2026-07-16, adversarial review round)
+
+The multi-agent review of the first implementation confirmed six correctness
+bugs in the timer-sync path plus a landscape-layout regression. The fixes
+below are part of the design, not incidental patches:
+
+- **Handshake gating (`{synced:true}`)**: a client must not publish absolute
+  state, nor offer controls, before the handshake snapshot has been applied.
+  The server channel delivers replay state in the order timer → index →
+  swapped and then surfaces a one-time local `{synced:true}` data event; the
+  BroadcastChannel factory surfaces it immediately (locally, never across).
+  `installSyncBridge` drops outgoing `{timer}` posts until synced; the remote
+  mounts its controls disabled and enables them on the synced signal. This
+  kills two bugs: a reloaded/swapped window auto-start (timeTracker fires on
+  the replayed index navigation) rebroadcasting `elapsedMs: 0` over a live
+  timer, and a pre-handshake phone tap stomping live timer/index state.
+- **POST `/sync` acks `{"seq":N}`**: the channel records the highest acked
+  post seq and skips absolute-state replay from any response with a lower seq
+  (transient messages — especially `close` — are never skipped). Prevents an
+  in-flight poll response from reverting a just-posted pause/resume.
+- **`peitho:timeradopt` event**: `adoptTimerState` announces discontinuous
+  rebasing on a dedicated event (never re-posted, unlike `peitho:timerchange`);
+  the agenda listens and rebases its `lastElapsedMs` accumulator without
+  attributing the jump to the current section's actual time.
+- **Monotonic server clock**: `atMs`/`nowMs` are milliseconds since a
+  process-wide `Instant` (OnceLock), not wall clock, so NTP steps cannot shift
+  reconstructed elapsed. Only server-relative differences are ever consumed.
+- **Rounded wire elapsed**: both post sites round `elapsedMs` to integers
+  (serde deserializes u64; a fractional value would 400 every post).
+- **Bounded layout chain**: `html/body` and `#peitho-remote-root` use fixed
+  `height: 100svh` (not `min-height`) so flex shrinking actually engages;
+  preview (`flex: 0 1 auto; min-height: 0`) and notes compress on landscape
+  phones while the pace row and Previous/Next always stay visible (preserves
+  the 7d10b2a guarantee).
+- **Preview shell reuses the controller's manifest** (`ShellOptions.manifest`)
+  instead of a second `manifest.json` fetch, and the 1 s timer tick updates
+  only time-dependent chrome in place (persistent tick/chip/planned elements;
+  notes text is written only when changed) so iOS momentum scrolling of long
+  notes survives.
+- `installSyncBridge` takes a `hooks` object (`closeWindow`/`pathname`/
+  `navigate`/`adoptTimerState`) instead of positional defaults restated at
+  every caller.
+
+## Non-goals
+
+- Markdown rendering of notes (undecided item — plaintext only).
+- Full agenda list on the phone.
+- Any notes gating beyond `--host`.
+- Landscape-phone layout tuning (portrait-first; nothing breaks, just untuned).

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -258,6 +258,15 @@ function isIndexSyncMessage(value) {
 function isSwappedSyncMessage(value) {
   return isRecord(value) && typeof value.swapped === "boolean";
 }
+function isNonNegativeFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+function isTimerSyncMessage(value) {
+  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
+}
+function isTimerReplaySyncMessage(value) {
+  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
+}
 function isGenerationSyncMessage(value) {
   return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
@@ -272,13 +281,39 @@ function serverSyncChannelFactory(options = {}) {
     let onmessage = null;
     let closed = false;
     let seq = 0;
+    let synced = false;
+    let highestAckedPostSeq = 0;
+    let pendingTimerPosts = 0;
+    let bufferedTimerReplay = null;
     let abortController = null;
     let retryTimer = null;
-    const deliverReplayState = (body) => {
-      if (isIndexSyncMessage(body)) {
+    const flushBufferedTimerReplay = () => {
+      if (closed || pendingTimerPosts > 0 || bufferedTimerReplay == null) return;
+      const replay = bufferedTimerReplay;
+      bufferedTimerReplay = null;
+      if (replay.seq >= highestAckedPostSeq) {
+        onmessage?.({ data: replay.data });
+      }
+    };
+    const deliverReplayState = (body, options2 = {}) => {
+      const skipAbsoluteState = options2.skipAbsoluteState === true;
+      const responseSeq = typeof body.seq === "number" && Number.isFinite(body.seq) ? body.seq : 0;
+      if (isTimerReplaySyncMessage(body)) {
+        if (skipAbsoluteState) {
+          bufferedTimerReplay = null;
+        } else if (options2.deferTimerReplay === true) {
+          bufferedTimerReplay = {
+            seq: responseSeq,
+            data: { timer: body.timer, nowMs: body.nowMs }
+          };
+        } else {
+          onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
+        }
+      }
+      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (isSwappedSyncMessage(body)) {
+      if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
       if (isGenerationSyncMessage(body)) {
@@ -307,7 +342,14 @@ function serverSyncChannelFactory(options = {}) {
           return false;
         }
         seq = body.seq;
-        deliverReplayState(body);
+        deliverReplayState(body, {
+          skipAbsoluteState: body.seq < highestAckedPostSeq,
+          deferTimerReplay: pendingTimerPosts > 0
+        });
+        if (!synced) {
+          synced = true;
+          onmessage?.({ data: { synced: true } });
+        }
         return true;
       } catch (error) {
         if (!closed) {
@@ -347,7 +389,10 @@ function serverSyncChannelFactory(options = {}) {
           if (body.message != null) {
             onmessage?.({ data: body.message });
           }
-          deliverReplayState(body);
+          deliverReplayState(body, {
+            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            deferTimerReplay: pendingTimerPosts > 0
+          });
         } catch (error) {
           if (!closed) {
             console.error(`Failed to poll sync message: ${String(error)}`);
@@ -366,15 +411,42 @@ function serverSyncChannelFactory(options = {}) {
         onmessage = next;
       },
       postMessage(message) {
-        void fetcher(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(message),
-          keepalive: true
-        }).then((response) => {
-          if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
+        const isTimerPost = isTimerSyncMessage(message);
+        if (isTimerPost) pendingTimerPosts += 1;
+        const completeTimerPost = () => {
+          if (!isTimerPost) return;
+          pendingTimerPosts = Math.max(0, pendingTimerPosts - 1);
+          flushBufferedTimerReplay();
+        };
+        let request;
+        try {
+          request = fetcher(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(message),
+            keepalive: true
+          });
+        } catch (error) {
+          completeTimerPost();
+          console.error(`Failed to post sync message: ${String(error)}`);
+          return;
+        }
+        void request.then(async (response) => {
+          if (!response.ok) {
+            console.error(`Failed to post sync message: ${response.status}`);
+            return;
+          }
+          try {
+            const body = await response.json();
+            if (typeof body.seq === "number" && Number.isFinite(body.seq)) {
+              highestAckedPostSeq = Math.max(highestAckedPostSeq, body.seq);
+            }
+          } catch (_error) {
+          }
         }).catch((error) => {
           console.error(`Failed to post sync message: ${String(error)}`);
+        }).finally(() => {
+          completeTimerPost();
         });
       },
       close() {

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -761,6 +761,9 @@ function serverSyncChannelFactory(options = {}) {
 
 // src/timeTracker.ts
 var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
+function isOverrun(elapsedMs, plannedDurationMs) {
+  return elapsedMs > plannedDurationMs;
+}
 function isValidDurationMs(ms) {
   return Number.isSafeInteger(ms) && ms > 0;
 }
@@ -800,17 +803,28 @@ function installRemoteControls(options) {
   counter.dataset.peithoRemote = "counter";
   counter.textContent = "\u2013 / \u2013";
   titlebar.append(title, counter);
-  const progress = doc.createElement("div");
-  progress.className = "peitho-remote-progress peitho-remote-dim-on-end";
-  progress.dataset.peithoRemote = "progress";
-  const progressFill = doc.createElement("div");
-  progressFill.className = "peitho-remote-progress-fill";
-  progressFill.dataset.peithoRemote = "progress-fill";
-  const planTick = doc.createElement("div");
-  planTick.className = "peitho-remote-plan-tick";
-  planTick.dataset.peithoRemote = "plan-tick";
-  planTick.hidden = true;
-  progress.append(progressFill, planTick);
+  const chase = doc.createElement("div");
+  chase.className = "peitho-remote-chase peitho-remote-dim-on-end";
+  chase.dataset.peithoRemote = "chase";
+  chase.dataset.peithoChase = "slide";
+  const chaseTrack = doc.createElement("div");
+  chaseTrack.className = "peitho-remote-chase-track";
+  chaseTrack.dataset.peithoRemote = "chase-track";
+  const chaseFill = doc.createElement("div");
+  chaseFill.className = "peitho-remote-chase-fill";
+  chaseFill.dataset.peithoRemote = "chase-fill";
+  chaseTrack.append(chaseFill);
+  const rabbit = doc.createElement("span");
+  rabbit.className = "peitho-remote-chase-marker";
+  rabbit.dataset.peithoRemote = "marker-rabbit";
+  rabbit.setAttribute("aria-label", "slide progress");
+  rabbit.textContent = "\u{1F430}";
+  const turtle = doc.createElement("span");
+  turtle.className = "peitho-remote-chase-marker";
+  turtle.dataset.peithoRemote = "marker-turtle";
+  turtle.setAttribute("aria-label", "time progress");
+  turtle.textContent = "\u{1F422}";
+  chase.append(chaseTrack, rabbit, turtle);
   const pace = doc.createElement("div");
   pace.className = "peitho-remote-pace peitho-remote-dim-on-end";
   const timerButton = doc.createElement("button");
@@ -842,11 +856,11 @@ function installRemoteControls(options) {
   planned.dataset.peithoRemote = "planned";
   planned.hidden = true;
   elapsedRow.append(elapsed, separator, planned);
-  const chip = doc.createElement("span");
-  chip.className = "peitho-remote-pace-chip";
-  chip.dataset.peithoRemote = "pace-chip";
-  chip.hidden = true;
-  pace.append(timerButton, elapsedRow, chip);
+  const delta = doc.createElement("span");
+  delta.className = "peitho-remote-pace-delta";
+  delta.dataset.peithoRemote = "pace-delta";
+  delta.hidden = true;
+  pace.append(timerButton, elapsedRow, delta);
   const notesPanel = doc.createElement("section");
   notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
   const notesCaption = doc.createElement("div");
@@ -875,7 +889,7 @@ function installRemoteControls(options) {
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
   timerButton.addEventListener("click", onTimer);
-  container.append(preview, titlebar, progress, pace, notesPanel, status, actions);
+  container.append(preview, titlebar, chase, pace, notesPanel, status, actions);
   root.append(container);
   return () => {
     prev.removeEventListener("click", onPrev);
@@ -1095,7 +1109,7 @@ var RemoteController = class {
     const total = this.slides.length;
     setText(this.root, "title", slideTitle(slide?.text.title));
     setText(this.root, "counter", currentIndex == null ? `\u2013 / ${total}` : `${currentIndex + 1} / ${total}`);
-    this.renderProgress(manifest, currentIndex);
+    this.renderChase(manifest, currentIndex);
     this.renderPaceStatic(manifest);
     this.renderTimeDependentChrome(manifest, currentIndex);
     this.renderSection(manifest, currentIndex);
@@ -1105,13 +1119,13 @@ var RemoteController = class {
     this.syncPreview(currentIndex);
     this.updateTimerInterval();
   }
-  renderProgress(manifest, currentIndex) {
-    const progress = this.root.querySelector('[data-peitho-remote="progress"]');
-    const fill = this.root.querySelector('[data-peitho-remote="progress-fill"]');
-    if (progress == null || fill == null) return;
-    const fraction = currentIndex == null ? 0 : manifest.slideCount <= 1 ? 1 : currentIndex / (manifest.slideCount - 1);
-    fill.style.width = `${clamp01(fraction) * 100}%`;
-    this.updatePlanTick(manifest, this.currentElapsedMs());
+  renderChase(manifest, currentIndex) {
+    const rabbit = this.root.querySelector('[data-peitho-remote="marker-rabbit"]');
+    if (rabbit == null) return;
+    const plannedDurationMs = validPlannedDurationMs(manifest);
+    const planned = plannedDurationMs != null;
+    rabbit.hidden = !planned;
+    if (planned) setChaseMarker(rabbit, slideFraction(manifest, currentIndex));
   }
   renderPaceStatic(manifest) {
     const elapsedRow = this.root.querySelector('[data-peitho-remote="elapsed-row"]');
@@ -1138,35 +1152,51 @@ var RemoteController = class {
     const icon = timerButton.querySelector(".peitho-remote-timer-icon");
     if (icon != null) icon.dataset.peithoIcon = state === "running" ? "pause" : "play";
     elapsed.textContent = formatMinuteSeconds(elapsedMs);
-    this.updatePlanTick(manifest, elapsedMs);
-    const chip = this.root.querySelector('[data-peitho-remote="pace-chip"]');
-    if (chip == null || currentIndex == null) {
-      if (chip != null) chip.hidden = true;
+    this.updateChaseTime(manifest, currentIndex, elapsedMs, state);
+  }
+  updateChaseTime(manifest, currentIndex, elapsedMs, state) {
+    const chase = this.root.querySelector('[data-peitho-remote="chase"]');
+    const fill = this.root.querySelector('[data-peitho-remote="chase-fill"]');
+    const rabbit = this.root.querySelector('[data-peitho-remote="marker-rabbit"]');
+    const turtle = this.root.querySelector('[data-peitho-remote="marker-turtle"]');
+    const delta = this.root.querySelector('[data-peitho-remote="pace-delta"]');
+    if (chase == null || fill == null || rabbit == null || turtle == null || delta == null) return;
+    const plannedDurationMs = validPlannedDurationMs(manifest);
+    if (plannedDurationMs == null) {
+      chase.dataset.peithoChase = "slide";
+      chase.classList.remove("peitho-remote-chase-overrun");
+      rabbit.hidden = true;
+      turtle.hidden = true;
+      delta.hidden = true;
+      delta.textContent = "";
+      delete delta.dataset.peithoPace;
+      setChaseFill(fill, slideFraction(manifest, currentIndex));
+      return;
+    }
+    chase.dataset.peithoChase = "time";
+    rabbit.hidden = false;
+    turtle.hidden = false;
+    const overrun = isOverrun(elapsedMs, plannedDurationMs);
+    chase.classList.toggle("peitho-remote-chase-overrun", overrun);
+    const turtleFraction = overrun ? 1 : plannedProgressAtElapsed(manifest, elapsedMs);
+    setChaseMarker(turtle, turtleFraction ?? 0);
+    setChaseFill(fill, turtleFraction ?? 0);
+    if (currentIndex == null) {
+      delta.hidden = true;
+      delta.textContent = "";
+      delete delta.dataset.peithoPace;
       return;
     }
     const paceState = remotePaceState(manifest, currentIndex, elapsedMs, state === "running");
     if (paceState == null) {
-      chip.hidden = true;
-      chip.textContent = "";
+      delta.hidden = true;
+      delta.textContent = "";
+      delete delta.dataset.peithoPace;
       return;
     }
-    chip.hidden = false;
-    chip.dataset.peithoPace = paceState.kind;
-    if (paceState.emoji != null) {
-      const emoji = this.doc.createElement("span");
-      emoji.dataset.peithoPaceEmoji = "";
-      emoji.textContent = paceState.emoji === "hare" ? "\u{1F407}" : "\u{1F422}";
-      chip.replaceChildren(emoji, this.doc.createTextNode(` ${paceState.label}`));
-    } else {
-      chip.textContent = paceState.label;
-    }
-  }
-  updatePlanTick(manifest, elapsedMs) {
-    const tick = this.root.querySelector('[data-peitho-remote="plan-tick"]');
-    if (tick == null) return;
-    const planProgress = plannedProgressAtElapsed(manifest, elapsedMs);
-    tick.hidden = planProgress == null;
-    if (planProgress != null) tick.style.left = `${planProgress * 100}%`;
+    delta.hidden = false;
+    delta.dataset.peithoPace = paceState.kind;
+    delta.textContent = paceState.label;
   }
   renderSection(manifest, currentIndex) {
     const existing = this.root.querySelector('[data-peitho-remote="section"]');
@@ -1284,6 +1314,22 @@ function clampIndex(index, total) {
   if (total === 0) return null;
   return Math.max(0, Math.min(Math.trunc(index), total - 1));
 }
+function slideFraction(manifest, currentIndex) {
+  if (currentIndex == null) return 0;
+  if (manifest.slideCount <= 1) return 1;
+  return clamp01(currentIndex / (manifest.slideCount - 1));
+}
+function chasePercent(ratio) {
+  return Math.round(clamp01(ratio) * 1e4) / 100;
+}
+function setChaseMarker(element, ratio) {
+  const percent = chasePercent(ratio);
+  element.style.left = `${percent}%`;
+  element.style.transform = `translateX(${-percent}%)`;
+}
+function setChaseFill(element, ratio) {
+  element.style.width = `${chasePercent(ratio)}%`;
+}
 function setText(root, key, value) {
   const element = root.querySelector(`[data-peitho-remote="${key}"]`);
   if (element != null) element.textContent = value;
@@ -1339,20 +1385,25 @@ function remotePaceState(manifest, index, elapsedMs, running) {
   const expected = expectedElapsedAtSlide(manifest, index);
   if (expected == null) return null;
   if (!running) {
-    return elapsedMs > 0 ? { kind: "paused", label: "Paused", emoji: null } : null;
+    return elapsedMs > 0 ? { kind: "paused", label: "Paused" } : null;
+  }
+  const plannedDurationMs = validPlannedDurationMs(manifest);
+  if (plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)) {
+    return {
+      kind: "overrun",
+      label: `+${formatMinuteSeconds(elapsedMs - plannedDurationMs)} over`
+    };
   }
   const delta = elapsedMs - expected;
   if (delta >= 0) {
     return {
       kind: "behind",
-      label: `${formatMinuteSeconds(delta)} behind`,
-      emoji: "tortoise"
+      label: `${formatMinuteSeconds(delta)} behind`
     };
   }
   return {
     kind: "ahead",
-    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`,
-    emoji: "hare"
+    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`
   };
 }
 function currentTimerElapsedMs(timer, now) {

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1,3 +1,213 @@
+// src/sections.ts
+function sectionIndexForSlide(sections, slideIndex) {
+  return sections.findIndex(
+    (section) => slideIndex >= section.startIndex && slideIndex <= section.endIndex
+  );
+}
+
+// src/canvas.ts
+function calculateCanvasFit(viewport, canvasWidth, canvasHeight) {
+  const scale = Math.min(viewport.width / canvasWidth, viewport.height / canvasHeight);
+  const width = canvasWidth * scale;
+  const height = canvasHeight * scale;
+  return {
+    scale,
+    width,
+    height,
+    left: (viewport.width - width) / 2,
+    top: (viewport.height - height) / 2
+  };
+}
+function installCanvasScaler(options) {
+  const win = options.window ?? window;
+  const canvasWidth = options.canvasWidth;
+  const canvasHeight = options.canvasHeight;
+  const viewport = options.viewport ?? (() => ({
+    width: win.innerWidth,
+    height: win.innerHeight
+  }));
+  function apply() {
+    const fit = calculateCanvasFit(viewport(), canvasWidth, canvasHeight);
+    options.target.style.width = `${canvasWidth}px`;
+    options.target.style.height = `${canvasHeight}px`;
+    options.target.style.transformOrigin = "top left";
+    options.target.style.transform = `translate(${fit.left}px, ${fit.top}px) scale(${fit.scale})`;
+  }
+  apply();
+  win.addEventListener("resize", apply);
+  return () => win.removeEventListener("resize", apply);
+}
+
+// src/fontscope.ts
+var FONT_SCOPE_ATTRIBUTE = "data-peitho-font-scope";
+var FONT_SCOPE_SELECTOR = `style[${FONT_SCOPE_ATTRIBUTE}]`;
+var fontScopeStates = /* @__PURE__ */ new WeakMap();
+function extractFontScopeCss(css) {
+  return [...extractLeadingImports(css), ...extractTopLevelFontFaces(css)].join("\n");
+}
+function installDocumentFontScope(doc, css) {
+  const fontCss = extractFontScopeCss(css);
+  if (fontCss.trim() === "") return () => {
+  };
+  const tracked = fontScopeStates.get(doc);
+  if (tracked) {
+    tracked.references += 1;
+    return cleanupDocumentFontScope(doc, tracked.style);
+  }
+  const existing = doc.head.querySelector(FONT_SCOPE_SELECTOR);
+  if (existing) return () => {
+  };
+  const style = doc.createElement("style");
+  style.setAttribute(FONT_SCOPE_ATTRIBUTE, "");
+  style.textContent = fontCss;
+  doc.head.appendChild(style);
+  fontScopeStates.set(doc, { style, references: 1 });
+  return cleanupDocumentFontScope(doc, style);
+}
+function cleanupDocumentFontScope(doc, style) {
+  let active = true;
+  return () => {
+    if (!active) return;
+    active = false;
+    const state = fontScopeStates.get(doc);
+    if (!state || state.style !== style) return;
+    state.references -= 1;
+    if (state.references > 0) return;
+    state.style.remove();
+    fontScopeStates.delete(doc);
+  };
+}
+function extractLeadingImports(css) {
+  const imports = [];
+  let index = skipWhitespaceAndComments(css, 0);
+  while (startsWithAtRule(css, index, "@charset")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    index = skipWhitespaceAndComments(css, end);
+  }
+  while (startsWithAtRule(css, index, "@import")) {
+    const end = consumeStatement(css, index);
+    if (end === null) return imports;
+    imports.push(css.slice(index, end).trim());
+    index = skipWhitespaceAndComments(css, end);
+  }
+  return imports;
+}
+function extractTopLevelFontFaces(css) {
+  const blocks = [];
+  let depth = 0;
+  let index = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (depth === 0 && startsWithAtRule(css, index, "@font-face")) {
+      const end = consumeBlock(css, index);
+      if (end === null) return blocks;
+      blocks.push(css.slice(index, end).trim());
+      index = end;
+      continue;
+    }
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = Math.max(0, depth - 1);
+    index += 1;
+  }
+  return blocks;
+}
+function consumeStatement(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === ";") return index + 1;
+    index += 1;
+  }
+  return null;
+}
+function consumeBlock(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    if (css[index] === "{") break;
+    index += 1;
+  }
+  if (index >= css.length) return null;
+  let depth = 0;
+  while (index < css.length) {
+    const next = skipCommentOrString(css, index);
+    if (next !== index) {
+      index = next;
+      continue;
+    }
+    const char = css[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+    index += 1;
+  }
+  return null;
+}
+function skipWhitespaceAndComments(css, start) {
+  let index = start;
+  while (index < css.length) {
+    const char = css[index];
+    if (isCssWhitespace(char)) {
+      index += 1;
+      continue;
+    }
+    if (css.startsWith("/*", index)) {
+      index = skipComment(css, index);
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+function skipCommentOrString(css, index) {
+  if (css.startsWith("/*", index)) return skipComment(css, index);
+  const char = css[index];
+  if (char === '"' || char === "'") return skipString(css, index);
+  return index;
+}
+function skipComment(css, index) {
+  const end = css.indexOf("*/", index + 2);
+  return end < 0 ? css.length : end + 2;
+}
+function skipString(css, index) {
+  const quote = css[index];
+  index += 1;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === "\\") {
+      index += 2;
+      continue;
+    }
+    if (char === quote) return index + 1;
+    index += 1;
+  }
+  return index;
+}
+function startsWithAtRule(css, index, rule) {
+  if (css.slice(index, index + rule.length).toLowerCase() !== rule) return false;
+  const next = css[index + rule.length];
+  return next === void 0 || !/[a-zA-Z0-9_-]/.test(next);
+}
+function isCssWhitespace(char) {
+  return char === " " || char === "\n" || char === "\r" || char === "	" || char === "\f";
+}
+
 // src/skipnav.ts
 function nextNonSkippedIndex(slides, from, direction) {
   let index = from + direction;
@@ -11,6 +221,303 @@ function initialSlideIndex(slides) {
   if (slides.length === 0) return null;
   return nextNonSkippedIndex(slides, -1, 1) ?? 0;
 }
+
+// src/shell.ts
+async function mountPresentShell(options) {
+  const shell = new PresentShellController(options);
+  await shell.load();
+  return shell;
+}
+var PresentShellController = class {
+  manifest = null;
+  currentIndex = -1;
+  slides = [];
+  root;
+  fetcher;
+  injectedManifest;
+  win;
+  doc;
+  log;
+  bus;
+  now;
+  viewport;
+  canvasCleanups = [];
+  fontScopeCleanup = null;
+  startedAtValue = null;
+  pausedAtValue = null;
+  pausedTotalMs = 0;
+  ended = false;
+  onNavigate = (event) => {
+    const detail = event.detail;
+    if (!detail || !("to" in detail)) {
+      this.log.error("Invalid peitho:navigate event");
+      return;
+    }
+    this.navigate(detail.to);
+  };
+  onTimerControl = (event) => {
+    const action = event.detail?.action;
+    if (action === "start") this.startPresentation();
+    else if (action === "pause") this.pauseTimer();
+    else if (action === "resume") this.resumeTimer();
+    else if (action === "reset") this.resetTimer();
+    else this.log.error("Invalid peitho:timercontrol event");
+  };
+  onPageHide = () => this.endPresentation();
+  constructor(options) {
+    this.root = options.root;
+    this.injectedManifest = options.manifest;
+    this.fetcher = options.fetcher ?? fetch.bind(globalThis);
+    this.win = options.window ?? window;
+    this.doc = options.document ?? document;
+    this.log = options.console ?? console;
+    this.bus = options.bus ?? this.win;
+    this.now = options.now ?? Date.now;
+    this.viewport = options.viewport;
+    this.root.classList.add("peitho-shell-viewport");
+    const rootPosition = this.win.getComputedStyle(this.root).position;
+    if (rootPosition === "static" || rootPosition === "") {
+      this.root.style.position = "relative";
+    }
+    this.root.style.overflow = "hidden";
+    this.root.style.background = "#000";
+    this.bus.addEventListener("peitho:navigate", this.onNavigate);
+    this.bus.addEventListener("peitho:timercontrol", this.onTimerControl);
+    this.win.addEventListener("pagehide", this.onPageHide);
+  }
+  async load() {
+    try {
+      const manifest = this.injectedManifest ?? await this.fetchJson("manifest.json");
+      const dimensions = {
+        width: manifest.canvasWidth,
+        height: manifest.canvasHeight
+      };
+      const cssAspect = manifest.aspectRatio.replace(":", " / ");
+      this.setCanvasRootProperties(dimensions, cssAspect);
+      const css = await this.fetchText("peitho.css");
+      this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
+      const pending = [];
+      for (const slide of manifest.slides) {
+        const html = await this.fetchText(slide.src);
+        const host = this.createSlideHost(slide, html, css, dimensions);
+        pending.push({ meta: slide, host });
+      }
+      this.manifest = manifest;
+      for (const view of pending) {
+        this.root.appendChild(view.host);
+        this.slides.push(view);
+      }
+      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+    } catch (error) {
+      this.clearCanvasRootProperties();
+      this.root.replaceChildren();
+      this.root.textContent = error instanceof Error ? error.message : String(error);
+    }
+  }
+  navigate(to) {
+    const index = this.resolveTarget(to);
+    if (index === null) return;
+    this.show(index);
+  }
+  elapsedMs() {
+    if (this.startedAtValue === null) return 0;
+    const current = this.now();
+    const pausedNow = this.pausedAtValue === null ? 0 : current - this.pausedAtValue;
+    return Math.max(0, current - this.startedAtValue - this.pausedTotalMs - pausedNow);
+  }
+  isPaused() {
+    return this.pausedAtValue !== null;
+  }
+  startedAt() {
+    return this.startedAtValue;
+  }
+  adoptTimerState(state) {
+    const elapsedMs = Math.max(0, state.elapsedMs);
+    const previousElapsedMs = this.elapsedMs();
+    if (!state.running && elapsedMs === 0) {
+      this.startedAtValue = null;
+      this.pausedAtValue = null;
+      this.pausedTotalMs = 0;
+      this.ended = false;
+      this.dispatchTimerAdopt(elapsedMs, state.running, previousElapsedMs);
+      return;
+    }
+    const now = this.now();
+    this.startedAtValue = now - elapsedMs;
+    this.pausedAtValue = state.running ? null : now;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+    this.dispatchTimerAdopt(elapsedMs, state.running, previousElapsedMs);
+  }
+  destroy() {
+    this.endPresentation();
+    this.fontScopeCleanup?.();
+    this.fontScopeCleanup = null;
+    while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
+    this.clearCanvasRootProperties();
+    this.bus.removeEventListener("peitho:navigate", this.onNavigate);
+    this.bus.removeEventListener("peitho:timercontrol", this.onTimerControl);
+    this.win.removeEventListener("pagehide", this.onPageHide);
+  }
+  async fetchJson(url) {
+    const response = await this.fetchOk(url);
+    return response.json();
+  }
+  async fetchText(url) {
+    const response = await this.fetchOk(url);
+    return response.text();
+  }
+  async fetchOk(url) {
+    const response = await this.fetcher(url);
+    if (!response.ok) throw new Error(`Failed to load ${url}: ${response.status}`);
+    return response;
+  }
+  setCanvasRootProperties(dimensions, cssAspect) {
+    this.root.style.setProperty("--peitho-canvas-width", `${dimensions.width}px`);
+    this.root.style.setProperty("--peitho-canvas-height", `${dimensions.height}px`);
+    this.root.style.setProperty("--peitho-canvas-aspect", cssAspect);
+  }
+  clearCanvasRootProperties() {
+    this.root.style.removeProperty("--peitho-canvas-width");
+    this.root.style.removeProperty("--peitho-canvas-height");
+    this.root.style.removeProperty("--peitho-canvas-aspect");
+  }
+  createSlideHost(slide, html, css, dimensions) {
+    const host = this.doc.createElement("section");
+    host.classList.add("peitho-slide");
+    host.dataset.slideKey = slide.key;
+    host.dataset.slideIndex = String(slide.index);
+    host.dataset.peithoCanvas = "slide";
+    host.style.position = "absolute";
+    host.style.left = "0";
+    host.style.top = "0";
+    this.canvasCleanups.push(
+      installCanvasScaler({
+        window: this.win,
+        target: host,
+        viewport: this.viewport,
+        canvasWidth: dimensions.width,
+        canvasHeight: dimensions.height
+      })
+    );
+    const shadow = host.attachShadow({ mode: "open" });
+    const style = this.doc.createElement("style");
+    style.textContent = css;
+    shadow.appendChild(style);
+    const template = this.doc.createElement("template");
+    template.innerHTML = html;
+    shadow.appendChild(template.content.cloneNode(true));
+    return host;
+  }
+  resolveTarget(to) {
+    if (to === "first") return 0;
+    if (to === "last") return this.slides.length - 1;
+    if (to === "next") return this.resolveSequentialTarget(1);
+    if (to === "prev") return this.resolveSequentialTarget(-1);
+    if ("index" in to) {
+      if (to.index < 0 || to.index >= this.slides.length) {
+        this.log.error(`Unknown slide index: ${to.index}`);
+        return null;
+      }
+      return to.index;
+    }
+    const index = this.slides.findIndex((slide) => slide.meta.key === to.key);
+    if (index < 0) {
+      this.log.error(`Unknown slide key: ${to.key}`);
+      return null;
+    }
+    return index;
+  }
+  resolveSequentialTarget(direction) {
+    return nextNonSkippedIndex(
+      this.slides.map((slide) => slide.meta),
+      this.currentIndex,
+      direction
+    );
+  }
+  show(index) {
+    if (index < 0 || index >= this.slides.length) {
+      this.log.error(`Unknown slide target: ${index}`);
+      return;
+    }
+    if (index === this.currentIndex) return;
+    this.slides.forEach((slide2, slideIndex) => {
+      slide2.host.hidden = slideIndex !== index;
+    });
+    const previousIndex = this.currentIndex < 0 ? null : this.currentIndex;
+    this.currentIndex = index;
+    const slide = this.slides[index];
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:slidechange", {
+        detail: {
+          key: slide.meta.key,
+          index: slide.meta.index,
+          total: this.slides.length,
+          previousIndex
+        }
+      })
+    );
+  }
+  startPresentation() {
+    if (this.startedAtValue !== null) return;
+    this.startedAtValue = this.now();
+    this.pausedAtValue = null;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:presentationstart", {
+        detail: { total: this.slides.length, startedAt: this.startedAtValue }
+      })
+    );
+    this.dispatchTimerChange();
+  }
+  endPresentation() {
+    if (this.ended || this.startedAtValue === null) return;
+    const endedAt = this.now();
+    const elapsedMs = this.elapsedMs();
+    this.ended = true;
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:presentationend", {
+        detail: { endedAt, elapsedMs }
+      })
+    );
+  }
+  pauseTimer() {
+    if (this.startedAtValue === null || this.pausedAtValue !== null) return;
+    this.pausedAtValue = this.now();
+    this.dispatchTimerChange();
+  }
+  resumeTimer() {
+    if (this.pausedAtValue === null) return;
+    this.pausedTotalMs += this.now() - this.pausedAtValue;
+    this.pausedAtValue = null;
+    this.dispatchTimerChange();
+  }
+  resetTimer() {
+    this.startedAtValue = null;
+    this.pausedAtValue = null;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+    this.dispatchTimerChange();
+  }
+  dispatchTimerChange() {
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:timerchange", {
+        detail: {
+          running: this.startedAtValue !== null && this.pausedAtValue === null,
+          elapsedMs: this.elapsedMs()
+        }
+      })
+    );
+  }
+  dispatchTimerAdopt(elapsedMs, running, previousElapsedMs) {
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:timeradopt", {
+        detail: { running, elapsedMs, previousElapsedMs }
+      })
+    );
+  }
+};
 
 // src/keyboard.ts
 var navigationKeyMap = /* @__PURE__ */ new Map([
@@ -46,6 +553,18 @@ function isIndexSyncMessage(value) {
 function isSwappedSyncMessage(value) {
   return isRecord(value) && typeof value.swapped === "boolean";
 }
+function isSyncedSyncMessage(value) {
+  return isRecord(value) && value.synced === true;
+}
+function isNonNegativeFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+function isTimerSyncMessage(value) {
+  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
+}
+function isTimerReplaySyncMessage(value) {
+  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
+}
 function isGenerationSyncMessage(value) {
   return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
@@ -60,13 +579,39 @@ function serverSyncChannelFactory(options = {}) {
     let onmessage = null;
     let closed = false;
     let seq = 0;
+    let synced = false;
+    let highestAckedPostSeq = 0;
+    let pendingTimerPosts = 0;
+    let bufferedTimerReplay = null;
     let abortController = null;
     let retryTimer = null;
-    const deliverReplayState = (body) => {
-      if (isIndexSyncMessage(body)) {
+    const flushBufferedTimerReplay = () => {
+      if (closed || pendingTimerPosts > 0 || bufferedTimerReplay == null) return;
+      const replay = bufferedTimerReplay;
+      bufferedTimerReplay = null;
+      if (replay.seq >= highestAckedPostSeq) {
+        onmessage?.({ data: replay.data });
+      }
+    };
+    const deliverReplayState = (body, options2 = {}) => {
+      const skipAbsoluteState = options2.skipAbsoluteState === true;
+      const responseSeq = typeof body.seq === "number" && Number.isFinite(body.seq) ? body.seq : 0;
+      if (isTimerReplaySyncMessage(body)) {
+        if (skipAbsoluteState) {
+          bufferedTimerReplay = null;
+        } else if (options2.deferTimerReplay === true) {
+          bufferedTimerReplay = {
+            seq: responseSeq,
+            data: { timer: body.timer, nowMs: body.nowMs }
+          };
+        } else {
+          onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
+        }
+      }
+      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (isSwappedSyncMessage(body)) {
+      if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
       if (isGenerationSyncMessage(body)) {
@@ -95,7 +640,14 @@ function serverSyncChannelFactory(options = {}) {
           return false;
         }
         seq = body.seq;
-        deliverReplayState(body);
+        deliverReplayState(body, {
+          skipAbsoluteState: body.seq < highestAckedPostSeq,
+          deferTimerReplay: pendingTimerPosts > 0
+        });
+        if (!synced) {
+          synced = true;
+          onmessage?.({ data: { synced: true } });
+        }
         return true;
       } catch (error) {
         if (!closed) {
@@ -135,7 +687,10 @@ function serverSyncChannelFactory(options = {}) {
           if (body.message != null) {
             onmessage?.({ data: body.message });
           }
-          deliverReplayState(body);
+          deliverReplayState(body, {
+            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            deferTimerReplay: pendingTimerPosts > 0
+          });
         } catch (error) {
           if (!closed) {
             console.error(`Failed to poll sync message: ${String(error)}`);
@@ -154,15 +709,42 @@ function serverSyncChannelFactory(options = {}) {
         onmessage = next;
       },
       postMessage(message) {
-        void fetcher(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(message),
-          keepalive: true
-        }).then((response) => {
-          if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
+        const isTimerPost = isTimerSyncMessage(message);
+        if (isTimerPost) pendingTimerPosts += 1;
+        const completeTimerPost = () => {
+          if (!isTimerPost) return;
+          pendingTimerPosts = Math.max(0, pendingTimerPosts - 1);
+          flushBufferedTimerReplay();
+        };
+        let request;
+        try {
+          request = fetcher(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(message),
+            keepalive: true
+          });
+        } catch (error) {
+          completeTimerPost();
+          console.error(`Failed to post sync message: ${String(error)}`);
+          return;
+        }
+        void request.then(async (response) => {
+          if (!response.ok) {
+            console.error(`Failed to post sync message: ${response.status}`);
+            return;
+          }
+          try {
+            const body = await response.json();
+            if (typeof body.seq === "number" && Number.isFinite(body.seq)) {
+              highestAckedPostSeq = Math.max(highestAckedPostSeq, body.seq);
+            }
+          } catch (_error) {
+          }
         }).catch((error) => {
           console.error(`Failed to post sync message: ${String(error)}`);
+        }).finally(() => {
+          completeTimerPost();
         });
       },
       close() {
@@ -175,6 +757,18 @@ function serverSyncChannelFactory(options = {}) {
       }
     };
   };
+}
+
+// src/timeTracker.ts
+var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
+function isValidDurationMs(ms) {
+  return Number.isSafeInteger(ms) && ms > 0;
+}
+function formatMinuteSeconds(ms) {
+  const totalSeconds = Math.round(ms / 1e3);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = (totalSeconds % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
 }
 
 // src/remote.ts
@@ -191,10 +785,77 @@ function installRemoteControls(options) {
   root.replaceChildren();
   const container = doc.createElement("section");
   container.className = "peitho-remote";
+  container.dataset.peithoEnded = "false";
+  const preview = doc.createElement("div");
+  preview.className = "peitho-remote-preview peitho-remote-dim-on-end";
+  preview.dataset.peithoRemote = "preview";
+  const titlebar = doc.createElement("div");
+  titlebar.className = "peitho-remote-titlebar peitho-remote-dim-on-end";
+  const title = doc.createElement("div");
+  title.className = "peitho-remote-title";
+  title.dataset.peithoRemote = "title";
+  title.textContent = "Loading";
   const counter = doc.createElement("div");
   counter.className = "peitho-remote-counter";
   counter.dataset.peithoRemote = "counter";
   counter.textContent = "\u2013 / \u2013";
+  titlebar.append(title, counter);
+  const progress = doc.createElement("div");
+  progress.className = "peitho-remote-progress peitho-remote-dim-on-end";
+  progress.dataset.peithoRemote = "progress";
+  const progressFill = doc.createElement("div");
+  progressFill.className = "peitho-remote-progress-fill";
+  progressFill.dataset.peithoRemote = "progress-fill";
+  const planTick = doc.createElement("div");
+  planTick.className = "peitho-remote-plan-tick";
+  planTick.dataset.peithoRemote = "plan-tick";
+  planTick.hidden = true;
+  progress.append(progressFill, planTick);
+  const pace = doc.createElement("div");
+  pace.className = "peitho-remote-pace peitho-remote-dim-on-end";
+  const timerButton = doc.createElement("button");
+  timerButton.type = "button";
+  timerButton.className = "peitho-remote-timer-button";
+  timerButton.dataset.peithoAction = "timer";
+  timerButton.dataset.peithoRunning = "false";
+  timerButton.dataset.peithoTimerAction = "start";
+  timerButton.disabled = true;
+  timerButton.setAttribute("aria-label", "Start timer");
+  const timerIcon = doc.createElement("span");
+  timerIcon.className = "peitho-remote-timer-icon";
+  timerIcon.dataset.peithoIcon = "play";
+  timerButton.append(timerIcon);
+  const elapsedRow = doc.createElement("div");
+  elapsedRow.className = "peitho-remote-elapsed-row";
+  elapsedRow.dataset.peithoRemote = "elapsed-row";
+  const elapsed = doc.createElement("span");
+  elapsed.className = "peitho-remote-elapsed";
+  elapsed.dataset.peithoRemote = "elapsed";
+  elapsed.textContent = "0:00";
+  const separator = doc.createElement("span");
+  separator.className = "peitho-remote-time-separator";
+  separator.dataset.peithoRemote = "time-separator";
+  separator.textContent = "/";
+  separator.hidden = true;
+  const planned = doc.createElement("span");
+  planned.className = "peitho-remote-planned";
+  planned.dataset.peithoRemote = "planned";
+  planned.hidden = true;
+  elapsedRow.append(elapsed, separator, planned);
+  const chip = doc.createElement("span");
+  chip.className = "peitho-remote-pace-chip";
+  chip.dataset.peithoRemote = "pace-chip";
+  chip.hidden = true;
+  pace.append(timerButton, elapsedRow, chip);
+  const notesPanel = doc.createElement("section");
+  notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
+  const notesCaption = doc.createElement("div");
+  notesCaption.className = "peitho-remote-notes-caption";
+  notesCaption.textContent = "NOTES";
+  const notesBody = doc.createElement("div");
+  notesBody.className = "peitho-remote-notes-body";
+  notesBody.dataset.peithoRemote = "notes";
+  notesPanel.append(notesCaption, notesBody);
   const status = doc.createElement("div");
   status.className = "peitho-remote-status";
   status.dataset.peithoRemote = "status";
@@ -202,24 +863,35 @@ function installRemoteControls(options) {
   actions.className = "peitho-remote-actions";
   const prev = remoteButton(doc, "prev", "Previous");
   const next = remoteButton(doc, "next", "Next");
+  actions.append(prev, next);
   const onPrev = () => dispatchNavigate(bus, "prev");
   const onNext = () => dispatchNavigate(bus, "next");
+  const onTimer = () => {
+    const action = timerButton.dataset.peithoTimerAction;
+    if (action === "start" || action === "pause" || action === "resume") {
+      dispatchTimerControl(bus, action);
+    }
+  };
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
-  actions.append(prev, next);
-  container.append(counter, status, actions);
+  timerButton.addEventListener("click", onTimer);
+  container.append(preview, titlebar, progress, pace, notesPanel, status, actions);
   root.append(container);
   return () => {
     prev.removeEventListener("click", onPrev);
     next.removeEventListener("click", onNext);
+    timerButton.removeEventListener("click", onTimer);
     container.remove();
   };
 }
 function installRemoteSyncBridge(options) {
   const bus = options.bus ?? window;
   const log = options.console ?? console;
+  const now = options.now ?? Date.now;
   const channel = (options.channelFactory ?? serverSyncChannelFactory())("peitho-sync");
+  let synced = false;
   const onNavigate = (event) => {
+    if (!synced) return;
     const to = event.detail?.to;
     if (to !== "next" && to !== "prev") return;
     const target = resolveRemoteTarget(options.slides, options.getCurrentIndex(), to);
@@ -227,8 +899,27 @@ function installRemoteSyncBridge(options) {
     channel.postMessage({ index: target });
     options.setCurrentIndex(target);
   };
+  const onTimerControl = (event) => {
+    if (!synced) return;
+    const action = event.detail?.action;
+    if (action !== "start" && action !== "pause" && action !== "resume" && action !== "reset") {
+      log.error("Invalid peitho:timercontrol event");
+      return;
+    }
+    const next = nextTimerStateForAction(action, options.getTimerState(), now());
+    if (next === null) return;
+    channel.postMessage({
+      timer: { running: next.running, elapsedMs: Math.round(next.elapsedMs) }
+    });
+    options.setTimerState(next);
+  };
   channel.onmessage = (event) => {
     const data = event.data;
+    if (isSyncedSyncMessage(data)) {
+      synced = true;
+      options.setSynced();
+      return;
+    }
     if (isCloseSyncMessage(data)) {
       options.setEnded();
       return;
@@ -237,12 +928,25 @@ function installRemoteSyncBridge(options) {
       options.setCurrentIndex(data.index);
       return;
     }
-    if (isSwappedSyncMessage(data) || isGenerationSyncMessage(data)) return;
+    if (isTimerReplaySyncMessage(data)) {
+      const serverAdvance = data.timer.running ? Math.max(0, data.nowMs - data.timer.atMs) : 0;
+      options.setTimerState({
+        running: data.timer.running,
+        elapsedMs: data.timer.elapsedMs + serverAdvance,
+        receivedAtMs: now()
+      });
+      return;
+    }
+    if (isSwappedSyncMessage(data) || isGenerationSyncMessage(data) || isTimerSyncMessage(data)) {
+      return;
+    }
     log.error("Invalid peitho remote sync message");
   };
   bus.addEventListener("peitho:navigate", onNavigate);
+  bus.addEventListener("peitho:timercontrol", onTimerControl);
   return () => {
     bus.removeEventListener("peitho:navigate", onNavigate);
+    bus.removeEventListener("peitho:timercontrol", onTimerControl);
     channel.onmessage = null;
     channel.close();
   };
@@ -252,43 +956,79 @@ var RemoteController = class {
   currentIndex = null;
   root;
   manifestUrl;
+  notesUrl;
   fetcher;
   channelFactory;
+  mountPresentShell;
   win;
   doc;
   bus;
+  previewBus = new EventTarget();
   log;
+  now;
+  synced = false;
+  notes = { version: 1, notes: {} };
+  renderedNotesValue = null;
   slides = [];
+  ended = false;
+  timerState = null;
   controlsCleanup = null;
   syncCleanup = null;
+  previewShell = null;
+  timerInterval = null;
   constructor(options) {
     this.root = options.root;
     this.manifestUrl = options.manifestUrl ?? "manifest.json";
+    this.notesUrl = options.notesUrl ?? "notes.json";
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
-    this.channelFactory = options.channelFactory;
+    this.channelFactory = options.syncChannelFactory ?? options.channelFactory;
+    this.mountPresentShell = options.mountPresentShell ?? mountPresentShell;
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
     this.bus = options.bus ?? this.win;
     this.log = options.console ?? console;
+    this.now = options.now ?? Date.now;
   }
   async load() {
     try {
       const manifest = await this.fetchJson(this.manifestUrl);
       this.manifest = manifest;
-      this.slides = manifest.slides.map((slide) => ({ skip: slide.skip === true }));
+      this.notes = await this.fetchNotes();
+      this.slides = manifest.slides.map((slide) => ({
+        key: slide.key,
+        skip: slide.skip === true,
+        title: slide.text.title
+      }));
       this.currentIndex = initialSlideIndex(this.slides);
       this.controlsCleanup = installRemoteControls({
         root: this.root,
         document: this.doc,
         bus: this.bus
       });
-      this.renderCounter();
+      const previewRoot = this.root.querySelector('[data-peitho-remote="preview"]');
+      if (previewRoot != null) {
+        this.previewShell = await this.mountPresentShell({
+          root: previewRoot,
+          fetcher: this.fetcher,
+          window: this.win,
+          document: this.doc,
+          bus: this.previewBus,
+          manifest,
+          now: this.now,
+          viewport: paneViewport(previewRoot)
+        });
+      }
+      this.render();
       this.syncCleanup = installRemoteSyncBridge({
         slides: this.slides,
         channelFactory: this.channelFactory,
         bus: this.bus,
+        now: this.now,
         getCurrentIndex: () => this.currentIndex,
         setCurrentIndex: (index) => this.setCurrentIndex(index),
+        getTimerState: () => this.timerState,
+        setTimerState: (state) => this.setTimerState(state),
+        setSynced: () => this.setSynced(),
         setEnded: () => this.setEnded(),
         console: this.log
       });
@@ -297,8 +1037,11 @@ var RemoteController = class {
     }
   }
   destroy() {
+    this.clearTimerInterval();
     this.syncCleanup?.();
     this.syncCleanup = null;
+    this.previewShell?.destroy();
+    this.previewShell = null;
     this.controlsCleanup?.();
     this.controlsCleanup = null;
   }
@@ -307,25 +1050,201 @@ var RemoteController = class {
     if (!response.ok) throw new Error(`Failed to load ${url}: ${response.status}`);
     return response.json();
   }
+  async fetchNotes() {
+    try {
+      return await this.fetchJson(this.notesUrl);
+    } catch (error) {
+      this.log.error(
+        `Failed to load ${this.notesUrl}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return { version: 1, notes: {} };
+    }
+  }
   setCurrentIndex(index) {
     this.currentIndex = clampIndex(index, this.slides.length);
-    this.renderCounter();
+    this.render();
+  }
+  setTimerState(state) {
+    this.timerState = {
+      running: state.running,
+      elapsedMs: Math.max(0, state.elapsedMs),
+      receivedAtMs: state.receivedAtMs
+    };
+    this.render();
+  }
+  setSynced() {
+    this.synced = true;
+    this.render();
   }
   setEnded() {
     const cleanup = this.syncCleanup;
     this.syncCleanup = null;
     cleanup?.();
-    for (const button of this.root.querySelectorAll("[data-peitho-action]")) {
-      button.disabled = true;
-    }
-    const status = this.root.querySelector('[data-peitho-remote="status"]');
-    if (status != null) status.textContent = "Ended";
+    this.ended = true;
+    this.clearTimerInterval();
+    this.render();
   }
-  renderCounter() {
-    const counter = this.root.querySelector('[data-peitho-remote="counter"]');
-    if (counter == null) return;
+  render() {
+    const manifest = this.manifest;
+    if (manifest == null) return;
+    const container = this.root.querySelector(".peitho-remote");
+    if (container == null) return;
+    container.dataset.peithoEnded = this.ended ? "true" : "false";
+    const currentIndex = this.currentIndex;
+    const slide = currentIndex == null ? null : manifest.slides[currentIndex];
     const total = this.slides.length;
-    counter.textContent = this.currentIndex === null ? `\u2013 / ${total}` : `${this.currentIndex + 1} / ${total}`;
+    setText(this.root, "title", slideTitle(slide?.text.title));
+    setText(this.root, "counter", currentIndex == null ? `\u2013 / ${total}` : `${currentIndex + 1} / ${total}`);
+    this.renderProgress(manifest, currentIndex);
+    this.renderPaceStatic(manifest);
+    this.renderTimeDependentChrome(manifest, currentIndex);
+    this.renderSection(manifest, currentIndex);
+    this.renderNotes(slide?.key);
+    this.renderButtons(currentIndex);
+    setText(this.root, "status", this.ended ? "Ended" : "");
+    this.syncPreview(currentIndex);
+    this.updateTimerInterval();
+  }
+  renderProgress(manifest, currentIndex) {
+    const progress = this.root.querySelector('[data-peitho-remote="progress"]');
+    const fill = this.root.querySelector('[data-peitho-remote="progress-fill"]');
+    if (progress == null || fill == null) return;
+    const fraction = currentIndex == null ? 0 : manifest.slideCount <= 1 ? 1 : currentIndex / (manifest.slideCount - 1);
+    fill.style.width = `${clamp01(fraction) * 100}%`;
+    this.updatePlanTick(manifest, this.currentElapsedMs());
+  }
+  renderPaceStatic(manifest) {
+    const elapsedRow = this.root.querySelector('[data-peitho-remote="elapsed-row"]');
+    if (elapsedRow == null) return;
+    const separator = elapsedRow.querySelector('[data-peitho-remote="time-separator"]');
+    const planned = elapsedRow.querySelector('[data-peitho-remote="planned"]');
+    const plannedDurationMs = validPlannedDurationMs(manifest);
+    if (separator != null) separator.hidden = plannedDurationMs == null;
+    if (planned != null) {
+      planned.hidden = plannedDurationMs == null;
+      planned.textContent = plannedDurationMs == null ? "" : formatMinuteSeconds(plannedDurationMs);
+    }
+  }
+  renderTimeDependentChrome(manifest, currentIndex) {
+    const timerButton = this.root.querySelector('[data-peitho-action="timer"]');
+    const elapsed = this.root.querySelector('[data-peitho-remote="elapsed"]');
+    if (timerButton == null || elapsed == null) return;
+    const elapsedMs = this.currentElapsedMs();
+    const state = timerVisualState(this.timerState, elapsedMs);
+    timerButton.disabled = this.ended || !this.synced;
+    timerButton.dataset.peithoRunning = state === "running" ? "true" : "false";
+    timerButton.dataset.peithoTimerAction = playpauseActionFor(state);
+    timerButton.setAttribute("aria-label", timerAriaLabel(state));
+    const icon = timerButton.querySelector(".peitho-remote-timer-icon");
+    if (icon != null) icon.dataset.peithoIcon = state === "running" ? "pause" : "play";
+    elapsed.textContent = formatMinuteSeconds(elapsedMs);
+    this.updatePlanTick(manifest, elapsedMs);
+    const chip = this.root.querySelector('[data-peitho-remote="pace-chip"]');
+    if (chip == null || currentIndex == null) {
+      if (chip != null) chip.hidden = true;
+      return;
+    }
+    const paceState = remotePaceState(manifest, currentIndex, elapsedMs, state === "running");
+    if (paceState == null) {
+      chip.hidden = true;
+      chip.textContent = "";
+      return;
+    }
+    chip.hidden = false;
+    chip.dataset.peithoPace = paceState.kind;
+    if (paceState.emoji != null) {
+      const emoji = this.doc.createElement("span");
+      emoji.dataset.peithoPaceEmoji = "";
+      emoji.textContent = paceState.emoji === "hare" ? "\u{1F407}" : "\u{1F422}";
+      chip.replaceChildren(emoji, this.doc.createTextNode(` ${paceState.label}`));
+    } else {
+      chip.textContent = paceState.label;
+    }
+  }
+  updatePlanTick(manifest, elapsedMs) {
+    const tick = this.root.querySelector('[data-peitho-remote="plan-tick"]');
+    if (tick == null) return;
+    const planProgress = plannedProgressAtElapsed(manifest, elapsedMs);
+    tick.hidden = planProgress == null;
+    if (planProgress != null) tick.style.left = `${planProgress * 100}%`;
+  }
+  renderSection(manifest, currentIndex) {
+    const existing = this.root.querySelector('[data-peitho-remote="section"]');
+    if (currentIndex == null || manifest.sections.length === 0) {
+      existing?.remove();
+      return;
+    }
+    const sectionIndex = sectionIndexForSlide(manifest.sections, currentIndex);
+    if (sectionIndex < 0) {
+      existing?.remove();
+      return;
+    }
+    const section = manifest.sections[sectionIndex];
+    const sectionSlideCount = section.endIndex - section.startIndex + 1;
+    const sectionOffset = currentIndex - section.startIndex + 1;
+    const sectionLine = existing ?? this.doc.createElement("div");
+    sectionLine.className = "peitho-remote-section peitho-remote-dim-on-end";
+    sectionLine.dataset.peithoRemote = "section";
+    const name = this.doc.createElement("b");
+    name.textContent = section.name;
+    sectionLine.replaceChildren(
+      name,
+      this.doc.createTextNode(` \xB7 slide ${sectionOffset} / ${sectionSlideCount} in section`)
+    );
+    if (existing == null) {
+      const notes = this.root.querySelector(".peitho-remote-notes");
+      notes?.before(sectionLine);
+    }
+  }
+  renderNotes(slideKey) {
+    const notes = this.root.querySelector('[data-peitho-remote="notes"]');
+    if (notes == null) return;
+    const value = slideKey == null ? null : this.notes.notes[slideKey];
+    if (value == null || value.length === 0) {
+      this.setNotesText(notes, "No notes for this slide");
+      notes.dataset.peithoEmpty = "true";
+      return;
+    }
+    this.setNotesText(notes, value);
+    notes.dataset.peithoEmpty = "false";
+  }
+  setNotesText(notes, value) {
+    if (this.renderedNotesValue === value) return;
+    notes.textContent = value;
+    this.renderedNotesValue = value;
+  }
+  renderButtons(currentIndex) {
+    const prev = this.root.querySelector('[data-peitho-action="prev"]');
+    const next = this.root.querySelector('[data-peitho-action="next"]');
+    if (prev == null || next == null) return;
+    prev.disabled = this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
+    next.disabled = this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
+  }
+  syncPreview(currentIndex) {
+    if (currentIndex == null) return;
+    this.previewBus.dispatchEvent(
+      new CustomEvent("peitho:navigate", { detail: { to: { index: currentIndex } } })
+    );
+  }
+  currentElapsedMs() {
+    return currentTimerElapsedMs(this.timerState, this.now());
+  }
+  updateTimerInterval() {
+    if (this.ended || this.timerState?.running !== true) {
+      this.clearTimerInterval();
+      return;
+    }
+    if (this.timerInterval != null) return;
+    this.timerInterval = this.win.setInterval(() => {
+      const manifest = this.manifest;
+      if (manifest == null) return;
+      this.renderTimeDependentChrome(manifest, this.currentIndex);
+    }, 1e3);
+  }
+  clearTimerInterval() {
+    if (this.timerInterval == null) return;
+    this.win.clearInterval(this.timerInterval);
+    this.timerInterval = null;
   }
   showError(message) {
     this.destroy();
@@ -337,12 +1256,24 @@ var RemoteController = class {
 function remoteButton(doc, action, label) {
   const button = doc.createElement("button");
   button.type = "button";
+  button.disabled = true;
   button.dataset.peithoAction = action;
-  button.textContent = label;
+  button.dataset.peithoDirection = action;
+  const arrow = doc.createElement("span");
+  arrow.className = "peitho-remote-action-arrow";
+  arrow.textContent = action === "prev" ? "\u2039" : "\u203A";
+  if (action === "prev") {
+    button.append(arrow, doc.createTextNode(` ${label}`));
+  } else {
+    button.append(doc.createTextNode(`${label} `), arrow);
+  }
   return button;
 }
 function dispatchNavigate(bus, to) {
   bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+}
+function dispatchTimerControl(bus, action) {
+  bus.dispatchEvent(new CustomEvent("peitho:timercontrol", { detail: { action } }));
 }
 function resolveRemoteTarget(slides, currentIndex, to) {
   const base = currentIndex ?? initialSlideIndex(slides);
@@ -353,9 +1284,126 @@ function clampIndex(index, total) {
   if (total === 0) return null;
   return Math.max(0, Math.min(Math.trunc(index), total - 1));
 }
+function setText(root, key, value) {
+  const element = root.querySelector(`[data-peitho-remote="${key}"]`);
+  if (element != null) element.textContent = value;
+}
+function slideTitle(title) {
+  return title == null || title.length === 0 ? "Untitled slide" : title;
+}
+function validPlannedDurationMs(manifest) {
+  const plannedDurationMs = manifest.plannedDurationMs;
+  return plannedDurationMs != null && isValidDurationMs(plannedDurationMs) ? plannedDurationMs : null;
+}
+function expectedElapsedAtSlide(manifest, index) {
+  const plannedDurationMs = validPlannedDurationMs(manifest);
+  if (plannedDurationMs == null) return null;
+  const slideCount = Math.max(1, manifest.slideCount);
+  const clampedIndex = Math.max(0, Math.min(Math.trunc(index), slideCount - 1));
+  if (manifest.sections.length === 0) {
+    return plannedDurationMs * clampedIndex / slideCount;
+  }
+  const sectionIndex = sectionIndexForSlide(manifest.sections, clampedIndex);
+  if (sectionIndex < 0) return plannedDurationMs * clampedIndex / slideCount;
+  let elapsed = 0;
+  for (let i = 0; i < sectionIndex; i += 1) {
+    elapsed += manifest.sections[i].plannedDurationMs;
+  }
+  const section = manifest.sections[sectionIndex];
+  const sectionSlideCount = section.endIndex - section.startIndex + 1;
+  return elapsed + section.plannedDurationMs * ((clampedIndex - section.startIndex) / sectionSlideCount);
+}
+function plannedProgressAtElapsed(manifest, elapsedMs) {
+  const plannedDurationMs = validPlannedDurationMs(manifest);
+  if (plannedDurationMs == null) return null;
+  if (manifest.slideCount <= 1) return 1;
+  const elapsed = clamp01(elapsedMs / plannedDurationMs) * plannedDurationMs;
+  if (manifest.sections.length === 0) {
+    return clamp01(elapsed / plannedDurationMs * manifest.slideCount / (manifest.slideCount - 1));
+  }
+  let elapsedBefore = 0;
+  for (const section of manifest.sections) {
+    const duration = section.plannedDurationMs;
+    const elapsedAfter = elapsedBefore + duration;
+    if (elapsed <= elapsedAfter) {
+      const sectionSlideCount = section.endIndex - section.startIndex + 1;
+      const ratio = duration === 0 ? 0 : (elapsed - elapsedBefore) / duration;
+      const slidePosition = section.startIndex + ratio * sectionSlideCount;
+      return clamp01(slidePosition / (manifest.slideCount - 1));
+    }
+    elapsedBefore = elapsedAfter;
+  }
+  return 1;
+}
+function remotePaceState(manifest, index, elapsedMs, running) {
+  const expected = expectedElapsedAtSlide(manifest, index);
+  if (expected == null) return null;
+  if (!running) {
+    return elapsedMs > 0 ? { kind: "paused", label: "Paused", emoji: null } : null;
+  }
+  const delta = elapsedMs - expected;
+  if (delta >= 0) {
+    return {
+      kind: "behind",
+      label: `${formatMinuteSeconds(delta)} behind`,
+      emoji: "tortoise"
+    };
+  }
+  return {
+    kind: "ahead",
+    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`,
+    emoji: "hare"
+  };
+}
+function currentTimerElapsedMs(timer, now) {
+  if (timer == null) return 0;
+  return Math.max(0, timer.elapsedMs + (timer.running ? now - timer.receivedAtMs : 0));
+}
+function timerVisualState(timer, elapsedMs) {
+  if (timer == null || !timer.running && elapsedMs === 0) return "stopped";
+  return timer.running ? "running" : "paused";
+}
+function playpauseActionFor(state) {
+  if (state === "running") return "pause";
+  if (state === "paused") return "resume";
+  return "start";
+}
+function timerAriaLabel(state) {
+  if (state === "running") return "Pause timer";
+  if (state === "paused") return "Resume timer";
+  return "Start timer";
+}
+function nextTimerStateForAction(action, current, now) {
+  const elapsedMs = currentTimerElapsedMs(current, now);
+  const state = timerVisualState(current, elapsedMs);
+  if (action === "start") {
+    if (state !== "stopped") return null;
+    return { running: true, elapsedMs: 0, receivedAtMs: now };
+  }
+  if (action === "pause") {
+    if (state !== "running") return null;
+    return { running: false, elapsedMs, receivedAtMs: now };
+  }
+  if (action === "resume") {
+    if (state !== "paused") return null;
+    return { running: true, elapsedMs, receivedAtMs: now };
+  }
+  return { running: false, elapsedMs: 0, receivedAtMs: now };
+}
+function paneViewport(pane) {
+  return () => ({
+    width: pane.clientWidth,
+    height: pane.clientHeight
+  });
+}
 export {
+  expectedElapsedAtSlide,
   installRemoteControls,
   installRemoteSyncBridge,
-  mountRemoteView
+  mountPresentShell,
+  mountRemoteView,
+  plannedProgressAtElapsed,
+  remotePaceState,
+  serverSyncChannelFactory
 };
 //# sourceMappingURL=remote.js.map

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -839,6 +839,13 @@ function installRemoteControls(options) {
   timerIcon.className = "peitho-remote-timer-icon";
   timerIcon.dataset.peithoIcon = "play";
   timerButton.append(timerIcon);
+  const resetButton = doc.createElement("button");
+  resetButton.type = "button";
+  resetButton.className = "peitho-remote-reset-button";
+  resetButton.dataset.peithoAction = "timer-reset";
+  resetButton.disabled = true;
+  resetButton.setAttribute("aria-label", "Reset timer");
+  resetButton.textContent = "\u21BA";
   const elapsedRow = doc.createElement("div");
   elapsedRow.className = "peitho-remote-elapsed-row";
   elapsedRow.dataset.peithoRemote = "elapsed-row";
@@ -860,7 +867,7 @@ function installRemoteControls(options) {
   delta.className = "peitho-remote-pace-delta";
   delta.dataset.peithoRemote = "pace-delta";
   delta.hidden = true;
-  pace.append(timerButton, elapsedRow, delta);
+  pace.append(timerButton, resetButton, elapsedRow, delta);
   const notesPanel = doc.createElement("section");
   notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
   const notesCaption = doc.createElement("div");
@@ -886,15 +893,18 @@ function installRemoteControls(options) {
       dispatchTimerControl(bus, action);
     }
   };
+  const onReset = () => dispatchTimerControl(bus, "reset");
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
   timerButton.addEventListener("click", onTimer);
+  resetButton.addEventListener("click", onReset);
   container.append(preview, titlebar, chase, pace, notesPanel, status, actions);
   root.append(container);
   return () => {
     prev.removeEventListener("click", onPrev);
     next.removeEventListener("click", onNext);
     timerButton.removeEventListener("click", onTimer);
+    resetButton.removeEventListener("click", onReset);
     container.remove();
   };
 }
@@ -1141,11 +1151,15 @@ var RemoteController = class {
   }
   renderTimeDependentChrome(manifest, currentIndex) {
     const timerButton = this.root.querySelector('[data-peitho-action="timer"]');
+    const resetButton = this.root.querySelector(
+      '[data-peitho-action="timer-reset"]'
+    );
     const elapsed = this.root.querySelector('[data-peitho-remote="elapsed"]');
-    if (timerButton == null || elapsed == null) return;
+    if (timerButton == null || resetButton == null || elapsed == null) return;
     const elapsedMs = this.currentElapsedMs();
     const state = timerVisualState(this.timerState, elapsedMs);
     timerButton.disabled = this.ended || !this.synced;
+    resetButton.disabled = this.ended || !this.synced || state === "stopped";
     timerButton.dataset.peithoRunning = state === "running" ? "true" : "false";
     timerButton.dataset.peithoTimerAction = playpauseActionFor(state);
     timerButton.setAttribute("aria-label", timerAriaLabel(state));
@@ -1178,9 +1192,9 @@ var RemoteController = class {
     turtle.hidden = false;
     const overrun = isOverrun(elapsedMs, plannedDurationMs);
     chase.classList.toggle("peitho-remote-chase-overrun", overrun);
-    const turtleFraction = overrun ? 1 : plannedProgressAtElapsed(manifest, elapsedMs);
-    setChaseMarker(turtle, turtleFraction ?? 0);
-    setChaseFill(fill, turtleFraction ?? 0);
+    const turtleFraction = clamp01(elapsedMs / plannedDurationMs);
+    setChaseMarker(turtle, turtleFraction);
+    setChaseFill(fill, turtleFraction);
     if (currentIndex == null) {
       delta.hidden = true;
       delta.textContent = "";
@@ -1345,45 +1359,26 @@ function expectedElapsedAtSlide(manifest, index) {
   const plannedDurationMs = validPlannedDurationMs(manifest);
   if (plannedDurationMs == null) return null;
   const slideCount = Math.max(1, manifest.slideCount);
-  const clampedIndex = Math.max(0, Math.min(Math.trunc(index), slideCount - 1));
+  const requestedIndex = Number.isFinite(index) ? Math.trunc(index) : 0;
+  if (requestedIndex <= 0) return 0;
+  if (requestedIndex >= slideCount) return plannedDurationMs;
   if (manifest.sections.length === 0) {
-    return plannedDurationMs * clampedIndex / slideCount;
+    return plannedDurationMs * requestedIndex / slideCount;
   }
-  const sectionIndex = sectionIndexForSlide(manifest.sections, clampedIndex);
-  if (sectionIndex < 0) return plannedDurationMs * clampedIndex / slideCount;
+  const sectionIndex = sectionIndexForSlide(manifest.sections, requestedIndex);
+  if (sectionIndex < 0) return plannedDurationMs * requestedIndex / slideCount;
   let elapsed = 0;
   for (let i = 0; i < sectionIndex; i += 1) {
     elapsed += manifest.sections[i].plannedDurationMs;
   }
   const section = manifest.sections[sectionIndex];
   const sectionSlideCount = section.endIndex - section.startIndex + 1;
-  return elapsed + section.plannedDurationMs * ((clampedIndex - section.startIndex) / sectionSlideCount);
-}
-function plannedProgressAtElapsed(manifest, elapsedMs) {
-  const plannedDurationMs = validPlannedDurationMs(manifest);
-  if (plannedDurationMs == null) return null;
-  if (manifest.slideCount <= 1) return 1;
-  const elapsed = clamp01(elapsedMs / plannedDurationMs) * plannedDurationMs;
-  if (manifest.sections.length === 0) {
-    return clamp01(elapsed / plannedDurationMs * manifest.slideCount / (manifest.slideCount - 1));
-  }
-  let elapsedBefore = 0;
-  for (const section of manifest.sections) {
-    const duration = section.plannedDurationMs;
-    const elapsedAfter = elapsedBefore + duration;
-    if (elapsed <= elapsedAfter) {
-      const sectionSlideCount = section.endIndex - section.startIndex + 1;
-      const ratio = duration === 0 ? 0 : (elapsed - elapsedBefore) / duration;
-      const slidePosition = section.startIndex + ratio * sectionSlideCount;
-      return clamp01(slidePosition / (manifest.slideCount - 1));
-    }
-    elapsedBefore = elapsedAfter;
-  }
-  return 1;
+  return elapsed + section.plannedDurationMs * ((requestedIndex - section.startIndex) / sectionSlideCount);
 }
 function remotePaceState(manifest, index, elapsedMs, running) {
-  const expected = expectedElapsedAtSlide(manifest, index);
-  if (expected == null) return null;
+  const expectedStart = expectedElapsedAtSlide(manifest, index);
+  const expectedEnd = expectedElapsedAtSlide(manifest, index + 1);
+  if (expectedStart == null || expectedEnd == null) return null;
   if (!running) {
     return elapsedMs > 0 ? { kind: "paused", label: "Paused" } : null;
   }
@@ -1394,16 +1389,18 @@ function remotePaceState(manifest, index, elapsedMs, running) {
       label: `+${formatMinuteSeconds(elapsedMs - plannedDurationMs)} over`
     };
   }
-  const delta = elapsedMs - expected;
-  if (delta >= 0) {
+  if (elapsedMs < expectedStart) {
     return {
-      kind: "behind",
-      label: `${formatMinuteSeconds(delta)} behind`
+      kind: "ahead",
+      label: `${formatMinuteSeconds(expectedStart - elapsedMs)} ahead`
     };
   }
+  if (elapsedMs <= expectedEnd) {
+    return { kind: "onpace", label: "on pace" };
+  }
   return {
-    kind: "ahead",
-    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`
+    kind: "behind",
+    label: `${formatMinuteSeconds(elapsedMs - expectedEnd)} behind`
   };
 }
 function currentTimerElapsedMs(timer, now) {
@@ -1453,7 +1450,6 @@ export {
   installRemoteSyncBridge,
   mountPresentShell,
   mountRemoteView,
-  plannedProgressAtElapsed,
   remotePaceState,
   serverSyncChannelFactory
 };

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -211,6 +211,12 @@ function installAgenda(options) {
       log.error("Invalid peitho:timeradopt event");
       return;
     }
+    if (!detail.running && detail.elapsedMs === 0) {
+      actualMs.fill(0);
+      lastElapsedMs = 0;
+      render();
+      return;
+    }
     if (options.shell.startedAt() !== null) {
       const sectionIndex = sectionIndexForSlide(options.sections, options.shell.currentIndex);
       if (sectionIndex >= 0) {

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -205,6 +205,21 @@ function installAgenda(options) {
     lastElapsedMs = 0;
     render();
   }
+  function onTimerAdopt(event) {
+    const detail = event.detail;
+    if (typeof detail?.running !== "boolean" || typeof detail.elapsedMs !== "number" || !Number.isFinite(detail.elapsedMs) || detail.elapsedMs < 0 || typeof detail.previousElapsedMs !== "number" || !Number.isFinite(detail.previousElapsedMs) || detail.previousElapsedMs < 0) {
+      log.error("Invalid peitho:timeradopt event");
+      return;
+    }
+    if (options.shell.startedAt() !== null) {
+      const sectionIndex = sectionIndexForSlide(options.sections, options.shell.currentIndex);
+      if (sectionIndex >= 0) {
+        actualMs[sectionIndex] += Math.max(0, detail.previousElapsedMs - lastElapsedMs);
+      }
+    }
+    lastElapsedMs = detail.elapsedMs;
+    render();
+  }
   function tick() {
     if (options.shell.startedAt() === null) {
       actualMs.fill(0);
@@ -218,11 +233,13 @@ function installAgenda(options) {
   render();
   bus.addEventListener("peitho:slidechange", onSlideChange);
   bus.addEventListener("peitho:timercontrol", onTimerControl);
+  bus.addEventListener("peitho:timeradopt", onTimerAdopt);
   const interval = win.setInterval(tick, 250);
   return () => {
     win.clearInterval(interval);
     bus.removeEventListener("peitho:slidechange", onSlideChange);
     bus.removeEventListener("peitho:timercontrol", onTimerControl);
+    bus.removeEventListener("peitho:timeradopt", onTimerAdopt);
     host.remove();
   };
 }
@@ -758,6 +775,7 @@ var PresentShellController = class {
   slides = [];
   root;
   fetcher;
+  injectedManifest;
   win;
   doc;
   log;
@@ -789,6 +807,7 @@ var PresentShellController = class {
   onPageHide = () => this.endPresentation();
   constructor(options) {
     this.root = options.root;
+    this.injectedManifest = options.manifest;
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
@@ -809,7 +828,7 @@ var PresentShellController = class {
   }
   async load() {
     try {
-      const manifest = await this.fetchJson("manifest.json");
+      const manifest = this.injectedManifest ?? await this.fetchJson("manifest.json");
       const dimensions = {
         width: manifest.canvasWidth,
         height: manifest.canvasHeight
@@ -852,6 +871,24 @@ var PresentShellController = class {
   }
   startedAt() {
     return this.startedAtValue;
+  }
+  adoptTimerState(state) {
+    const elapsedMs = Math.max(0, state.elapsedMs);
+    const previousElapsedMs = this.elapsedMs();
+    if (!state.running && elapsedMs === 0) {
+      this.startedAtValue = null;
+      this.pausedAtValue = null;
+      this.pausedTotalMs = 0;
+      this.ended = false;
+      this.dispatchTimerAdopt(elapsedMs, state.running, previousElapsedMs);
+      return;
+    }
+    const now = this.now();
+    this.startedAtValue = now - elapsedMs;
+    this.pausedAtValue = state.running ? null : now;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+    this.dispatchTimerAdopt(elapsedMs, state.running, previousElapsedMs);
   }
   destroy() {
     this.endPresentation();
@@ -973,6 +1010,7 @@ var PresentShellController = class {
         detail: { total: this.slides.length, startedAt: this.startedAtValue }
       })
     );
+    this.dispatchTimerChange();
   }
   endPresentation() {
     if (this.ended || this.startedAtValue === null) return;
@@ -988,17 +1026,37 @@ var PresentShellController = class {
   pauseTimer() {
     if (this.startedAtValue === null || this.pausedAtValue !== null) return;
     this.pausedAtValue = this.now();
+    this.dispatchTimerChange();
   }
   resumeTimer() {
     if (this.pausedAtValue === null) return;
     this.pausedTotalMs += this.now() - this.pausedAtValue;
     this.pausedAtValue = null;
+    this.dispatchTimerChange();
   }
   resetTimer() {
     this.startedAtValue = null;
     this.pausedAtValue = null;
     this.pausedTotalMs = 0;
     this.ended = false;
+    this.dispatchTimerChange();
+  }
+  dispatchTimerChange() {
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:timerchange", {
+        detail: {
+          running: this.startedAtValue !== null && this.pausedAtValue === null,
+          elapsedMs: this.elapsedMs()
+        }
+      })
+    );
+  }
+  dispatchTimerAdopt(elapsedMs, running, previousElapsedMs) {
+    this.bus.dispatchEvent(
+      new CustomEvent("peitho:timeradopt", {
+        detail: { running, elapsedMs, previousElapsedMs }
+      })
+    );
   }
 };
 
@@ -1039,12 +1097,31 @@ function isIndexSyncMessage(value) {
 function isSwappedSyncMessage(value) {
   return isRecord(value) && typeof value.swapped === "boolean";
 }
+function isSyncedSyncMessage(value) {
+  return isRecord(value) && value.synced === true;
+}
+function isNonNegativeFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+function isTimerSyncMessage(value) {
+  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
+}
+function isTimerReplaySyncMessage(value) {
+  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
+}
 function isGenerationSyncMessage(value) {
   return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
 function defaultChannelFactory(name) {
   const channel = new BroadcastChannel(name);
   let onmessage = null;
+  let syncedDelivered = false;
+  const deliverSynced = () => {
+    if (syncedDelivered || onmessage == null) return;
+    syncedDelivered = true;
+    onmessage({ data: { synced: true } });
+  };
+  queueMicrotask(deliverSynced);
   channel.onmessage = (event) => {
     onmessage?.({ data: event.data });
   };
@@ -1054,6 +1131,7 @@ function defaultChannelFactory(name) {
     },
     set onmessage(next) {
       onmessage = next;
+      deliverSynced();
     },
     postMessage(message) {
       channel.postMessage(message);
@@ -1074,13 +1152,39 @@ function serverSyncChannelFactory(options = {}) {
     let onmessage = null;
     let closed = false;
     let seq = 0;
+    let synced = false;
+    let highestAckedPostSeq = 0;
+    let pendingTimerPosts = 0;
+    let bufferedTimerReplay = null;
     let abortController = null;
     let retryTimer = null;
-    const deliverReplayState = (body) => {
-      if (isIndexSyncMessage(body)) {
+    const flushBufferedTimerReplay = () => {
+      if (closed || pendingTimerPosts > 0 || bufferedTimerReplay == null) return;
+      const replay = bufferedTimerReplay;
+      bufferedTimerReplay = null;
+      if (replay.seq >= highestAckedPostSeq) {
+        onmessage?.({ data: replay.data });
+      }
+    };
+    const deliverReplayState = (body, options2 = {}) => {
+      const skipAbsoluteState = options2.skipAbsoluteState === true;
+      const responseSeq = typeof body.seq === "number" && Number.isFinite(body.seq) ? body.seq : 0;
+      if (isTimerReplaySyncMessage(body)) {
+        if (skipAbsoluteState) {
+          bufferedTimerReplay = null;
+        } else if (options2.deferTimerReplay === true) {
+          bufferedTimerReplay = {
+            seq: responseSeq,
+            data: { timer: body.timer, nowMs: body.nowMs }
+          };
+        } else {
+          onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
+        }
+      }
+      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (isSwappedSyncMessage(body)) {
+      if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
       if (isGenerationSyncMessage(body)) {
@@ -1109,7 +1213,14 @@ function serverSyncChannelFactory(options = {}) {
           return false;
         }
         seq = body.seq;
-        deliverReplayState(body);
+        deliverReplayState(body, {
+          skipAbsoluteState: body.seq < highestAckedPostSeq,
+          deferTimerReplay: pendingTimerPosts > 0
+        });
+        if (!synced) {
+          synced = true;
+          onmessage?.({ data: { synced: true } });
+        }
         return true;
       } catch (error) {
         if (!closed) {
@@ -1149,7 +1260,10 @@ function serverSyncChannelFactory(options = {}) {
           if (body.message != null) {
             onmessage?.({ data: body.message });
           }
-          deliverReplayState(body);
+          deliverReplayState(body, {
+            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            deferTimerReplay: pendingTimerPosts > 0
+          });
         } catch (error) {
           if (!closed) {
             console.error(`Failed to poll sync message: ${String(error)}`);
@@ -1168,15 +1282,42 @@ function serverSyncChannelFactory(options = {}) {
         onmessage = next;
       },
       postMessage(message) {
-        void fetcher(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(message),
-          keepalive: true
-        }).then((response) => {
-          if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
+        const isTimerPost = isTimerSyncMessage(message);
+        if (isTimerPost) pendingTimerPosts += 1;
+        const completeTimerPost = () => {
+          if (!isTimerPost) return;
+          pendingTimerPosts = Math.max(0, pendingTimerPosts - 1);
+          flushBufferedTimerReplay();
+        };
+        let request;
+        try {
+          request = fetcher(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(message),
+            keepalive: true
+          });
+        } catch (error) {
+          completeTimerPost();
+          console.error(`Failed to post sync message: ${String(error)}`);
+          return;
+        }
+        void request.then(async (response) => {
+          if (!response.ok) {
+            console.error(`Failed to post sync message: ${response.status}`);
+            return;
+          }
+          try {
+            const body = await response.json();
+            if (typeof body.seq === "number" && Number.isFinite(body.seq)) {
+              highestAckedPostSeq = Math.max(highestAckedPostSeq, body.seq);
+            }
+          } catch (_error) {
+          }
         }).catch((error) => {
           console.error(`Failed to post sync message: ${String(error)}`);
+        }).finally(() => {
+          completeTimerPost();
         });
       },
       close() {
@@ -1190,8 +1331,12 @@ function serverSyncChannelFactory(options = {}) {
     };
   };
 }
-function installSyncBridge(win = window, channelFactory = defaultChannelFactory, bus = win, closeWindow = () => win.close(), pathname = () => win.location.pathname, navigate = (url) => win.location.replace(url)) {
+function installSyncBridge(win = window, channelFactory = defaultChannelFactory, bus = win, hooks = {}) {
   const channel = channelFactory("peitho-sync");
+  const closeWindow = hooks.closeWindow ?? (() => win.close());
+  const pathname = hooks.pathname ?? (() => win.location.pathname);
+  const navigate = hooks.navigate ?? ((url) => win.location.replace(url));
+  let synced = false;
   const onSlideChange = (event) => {
     const detail = event.detail;
     if (typeof detail?.index !== "number") return;
@@ -1208,8 +1353,23 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
     }
     channel.postMessage({ swapped: !route.swapped });
   };
+  const onTimerChange = (event) => {
+    if (!synced) return;
+    const detail = event.detail;
+    if (typeof detail?.running !== "boolean" || !isNonNegativeFiniteNumber(detail.elapsedMs)) {
+      console.error("Invalid peitho:timerchange event");
+      return;
+    }
+    channel.postMessage({
+      timer: { running: detail.running, elapsedMs: Math.round(detail.elapsedMs) }
+    });
+  };
   channel.onmessage = (event) => {
     const data = event.data;
+    if (isSyncedSyncMessage(data)) {
+      synced = true;
+      return;
+    }
     if (isCloseSyncMessage(data)) {
       closeWindow();
       return;
@@ -1233,15 +1393,27 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
     if (isGenerationSyncMessage(data)) {
       return;
     }
+    if (isTimerReplaySyncMessage(data)) {
+      if (hooks.adoptTimerState) {
+        const serverElapsed = data.timer.elapsedMs + (data.timer.running ? Math.max(0, data.nowMs - data.timer.atMs) : 0);
+        hooks.adoptTimerState({ running: data.timer.running, elapsedMs: serverElapsed });
+      }
+      return;
+    }
+    if (isTimerSyncMessage(data)) {
+      return;
+    }
     console.error("Invalid peitho sync message");
   };
   bus.addEventListener("peitho:slidechange", onSlideChange);
   bus.addEventListener("peitho:closerequest", onCloseRequest);
   bus.addEventListener("peitho:swaprequest", onSwapRequest);
+  bus.addEventListener("peitho:timerchange", onTimerChange);
   return () => {
     bus.removeEventListener("peitho:slidechange", onSlideChange);
     bus.removeEventListener("peitho:closerequest", onCloseRequest);
     bus.removeEventListener("peitho:swaprequest", onSwapRequest);
+    bus.removeEventListener("peitho:timerchange", onTimerChange);
     channel.onmessage = null;
     channel.close();
   };
@@ -1471,7 +1643,17 @@ async function mountPresenterView(options) {
     viewport: paneViewport(previewRoot)
   });
   const keyboardCleanup = installPresenterKeyboard(win, bus, dispatchPlaypause);
-  const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
+  const syncCleanup = installSyncBridge(
+    win,
+    options.syncChannelFactory,
+    bus,
+    {
+      adoptTimerState: (state) => {
+        mainShell.adoptTimerState(state);
+        tick();
+      }
+    }
+  );
   const rawPlannedDurationMs = mainShell.manifest?.plannedDurationMs ?? null;
   const plannedDurationMs = rawPlannedDurationMs != null && isValidDurationMs(rawPlannedDurationMs) ? rawPlannedDurationMs : null;
   if (rawPlannedDurationMs != null && plannedDurationMs == null) {

--- a/packages/peitho-present/src/agenda.ts
+++ b/packages/peitho-present/src/agenda.ts
@@ -1,6 +1,11 @@
 import type { ManifestSection } from "../../../bindings/ManifestSection";
 import { sectionIndexForSlide } from "./sections";
-import type { PresentShell, SlideChangeDetail, TimerControlDetail } from "./shell";
+import type {
+  PresentShell,
+  SlideChangeDetail,
+  TimerAdoptDetail,
+  TimerControlDetail,
+} from "./shell";
 import { formatMinuteSeconds, isValidDurationMs } from "./timeTracker";
 
 const EM_DASH = "—";
@@ -79,6 +84,30 @@ export function installAgenda(options: AgendaOptions): () => void {
     render();
   }
 
+  function onTimerAdopt(event: Event): void {
+    const detail = (event as CustomEvent<TimerAdoptDetail>).detail;
+    if (
+      typeof detail?.running !== "boolean" ||
+      typeof detail.elapsedMs !== "number" ||
+      !Number.isFinite(detail.elapsedMs) ||
+      detail.elapsedMs < 0 ||
+      typeof detail.previousElapsedMs !== "number" ||
+      !Number.isFinite(detail.previousElapsedMs) ||
+      detail.previousElapsedMs < 0
+    ) {
+      log.error("Invalid peitho:timeradopt event");
+      return;
+    }
+    if (options.shell.startedAt() !== null) {
+      const sectionIndex = sectionIndexForSlide(options.sections, options.shell.currentIndex);
+      if (sectionIndex >= 0) {
+        actualMs[sectionIndex] += Math.max(0, detail.previousElapsedMs - lastElapsedMs);
+      }
+    }
+    lastElapsedMs = detail.elapsedMs;
+    render();
+  }
+
   function tick(): void {
     if (options.shell.startedAt() === null) {
       // Reset events zero actuals immediately in onTimerControl; this branch keeps
@@ -96,12 +125,14 @@ export function installAgenda(options: AgendaOptions): () => void {
   render();
   bus.addEventListener("peitho:slidechange", onSlideChange);
   bus.addEventListener("peitho:timercontrol", onTimerControl);
+  bus.addEventListener("peitho:timeradopt", onTimerAdopt);
   const interval = win.setInterval(tick, 250);
 
   return () => {
     win.clearInterval(interval);
     bus.removeEventListener("peitho:slidechange", onSlideChange);
     bus.removeEventListener("peitho:timercontrol", onTimerControl);
+    bus.removeEventListener("peitho:timeradopt", onTimerAdopt);
     host.remove();
   };
 }

--- a/packages/peitho-present/src/agenda.ts
+++ b/packages/peitho-present/src/agenda.ts
@@ -98,6 +98,12 @@ export function installAgenda(options: AgendaOptions): () => void {
       log.error("Invalid peitho:timeradopt event");
       return;
     }
+    if (!detail.running && detail.elapsedMs === 0) {
+      actualMs.fill(0);
+      lastElapsedMs = 0;
+      render();
+      return;
+    }
     if (options.shell.startedAt() !== null) {
       const sectionIndex = sectionIndexForSlide(options.sections, options.shell.currentIndex);
       if (sectionIndex >= 0) {

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -46,12 +46,20 @@ export type {
   PresentationStartDetail,
   ShellOptions,
   SlideChangeDetail,
-  TimerControlDetail
+  TimerAdoptDetail,
+  TimerControlDetail,
+  TimerStateDetail
 } from "./shell";
 export type {
   ServerSyncOptions,
+  SyncBridgeHooks,
   SyncChannel,
   SyncChannelFactory,
-  SyncMessage
+  SyncMessage,
+  SyncedSyncMessage,
+  TimerReplaySyncMessage,
+  TimerSyncMessage,
+  TimerSyncSnapshot,
+  TimerSyncState
 } from "./sync";
 export type { TimeTrackerOptions, TimeTrackerShell } from "./timeTracker";

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -267,7 +267,17 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
     viewport: paneViewport(previewRoot)
   });
   const keyboardCleanup = installPresenterKeyboard(win, bus, dispatchPlaypause);
-  const syncCleanup = installSyncBridge(win, options.syncChannelFactory, bus);
+  const syncCleanup = installSyncBridge(
+    win,
+    options.syncChannelFactory,
+    bus,
+    {
+      adoptTimerState: (state) => {
+        mainShell.adoptTimerState(state);
+        tick();
+      }
+    }
+  );
   const rawPlannedDurationMs = mainShell.manifest?.plannedDurationMs ?? null;
   const plannedDurationMs =
     rawPlannedDurationMs != null && isValidDurationMs(rawPlannedDurationMs)

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -1,15 +1,46 @@
 import type { Manifest } from "../../../bindings/Manifest";
+import type { Notes } from "../../../bindings/Notes";
+import { sectionIndexForSlide } from "./sections";
+import {
+  mountPresentShell as defaultMountPresentShell,
+  type PresentShell,
+  type ShellOptions,
+  type TimerControlDetail
+} from "./shell";
 import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
 import {
   isCloseSyncMessage,
   isGenerationSyncMessage,
   isIndexSyncMessage,
+  isSyncedSyncMessage,
   isSwappedSyncMessage,
+  isTimerReplaySyncMessage,
+  isTimerSyncMessage,
   serverSyncChannelFactory,
   type SyncChannelFactory
 } from "./sync";
+import { clamp01, formatMinuteSeconds, isValidDurationMs } from "./timeTracker";
 
-type RemoteSlide = { skip: boolean };
+export { mountPresentShell } from "./shell";
+export { serverSyncChannelFactory } from "./sync";
+
+type RemoteSlide = {
+  key: string;
+  skip: boolean;
+  title: string;
+};
+
+type RemoteTimerAnchor = {
+  running: boolean;
+  elapsedMs: number;
+  receivedAtMs: number;
+};
+
+type TimerVisualState = "stopped" | "running" | "paused";
+
+export type RemotePaceState =
+  | { kind: "ahead" | "behind"; label: string; emoji: "hare" | "tortoise" }
+  | { kind: "paused"; label: "Paused"; emoji: null };
 
 export type RemoteView = {
   manifest: Manifest | null;
@@ -20,12 +51,16 @@ export type RemoteView = {
 export type RemoteViewOptions = {
   root: HTMLElement;
   manifestUrl?: string;
+  notesUrl?: string;
   fetcher?: typeof fetch;
   channelFactory?: SyncChannelFactory;
+  syncChannelFactory?: SyncChannelFactory;
+  mountPresentShell?: (options: ShellOptions) => Promise<PresentShell>;
   window?: Window;
   document?: Document;
   bus?: EventTarget;
   console?: Pick<Console, "error">;
+  now?: () => number;
 };
 
 export type RemoteControlsOptions = {
@@ -38,8 +73,12 @@ export type RemoteSyncBridgeOptions = {
   slides: ReadonlyArray<RemoteSlide>;
   channelFactory?: SyncChannelFactory;
   bus?: EventTarget;
+  now?: () => number;
   getCurrentIndex(): number | null;
   setCurrentIndex(index: number): void;
+  getTimerState(): RemoteTimerAnchor | null;
+  setTimerState(state: RemoteTimerAnchor): void;
+  setSynced(): void;
   setEnded(): void;
   console?: Pick<Console, "error">;
 };
@@ -59,11 +98,82 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
 
   const container = doc.createElement("section");
   container.className = "peitho-remote";
+  container.dataset.peithoEnded = "false";
 
+  const preview = doc.createElement("div");
+  preview.className = "peitho-remote-preview peitho-remote-dim-on-end";
+  preview.dataset.peithoRemote = "preview";
+
+  const titlebar = doc.createElement("div");
+  titlebar.className = "peitho-remote-titlebar peitho-remote-dim-on-end";
+  const title = doc.createElement("div");
+  title.className = "peitho-remote-title";
+  title.dataset.peithoRemote = "title";
+  title.textContent = "Loading";
   const counter = doc.createElement("div");
   counter.className = "peitho-remote-counter";
   counter.dataset.peithoRemote = "counter";
   counter.textContent = "– / –";
+  titlebar.append(title, counter);
+
+  const progress = doc.createElement("div");
+  progress.className = "peitho-remote-progress peitho-remote-dim-on-end";
+  progress.dataset.peithoRemote = "progress";
+  const progressFill = doc.createElement("div");
+  progressFill.className = "peitho-remote-progress-fill";
+  progressFill.dataset.peithoRemote = "progress-fill";
+  const planTick = doc.createElement("div");
+  planTick.className = "peitho-remote-plan-tick";
+  planTick.dataset.peithoRemote = "plan-tick";
+  planTick.hidden = true;
+  progress.append(progressFill, planTick);
+
+  const pace = doc.createElement("div");
+  pace.className = "peitho-remote-pace peitho-remote-dim-on-end";
+  const timerButton = doc.createElement("button");
+  timerButton.type = "button";
+  timerButton.className = "peitho-remote-timer-button";
+  timerButton.dataset.peithoAction = "timer";
+  timerButton.dataset.peithoRunning = "false";
+  timerButton.dataset.peithoTimerAction = "start";
+  timerButton.disabled = true;
+  timerButton.setAttribute("aria-label", "Start timer");
+  const timerIcon = doc.createElement("span");
+  timerIcon.className = "peitho-remote-timer-icon";
+  timerIcon.dataset.peithoIcon = "play";
+  timerButton.append(timerIcon);
+  const elapsedRow = doc.createElement("div");
+  elapsedRow.className = "peitho-remote-elapsed-row";
+  elapsedRow.dataset.peithoRemote = "elapsed-row";
+  const elapsed = doc.createElement("span");
+  elapsed.className = "peitho-remote-elapsed";
+  elapsed.dataset.peithoRemote = "elapsed";
+  elapsed.textContent = "0:00";
+  const separator = doc.createElement("span");
+  separator.className = "peitho-remote-time-separator";
+  separator.dataset.peithoRemote = "time-separator";
+  separator.textContent = "/";
+  separator.hidden = true;
+  const planned = doc.createElement("span");
+  planned.className = "peitho-remote-planned";
+  planned.dataset.peithoRemote = "planned";
+  planned.hidden = true;
+  elapsedRow.append(elapsed, separator, planned);
+  const chip = doc.createElement("span");
+  chip.className = "peitho-remote-pace-chip";
+  chip.dataset.peithoRemote = "pace-chip";
+  chip.hidden = true;
+  pace.append(timerButton, elapsedRow, chip);
+
+  const notesPanel = doc.createElement("section");
+  notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
+  const notesCaption = doc.createElement("div");
+  notesCaption.className = "peitho-remote-notes-caption";
+  notesCaption.textContent = "NOTES";
+  const notesBody = doc.createElement("div");
+  notesBody.className = "peitho-remote-notes-body";
+  notesBody.dataset.peithoRemote = "notes";
+  notesPanel.append(notesCaption, notesBody);
 
   const status = doc.createElement("div");
   status.className = "peitho-remote-status";
@@ -71,22 +181,29 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
 
   const actions = doc.createElement("div");
   actions.className = "peitho-remote-actions";
-
   const prev = remoteButton(doc, "prev", "Previous");
   const next = remoteButton(doc, "next", "Next");
+  actions.append(prev, next);
 
   const onPrev = (): void => dispatchNavigate(bus, "prev");
   const onNext = (): void => dispatchNavigate(bus, "next");
+  const onTimer = (): void => {
+    const action = timerButton.dataset.peithoTimerAction;
+    if (action === "start" || action === "pause" || action === "resume") {
+      dispatchTimerControl(bus, action);
+    }
+  };
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
+  timerButton.addEventListener("click", onTimer);
 
-  actions.append(prev, next);
-  container.append(counter, status, actions);
+  container.append(preview, titlebar, progress, pace, notesPanel, status, actions);
   root.append(container);
 
   return () => {
     prev.removeEventListener("click", onPrev);
     next.removeEventListener("click", onNext);
+    timerButton.removeEventListener("click", onTimer);
     container.remove();
   };
 }
@@ -94,9 +211,12 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
 export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () => void {
   const bus = options.bus ?? window;
   const log = options.console ?? console;
+  const now = options.now ?? Date.now;
   const channel = (options.channelFactory ?? serverSyncChannelFactory())("peitho-sync");
+  let synced = false;
 
   const onNavigate = (event: Event): void => {
+    if (!synced) return;
     const to = (event as CustomEvent<{ to?: unknown }>).detail?.to;
     if (to !== "next" && to !== "prev") return;
     const target = resolveRemoteTarget(options.slides, options.getCurrentIndex(), to);
@@ -105,8 +225,28 @@ export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () =>
     options.setCurrentIndex(target);
   };
 
+  const onTimerControl = (event: Event): void => {
+    if (!synced) return;
+    const action = (event as CustomEvent<TimerControlDetail>).detail?.action;
+    if (action !== "start" && action !== "pause" && action !== "resume" && action !== "reset") {
+      log.error("Invalid peitho:timercontrol event");
+      return;
+    }
+    const next = nextTimerStateForAction(action, options.getTimerState(), now());
+    if (next === null) return;
+    channel.postMessage({
+      timer: { running: next.running, elapsedMs: Math.round(next.elapsedMs) }
+    });
+    options.setTimerState(next);
+  };
+
   channel.onmessage = (event: { data: unknown }): void => {
     const data = event.data;
+    if (isSyncedSyncMessage(data)) {
+      synced = true;
+      options.setSynced();
+      return;
+    }
     if (isCloseSyncMessage(data)) {
       options.setEnded();
       return;
@@ -115,13 +255,30 @@ export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () =>
       options.setCurrentIndex(data.index);
       return;
     }
-    if (isSwappedSyncMessage(data) || isGenerationSyncMessage(data)) return;
+    if (isTimerReplaySyncMessage(data)) {
+      const serverAdvance = data.timer.running ? Math.max(0, data.nowMs - data.timer.atMs) : 0;
+      options.setTimerState({
+        running: data.timer.running,
+        elapsedMs: data.timer.elapsedMs + serverAdvance,
+        receivedAtMs: now()
+      });
+      return;
+    }
+    if (
+      isSwappedSyncMessage(data) ||
+      isGenerationSyncMessage(data) ||
+      isTimerSyncMessage(data)
+    ) {
+      return;
+    }
     log.error("Invalid peitho remote sync message");
   };
 
   bus.addEventListener("peitho:navigate", onNavigate);
+  bus.addEventListener("peitho:timercontrol", onTimerControl);
   return () => {
     bus.removeEventListener("peitho:navigate", onNavigate);
+    bus.removeEventListener("peitho:timercontrol", onTimerControl);
     channel.onmessage = null;
     channel.close();
   };
@@ -132,45 +289,81 @@ class RemoteController implements RemoteView {
   currentIndex: number | null = null;
   private readonly root: HTMLElement;
   private readonly manifestUrl: string;
+  private readonly notesUrl: string;
   private readonly fetcher: typeof fetch;
   private readonly channelFactory?: SyncChannelFactory;
+  private readonly mountPresentShell: (options: ShellOptions) => Promise<PresentShell>;
   private readonly win: Window;
   private readonly doc: Document;
   private readonly bus: EventTarget;
+  private readonly previewBus = new EventTarget();
   private readonly log: Pick<Console, "error">;
+  private readonly now: () => number;
+  private synced = false;
+  private notes: Notes = { version: 1, notes: {} };
+  private renderedNotesValue: string | null = null;
   private slides: RemoteSlide[] = [];
+  private ended = false;
+  private timerState: RemoteTimerAnchor | null = null;
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
+  private previewShell: PresentShell | null = null;
+  private timerInterval: number | null = null;
 
   constructor(options: RemoteViewOptions) {
     this.root = options.root;
     this.manifestUrl = options.manifestUrl ?? "manifest.json";
+    this.notesUrl = options.notesUrl ?? "notes.json";
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
-    this.channelFactory = options.channelFactory;
+    this.channelFactory = options.syncChannelFactory ?? options.channelFactory;
+    this.mountPresentShell = options.mountPresentShell ?? defaultMountPresentShell;
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
     this.bus = options.bus ?? this.win;
     this.log = options.console ?? console;
+    this.now = options.now ?? Date.now;
   }
 
   async load(): Promise<void> {
     try {
       const manifest = await this.fetchJson<Manifest>(this.manifestUrl);
       this.manifest = manifest;
-      this.slides = manifest.slides.map((slide) => ({ skip: slide.skip === true }));
+      this.notes = await this.fetchNotes();
+      this.slides = manifest.slides.map((slide) => ({
+        key: slide.key,
+        skip: slide.skip === true,
+        title: slide.text.title
+      }));
       this.currentIndex = initialSlideIndex(this.slides);
       this.controlsCleanup = installRemoteControls({
         root: this.root,
         document: this.doc,
         bus: this.bus
       });
-      this.renderCounter();
+      const previewRoot = this.root.querySelector<HTMLElement>('[data-peitho-remote="preview"]');
+      if (previewRoot != null) {
+        this.previewShell = await this.mountPresentShell({
+          root: previewRoot,
+          fetcher: this.fetcher,
+          window: this.win,
+          document: this.doc,
+          bus: this.previewBus,
+          manifest,
+          now: this.now,
+          viewport: paneViewport(previewRoot)
+        });
+      }
+      this.render();
       this.syncCleanup = installRemoteSyncBridge({
         slides: this.slides,
         channelFactory: this.channelFactory,
         bus: this.bus,
+        now: this.now,
         getCurrentIndex: () => this.currentIndex,
         setCurrentIndex: (index) => this.setCurrentIndex(index),
+        getTimerState: () => this.timerState,
+        setTimerState: (state) => this.setTimerState(state),
+        setSynced: () => this.setSynced(),
         setEnded: () => this.setEnded(),
         console: this.log
       });
@@ -180,8 +373,11 @@ class RemoteController implements RemoteView {
   }
 
   destroy(): void {
+    this.clearTimerInterval();
     this.syncCleanup?.();
     this.syncCleanup = null;
+    this.previewShell?.destroy();
+    this.previewShell = null;
     this.controlsCleanup?.();
     this.controlsCleanup = null;
   }
@@ -192,27 +388,226 @@ class RemoteController implements RemoteView {
     return response.json() as Promise<T>;
   }
 
+  private async fetchNotes(): Promise<Notes> {
+    try {
+      return await this.fetchJson<Notes>(this.notesUrl);
+    } catch (error) {
+      this.log.error(
+        `Failed to load ${this.notesUrl}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return { version: 1, notes: {} };
+    }
+  }
+
   private setCurrentIndex(index: number): void {
     this.currentIndex = clampIndex(index, this.slides.length);
-    this.renderCounter();
+    this.render();
+  }
+
+  private setTimerState(state: RemoteTimerAnchor): void {
+    this.timerState = {
+      running: state.running,
+      elapsedMs: Math.max(0, state.elapsedMs),
+      receivedAtMs: state.receivedAtMs
+    };
+    this.render();
+  }
+
+  private setSynced(): void {
+    this.synced = true;
+    this.render();
   }
 
   private setEnded(): void {
     const cleanup = this.syncCleanup;
     this.syncCleanup = null;
     cleanup?.();
-    for (const button of this.root.querySelectorAll<HTMLButtonElement>("[data-peitho-action]")) {
-      button.disabled = true;
-    }
-    const status = this.root.querySelector<HTMLElement>('[data-peitho-remote="status"]');
-    if (status != null) status.textContent = "Ended";
+    this.ended = true;
+    this.clearTimerInterval();
+    this.render();
   }
 
-  private renderCounter(): void {
-    const counter = this.root.querySelector<HTMLElement>('[data-peitho-remote="counter"]');
-    if (counter == null) return;
+  private render(): void {
+    const manifest = this.manifest;
+    if (manifest == null) return;
+    const container = this.root.querySelector<HTMLElement>(".peitho-remote");
+    if (container == null) return;
+    container.dataset.peithoEnded = this.ended ? "true" : "false";
+    const currentIndex = this.currentIndex;
+    const slide = currentIndex == null ? null : manifest.slides[currentIndex];
     const total = this.slides.length;
-    counter.textContent = this.currentIndex === null ? `– / ${total}` : `${this.currentIndex + 1} / ${total}`;
+
+    setText(this.root, "title", slideTitle(slide?.text.title));
+    setText(this.root, "counter", currentIndex == null ? `– / ${total}` : `${currentIndex + 1} / ${total}`);
+
+    this.renderProgress(manifest, currentIndex);
+    this.renderPaceStatic(manifest);
+    this.renderTimeDependentChrome(manifest, currentIndex);
+    this.renderSection(manifest, currentIndex);
+    this.renderNotes(slide?.key);
+    this.renderButtons(currentIndex);
+    setText(this.root, "status", this.ended ? "Ended" : "");
+    this.syncPreview(currentIndex);
+    this.updateTimerInterval();
+  }
+
+  private renderProgress(manifest: Manifest, currentIndex: number | null): void {
+    const progress = this.root.querySelector<HTMLElement>('[data-peitho-remote="progress"]');
+    const fill = this.root.querySelector<HTMLElement>('[data-peitho-remote="progress-fill"]');
+    if (progress == null || fill == null) return;
+    const fraction =
+      currentIndex == null ? 0 : manifest.slideCount <= 1 ? 1 : currentIndex / (manifest.slideCount - 1);
+    fill.style.width = `${clamp01(fraction) * 100}%`;
+    this.updatePlanTick(manifest, this.currentElapsedMs());
+  }
+
+  private renderPaceStatic(manifest: Manifest): void {
+    const elapsedRow = this.root.querySelector<HTMLElement>('[data-peitho-remote="elapsed-row"]');
+    if (elapsedRow == null) return;
+    const separator = elapsedRow.querySelector<HTMLElement>('[data-peitho-remote="time-separator"]');
+    const planned = elapsedRow.querySelector<HTMLElement>('[data-peitho-remote="planned"]');
+    const plannedDurationMs = validPlannedDurationMs(manifest);
+    if (separator != null) separator.hidden = plannedDurationMs == null;
+    if (planned != null) {
+      planned.hidden = plannedDurationMs == null;
+      planned.textContent = plannedDurationMs == null ? "" : formatMinuteSeconds(plannedDurationMs);
+    }
+  }
+
+  private renderTimeDependentChrome(manifest: Manifest, currentIndex: number | null): void {
+    const timerButton = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]');
+    const elapsed = this.root.querySelector<HTMLElement>('[data-peitho-remote="elapsed"]');
+    if (timerButton == null || elapsed == null) return;
+
+    const elapsedMs = this.currentElapsedMs();
+    const state = timerVisualState(this.timerState, elapsedMs);
+    timerButton.disabled = this.ended || !this.synced;
+    timerButton.dataset.peithoRunning = state === "running" ? "true" : "false";
+    timerButton.dataset.peithoTimerAction = playpauseActionFor(state);
+    timerButton.setAttribute("aria-label", timerAriaLabel(state));
+    const icon = timerButton.querySelector<HTMLElement>(".peitho-remote-timer-icon");
+    if (icon != null) icon.dataset.peithoIcon = state === "running" ? "pause" : "play";
+
+    elapsed.textContent = formatMinuteSeconds(elapsedMs);
+
+    this.updatePlanTick(manifest, elapsedMs);
+    const chip = this.root.querySelector<HTMLElement>('[data-peitho-remote="pace-chip"]');
+    if (chip == null || currentIndex == null) {
+      if (chip != null) chip.hidden = true;
+      return;
+    }
+    const paceState = remotePaceState(manifest, currentIndex, elapsedMs, state === "running");
+    if (paceState == null) {
+      chip.hidden = true;
+      chip.textContent = "";
+      return;
+    }
+    chip.hidden = false;
+    chip.dataset.peithoPace = paceState.kind;
+    if (paceState.emoji != null) {
+      const emoji = this.doc.createElement("span");
+      emoji.dataset.peithoPaceEmoji = "";
+      emoji.textContent = paceState.emoji === "hare" ? "🐇" : "🐢";
+      chip.replaceChildren(emoji, this.doc.createTextNode(` ${paceState.label}`));
+    } else {
+      chip.textContent = paceState.label;
+    }
+  }
+
+  private updatePlanTick(manifest: Manifest, elapsedMs: number): void {
+    const tick = this.root.querySelector<HTMLElement>('[data-peitho-remote="plan-tick"]');
+    if (tick == null) return;
+    const planProgress = plannedProgressAtElapsed(manifest, elapsedMs);
+    tick.hidden = planProgress == null;
+    if (planProgress != null) tick.style.left = `${planProgress * 100}%`;
+  }
+
+  private renderSection(manifest: Manifest, currentIndex: number | null): void {
+    const existing = this.root.querySelector<HTMLElement>('[data-peitho-remote="section"]');
+    if (currentIndex == null || manifest.sections.length === 0) {
+      existing?.remove();
+      return;
+    }
+    const sectionIndex = sectionIndexForSlide(manifest.sections, currentIndex);
+    if (sectionIndex < 0) {
+      existing?.remove();
+      return;
+    }
+    const section = manifest.sections[sectionIndex];
+    const sectionSlideCount = section.endIndex - section.startIndex + 1;
+    const sectionOffset = currentIndex - section.startIndex + 1;
+    const sectionLine = existing ?? this.doc.createElement("div");
+    sectionLine.className = "peitho-remote-section peitho-remote-dim-on-end";
+    sectionLine.dataset.peithoRemote = "section";
+    const name = this.doc.createElement("b");
+    name.textContent = section.name;
+    sectionLine.replaceChildren(
+      name,
+      this.doc.createTextNode(` · slide ${sectionOffset} / ${sectionSlideCount} in section`)
+    );
+    if (existing == null) {
+      const notes = this.root.querySelector<HTMLElement>(".peitho-remote-notes");
+      notes?.before(sectionLine);
+    }
+  }
+
+  private renderNotes(slideKey: string | undefined): void {
+    const notes = this.root.querySelector<HTMLElement>('[data-peitho-remote="notes"]');
+    if (notes == null) return;
+    const value = slideKey == null ? null : this.notes.notes[slideKey];
+    if (value == null || value.length === 0) {
+      this.setNotesText(notes, "No notes for this slide");
+      notes.dataset.peithoEmpty = "true";
+      return;
+    }
+    this.setNotesText(notes, value);
+    notes.dataset.peithoEmpty = "false";
+  }
+
+  private setNotesText(notes: HTMLElement, value: string): void {
+    if (this.renderedNotesValue === value) return;
+    notes.textContent = value;
+    this.renderedNotesValue = value;
+  }
+
+  private renderButtons(currentIndex: number | null): void {
+    const prev = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="prev"]');
+    const next = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="next"]');
+    if (prev == null || next == null) return;
+    prev.disabled =
+      this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
+    next.disabled =
+      this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
+  }
+
+  private syncPreview(currentIndex: number | null): void {
+    if (currentIndex == null) return;
+    this.previewBus.dispatchEvent(
+      new CustomEvent("peitho:navigate", { detail: { to: { index: currentIndex } } })
+    );
+  }
+
+  private currentElapsedMs(): number {
+    return currentTimerElapsedMs(this.timerState, this.now());
+  }
+
+  private updateTimerInterval(): void {
+    if (this.ended || this.timerState?.running !== true) {
+      this.clearTimerInterval();
+      return;
+    }
+    if (this.timerInterval != null) return;
+    this.timerInterval = this.win.setInterval(() => {
+      const manifest = this.manifest;
+      if (manifest == null) return;
+      this.renderTimeDependentChrome(manifest, this.currentIndex);
+    }, 1000);
+  }
+
+  private clearTimerInterval(): void {
+    if (this.timerInterval == null) return;
+    this.win.clearInterval(this.timerInterval);
+    this.timerInterval = null;
   }
 
   private showError(message: string): void {
@@ -226,13 +621,26 @@ class RemoteController implements RemoteView {
 function remoteButton(doc: Document, action: "prev" | "next", label: string): HTMLButtonElement {
   const button = doc.createElement("button");
   button.type = "button";
+  button.disabled = true;
   button.dataset.peithoAction = action;
-  button.textContent = label;
+  button.dataset.peithoDirection = action;
+  const arrow = doc.createElement("span");
+  arrow.className = "peitho-remote-action-arrow";
+  arrow.textContent = action === "prev" ? "‹" : "›";
+  if (action === "prev") {
+    button.append(arrow, doc.createTextNode(` ${label}`));
+  } else {
+    button.append(doc.createTextNode(`${label} `), arrow);
+  }
   return button;
 }
 
 function dispatchNavigate(bus: EventTarget, to: "prev" | "next"): void {
   bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to } }));
+}
+
+function dispatchTimerControl(bus: EventTarget, action: TimerControlDetail["action"]): void {
+  bus.dispatchEvent(new CustomEvent<TimerControlDetail>("peitho:timercontrol", { detail: { action } }));
 }
 
 function resolveRemoteTarget(
@@ -248,4 +656,142 @@ function resolveRemoteTarget(
 function clampIndex(index: number, total: number): number | null {
   if (total === 0) return null;
   return Math.max(0, Math.min(Math.trunc(index), total - 1));
+}
+
+function setText(root: HTMLElement, key: string, value: string): void {
+  const element = root.querySelector<HTMLElement>(`[data-peitho-remote="${key}"]`);
+  if (element != null) element.textContent = value;
+}
+
+function slideTitle(title: string | undefined): string {
+  return title == null || title.length === 0 ? "Untitled slide" : title;
+}
+
+function validPlannedDurationMs(manifest: Manifest): number | null {
+  const plannedDurationMs = manifest.plannedDurationMs;
+  return plannedDurationMs != null && isValidDurationMs(plannedDurationMs)
+    ? plannedDurationMs
+    : null;
+}
+
+export function expectedElapsedAtSlide(manifest: Manifest, index: number): number | null {
+  const plannedDurationMs = validPlannedDurationMs(manifest);
+  if (plannedDurationMs == null) return null;
+  const slideCount = Math.max(1, manifest.slideCount);
+  const clampedIndex = Math.max(0, Math.min(Math.trunc(index), slideCount - 1));
+  if (manifest.sections.length === 0) {
+    return (plannedDurationMs * clampedIndex) / slideCount;
+  }
+  const sectionIndex = sectionIndexForSlide(manifest.sections, clampedIndex);
+  if (sectionIndex < 0) return (plannedDurationMs * clampedIndex) / slideCount;
+  let elapsed = 0;
+  for (let i = 0; i < sectionIndex; i += 1) {
+    elapsed += manifest.sections[i].plannedDurationMs;
+  }
+  const section = manifest.sections[sectionIndex];
+  const sectionSlideCount = section.endIndex - section.startIndex + 1;
+  return (
+    elapsed +
+    section.plannedDurationMs * ((clampedIndex - section.startIndex) / sectionSlideCount)
+  );
+}
+
+export function plannedProgressAtElapsed(manifest: Manifest, elapsedMs: number): number | null {
+  const plannedDurationMs = validPlannedDurationMs(manifest);
+  if (plannedDurationMs == null) return null;
+  if (manifest.slideCount <= 1) return 1;
+  const elapsed = clamp01(elapsedMs / plannedDurationMs) * plannedDurationMs;
+  if (manifest.sections.length === 0) {
+    return clamp01(((elapsed / plannedDurationMs) * manifest.slideCount) / (manifest.slideCount - 1));
+  }
+  let elapsedBefore = 0;
+  for (const section of manifest.sections) {
+    const duration = section.plannedDurationMs;
+    const elapsedAfter = elapsedBefore + duration;
+    if (elapsed <= elapsedAfter) {
+      const sectionSlideCount = section.endIndex - section.startIndex + 1;
+      const ratio = duration === 0 ? 0 : (elapsed - elapsedBefore) / duration;
+      const slidePosition = section.startIndex + ratio * sectionSlideCount;
+      return clamp01(slidePosition / (manifest.slideCount - 1));
+    }
+    elapsedBefore = elapsedAfter;
+  }
+  return 1;
+}
+
+export function remotePaceState(
+  manifest: Manifest,
+  index: number,
+  elapsedMs: number,
+  running: boolean
+): RemotePaceState | null {
+  const expected = expectedElapsedAtSlide(manifest, index);
+  if (expected == null) return null;
+  if (!running) {
+    return elapsedMs > 0 ? { kind: "paused", label: "Paused", emoji: null } : null;
+  }
+  const delta = elapsedMs - expected;
+  if (delta >= 0) {
+    return {
+      kind: "behind",
+      label: `${formatMinuteSeconds(delta)} behind`,
+      emoji: "tortoise"
+    };
+  }
+  return {
+    kind: "ahead",
+    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`,
+    emoji: "hare"
+  };
+}
+
+function currentTimerElapsedMs(timer: RemoteTimerAnchor | null, now: number): number {
+  if (timer == null) return 0;
+  return Math.max(0, timer.elapsedMs + (timer.running ? now - timer.receivedAtMs : 0));
+}
+
+function timerVisualState(timer: RemoteTimerAnchor | null, elapsedMs: number): TimerVisualState {
+  if (timer == null || (!timer.running && elapsedMs === 0)) return "stopped";
+  return timer.running ? "running" : "paused";
+}
+
+function playpauseActionFor(state: TimerVisualState): TimerControlDetail["action"] {
+  if (state === "running") return "pause";
+  if (state === "paused") return "resume";
+  return "start";
+}
+
+function timerAriaLabel(state: TimerVisualState): string {
+  if (state === "running") return "Pause timer";
+  if (state === "paused") return "Resume timer";
+  return "Start timer";
+}
+
+function nextTimerStateForAction(
+  action: TimerControlDetail["action"],
+  current: RemoteTimerAnchor | null,
+  now: number
+): RemoteTimerAnchor | null {
+  const elapsedMs = currentTimerElapsedMs(current, now);
+  const state = timerVisualState(current, elapsedMs);
+  if (action === "start") {
+    if (state !== "stopped") return null;
+    return { running: true, elapsedMs: 0, receivedAtMs: now };
+  }
+  if (action === "pause") {
+    if (state !== "running") return null;
+    return { running: false, elapsedMs, receivedAtMs: now };
+  }
+  if (action === "resume") {
+    if (state !== "paused") return null;
+    return { running: true, elapsedMs, receivedAtMs: now };
+  }
+  return { running: false, elapsedMs: 0, receivedAtMs: now };
+}
+
+function paneViewport(pane: HTMLElement): () => { width: number; height: number } {
+  return () => ({
+    width: pane.clientWidth,
+    height: pane.clientHeight
+  });
 }

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -39,7 +39,7 @@ type RemoteTimerAnchor = {
 type TimerVisualState = "stopped" | "running" | "paused";
 
 export type RemotePaceState =
-  | { kind: "ahead" | "behind" | "overrun"; label: string }
+  | { kind: "ahead" | "behind" | "onpace" | "overrun"; label: string }
   | { kind: "paused"; label: "Paused" };
 
 export type RemoteView = {
@@ -153,6 +153,13 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   timerIcon.className = "peitho-remote-timer-icon";
   timerIcon.dataset.peithoIcon = "play";
   timerButton.append(timerIcon);
+  const resetButton = doc.createElement("button");
+  resetButton.type = "button";
+  resetButton.className = "peitho-remote-reset-button";
+  resetButton.dataset.peithoAction = "timer-reset";
+  resetButton.disabled = true;
+  resetButton.setAttribute("aria-label", "Reset timer");
+  resetButton.textContent = "↺";
   const elapsedRow = doc.createElement("div");
   elapsedRow.className = "peitho-remote-elapsed-row";
   elapsedRow.dataset.peithoRemote = "elapsed-row";
@@ -174,7 +181,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   delta.className = "peitho-remote-pace-delta";
   delta.dataset.peithoRemote = "pace-delta";
   delta.hidden = true;
-  pace.append(timerButton, elapsedRow, delta);
+  pace.append(timerButton, resetButton, elapsedRow, delta);
 
   const notesPanel = doc.createElement("section");
   notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
@@ -204,9 +211,11 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
       dispatchTimerControl(bus, action);
     }
   };
+  const onReset = (): void => dispatchTimerControl(bus, "reset");
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
   timerButton.addEventListener("click", onTimer);
+  resetButton.addEventListener("click", onReset);
 
   container.append(preview, titlebar, chase, pace, notesPanel, status, actions);
   root.append(container);
@@ -215,6 +224,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
     prev.removeEventListener("click", onPrev);
     next.removeEventListener("click", onNext);
     timerButton.removeEventListener("click", onTimer);
+    resetButton.removeEventListener("click", onReset);
     container.remove();
   };
 }
@@ -486,12 +496,16 @@ class RemoteController implements RemoteView {
 
   private renderTimeDependentChrome(manifest: Manifest, currentIndex: number | null): void {
     const timerButton = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]');
+    const resetButton = this.root.querySelector<HTMLButtonElement>(
+      '[data-peitho-action="timer-reset"]'
+    );
     const elapsed = this.root.querySelector<HTMLElement>('[data-peitho-remote="elapsed"]');
-    if (timerButton == null || elapsed == null) return;
+    if (timerButton == null || resetButton == null || elapsed == null) return;
 
     const elapsedMs = this.currentElapsedMs();
     const state = timerVisualState(this.timerState, elapsedMs);
     timerButton.disabled = this.ended || !this.synced;
+    resetButton.disabled = this.ended || !this.synced || state === "stopped";
     timerButton.dataset.peithoRunning = state === "running" ? "true" : "false";
     timerButton.dataset.peithoTimerAction = playpauseActionFor(state);
     timerButton.setAttribute("aria-label", timerAriaLabel(state));
@@ -534,9 +548,9 @@ class RemoteController implements RemoteView {
     turtle.hidden = false;
     const overrun = isOverrun(elapsedMs, plannedDurationMs);
     chase.classList.toggle("peitho-remote-chase-overrun", overrun);
-    const turtleFraction = overrun ? 1 : plannedProgressAtElapsed(manifest, elapsedMs);
-    setChaseMarker(turtle, turtleFraction ?? 0);
-    setChaseFill(fill, turtleFraction ?? 0);
+    const turtleFraction = clamp01(elapsedMs / plannedDurationMs);
+    setChaseMarker(turtle, turtleFraction);
+    setChaseFill(fill, turtleFraction);
 
     if (currentIndex == null) {
       delta.hidden = true;
@@ -732,12 +746,14 @@ export function expectedElapsedAtSlide(manifest: Manifest, index: number): numbe
   const plannedDurationMs = validPlannedDurationMs(manifest);
   if (plannedDurationMs == null) return null;
   const slideCount = Math.max(1, manifest.slideCount);
-  const clampedIndex = Math.max(0, Math.min(Math.trunc(index), slideCount - 1));
+  const requestedIndex = Number.isFinite(index) ? Math.trunc(index) : 0;
+  if (requestedIndex <= 0) return 0;
+  if (requestedIndex >= slideCount) return plannedDurationMs;
   if (manifest.sections.length === 0) {
-    return (plannedDurationMs * clampedIndex) / slideCount;
+    return (plannedDurationMs * requestedIndex) / slideCount;
   }
-  const sectionIndex = sectionIndexForSlide(manifest.sections, clampedIndex);
-  if (sectionIndex < 0) return (plannedDurationMs * clampedIndex) / slideCount;
+  const sectionIndex = sectionIndexForSlide(manifest.sections, requestedIndex);
+  if (sectionIndex < 0) return (plannedDurationMs * requestedIndex) / slideCount;
   let elapsed = 0;
   for (let i = 0; i < sectionIndex; i += 1) {
     elapsed += manifest.sections[i].plannedDurationMs;
@@ -746,31 +762,8 @@ export function expectedElapsedAtSlide(manifest: Manifest, index: number): numbe
   const sectionSlideCount = section.endIndex - section.startIndex + 1;
   return (
     elapsed +
-    section.plannedDurationMs * ((clampedIndex - section.startIndex) / sectionSlideCount)
+    section.plannedDurationMs * ((requestedIndex - section.startIndex) / sectionSlideCount)
   );
-}
-
-export function plannedProgressAtElapsed(manifest: Manifest, elapsedMs: number): number | null {
-  const plannedDurationMs = validPlannedDurationMs(manifest);
-  if (plannedDurationMs == null) return null;
-  if (manifest.slideCount <= 1) return 1;
-  const elapsed = clamp01(elapsedMs / plannedDurationMs) * plannedDurationMs;
-  if (manifest.sections.length === 0) {
-    return clamp01(((elapsed / plannedDurationMs) * manifest.slideCount) / (manifest.slideCount - 1));
-  }
-  let elapsedBefore = 0;
-  for (const section of manifest.sections) {
-    const duration = section.plannedDurationMs;
-    const elapsedAfter = elapsedBefore + duration;
-    if (elapsed <= elapsedAfter) {
-      const sectionSlideCount = section.endIndex - section.startIndex + 1;
-      const ratio = duration === 0 ? 0 : (elapsed - elapsedBefore) / duration;
-      const slidePosition = section.startIndex + ratio * sectionSlideCount;
-      return clamp01(slidePosition / (manifest.slideCount - 1));
-    }
-    elapsedBefore = elapsedAfter;
-  }
-  return 1;
 }
 
 export function remotePaceState(
@@ -779,8 +772,9 @@ export function remotePaceState(
   elapsedMs: number,
   running: boolean
 ): RemotePaceState | null {
-  const expected = expectedElapsedAtSlide(manifest, index);
-  if (expected == null) return null;
+  const expectedStart = expectedElapsedAtSlide(manifest, index);
+  const expectedEnd = expectedElapsedAtSlide(manifest, index + 1);
+  if (expectedStart == null || expectedEnd == null) return null;
   if (!running) {
     return elapsedMs > 0 ? { kind: "paused", label: "Paused" } : null;
   }
@@ -791,16 +785,18 @@ export function remotePaceState(
       label: `+${formatMinuteSeconds(elapsedMs - plannedDurationMs)} over`
     };
   }
-  const delta = elapsedMs - expected;
-  if (delta >= 0) {
+  if (elapsedMs < expectedStart) {
     return {
-      kind: "behind",
-      label: `${formatMinuteSeconds(delta)} behind`
+      kind: "ahead",
+      label: `${formatMinuteSeconds(expectedStart - elapsedMs)} ahead`
     };
   }
+  if (elapsedMs <= expectedEnd) {
+    return { kind: "onpace", label: "on pace" };
+  }
   return {
-    kind: "ahead",
-    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`
+    kind: "behind",
+    label: `${formatMinuteSeconds(elapsedMs - expectedEnd)} behind`
   };
 }
 

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -19,7 +19,7 @@ import {
   serverSyncChannelFactory,
   type SyncChannelFactory
 } from "./sync";
-import { clamp01, formatMinuteSeconds, isValidDurationMs } from "./timeTracker";
+import { clamp01, formatMinuteSeconds, isOverrun, isValidDurationMs } from "./timeTracker";
 
 export { mountPresentShell } from "./shell";
 export { serverSyncChannelFactory } from "./sync";
@@ -39,8 +39,8 @@ type RemoteTimerAnchor = {
 type TimerVisualState = "stopped" | "running" | "paused";
 
 export type RemotePaceState =
-  | { kind: "ahead" | "behind"; label: string; emoji: "hare" | "tortoise" }
-  | { kind: "paused"; label: "Paused"; emoji: null };
+  | { kind: "ahead" | "behind" | "overrun"; label: string }
+  | { kind: "paused"; label: "Paused" };
 
 export type RemoteView = {
   manifest: Manifest | null;
@@ -116,17 +116,28 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   counter.textContent = "– / –";
   titlebar.append(title, counter);
 
-  const progress = doc.createElement("div");
-  progress.className = "peitho-remote-progress peitho-remote-dim-on-end";
-  progress.dataset.peithoRemote = "progress";
-  const progressFill = doc.createElement("div");
-  progressFill.className = "peitho-remote-progress-fill";
-  progressFill.dataset.peithoRemote = "progress-fill";
-  const planTick = doc.createElement("div");
-  planTick.className = "peitho-remote-plan-tick";
-  planTick.dataset.peithoRemote = "plan-tick";
-  planTick.hidden = true;
-  progress.append(progressFill, planTick);
+  const chase = doc.createElement("div");
+  chase.className = "peitho-remote-chase peitho-remote-dim-on-end";
+  chase.dataset.peithoRemote = "chase";
+  chase.dataset.peithoChase = "slide";
+  const chaseTrack = doc.createElement("div");
+  chaseTrack.className = "peitho-remote-chase-track";
+  chaseTrack.dataset.peithoRemote = "chase-track";
+  const chaseFill = doc.createElement("div");
+  chaseFill.className = "peitho-remote-chase-fill";
+  chaseFill.dataset.peithoRemote = "chase-fill";
+  chaseTrack.append(chaseFill);
+  const rabbit = doc.createElement("span");
+  rabbit.className = "peitho-remote-chase-marker";
+  rabbit.dataset.peithoRemote = "marker-rabbit";
+  rabbit.setAttribute("aria-label", "slide progress");
+  rabbit.textContent = "🐰";
+  const turtle = doc.createElement("span");
+  turtle.className = "peitho-remote-chase-marker";
+  turtle.dataset.peithoRemote = "marker-turtle";
+  turtle.setAttribute("aria-label", "time progress");
+  turtle.textContent = "🐢";
+  chase.append(chaseTrack, rabbit, turtle);
 
   const pace = doc.createElement("div");
   pace.className = "peitho-remote-pace peitho-remote-dim-on-end";
@@ -159,11 +170,11 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   planned.dataset.peithoRemote = "planned";
   planned.hidden = true;
   elapsedRow.append(elapsed, separator, planned);
-  const chip = doc.createElement("span");
-  chip.className = "peitho-remote-pace-chip";
-  chip.dataset.peithoRemote = "pace-chip";
-  chip.hidden = true;
-  pace.append(timerButton, elapsedRow, chip);
+  const delta = doc.createElement("span");
+  delta.className = "peitho-remote-pace-delta";
+  delta.dataset.peithoRemote = "pace-delta";
+  delta.hidden = true;
+  pace.append(timerButton, elapsedRow, delta);
 
   const notesPanel = doc.createElement("section");
   notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
@@ -197,7 +208,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   next.addEventListener("click", onNext);
   timerButton.addEventListener("click", onTimer);
 
-  container.append(preview, titlebar, progress, pace, notesPanel, status, actions);
+  container.append(preview, titlebar, chase, pace, notesPanel, status, actions);
   root.append(container);
 
   return () => {
@@ -440,7 +451,7 @@ class RemoteController implements RemoteView {
     setText(this.root, "title", slideTitle(slide?.text.title));
     setText(this.root, "counter", currentIndex == null ? `– / ${total}` : `${currentIndex + 1} / ${total}`);
 
-    this.renderProgress(manifest, currentIndex);
+    this.renderChase(manifest, currentIndex);
     this.renderPaceStatic(manifest);
     this.renderTimeDependentChrome(manifest, currentIndex);
     this.renderSection(manifest, currentIndex);
@@ -451,14 +462,13 @@ class RemoteController implements RemoteView {
     this.updateTimerInterval();
   }
 
-  private renderProgress(manifest: Manifest, currentIndex: number | null): void {
-    const progress = this.root.querySelector<HTMLElement>('[data-peitho-remote="progress"]');
-    const fill = this.root.querySelector<HTMLElement>('[data-peitho-remote="progress-fill"]');
-    if (progress == null || fill == null) return;
-    const fraction =
-      currentIndex == null ? 0 : manifest.slideCount <= 1 ? 1 : currentIndex / (manifest.slideCount - 1);
-    fill.style.width = `${clamp01(fraction) * 100}%`;
-    this.updatePlanTick(manifest, this.currentElapsedMs());
+  private renderChase(manifest: Manifest, currentIndex: number | null): void {
+    const rabbit = this.root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]');
+    if (rabbit == null) return;
+    const plannedDurationMs = validPlannedDurationMs(manifest);
+    const planned = plannedDurationMs != null;
+    rabbit.hidden = !planned;
+    if (planned) setChaseMarker(rabbit, slideFraction(manifest, currentIndex));
   }
 
   private renderPaceStatic(manifest: Manifest): void {
@@ -490,36 +500,60 @@ class RemoteController implements RemoteView {
 
     elapsed.textContent = formatMinuteSeconds(elapsedMs);
 
-    this.updatePlanTick(manifest, elapsedMs);
-    const chip = this.root.querySelector<HTMLElement>('[data-peitho-remote="pace-chip"]');
-    if (chip == null || currentIndex == null) {
-      if (chip != null) chip.hidden = true;
+    this.updateChaseTime(manifest, currentIndex, elapsedMs, state);
+  }
+
+  private updateChaseTime(
+    manifest: Manifest,
+    currentIndex: number | null,
+    elapsedMs: number,
+    state: TimerVisualState
+  ): void {
+    const chase = this.root.querySelector<HTMLElement>('[data-peitho-remote="chase"]');
+    const fill = this.root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]');
+    const rabbit = this.root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]');
+    const turtle = this.root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]');
+    const delta = this.root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]');
+    if (chase == null || fill == null || rabbit == null || turtle == null || delta == null) return;
+
+    const plannedDurationMs = validPlannedDurationMs(manifest);
+    if (plannedDurationMs == null) {
+      chase.dataset.peithoChase = "slide";
+      chase.classList.remove("peitho-remote-chase-overrun");
+      rabbit.hidden = true;
+      turtle.hidden = true;
+      delta.hidden = true;
+      delta.textContent = "";
+      delete delta.dataset.peithoPace;
+      setChaseFill(fill, slideFraction(manifest, currentIndex));
+      return;
+    }
+
+    chase.dataset.peithoChase = "time";
+    rabbit.hidden = false;
+    turtle.hidden = false;
+    const overrun = isOverrun(elapsedMs, plannedDurationMs);
+    chase.classList.toggle("peitho-remote-chase-overrun", overrun);
+    const turtleFraction = overrun ? 1 : plannedProgressAtElapsed(manifest, elapsedMs);
+    setChaseMarker(turtle, turtleFraction ?? 0);
+    setChaseFill(fill, turtleFraction ?? 0);
+
+    if (currentIndex == null) {
+      delta.hidden = true;
+      delta.textContent = "";
+      delete delta.dataset.peithoPace;
       return;
     }
     const paceState = remotePaceState(manifest, currentIndex, elapsedMs, state === "running");
     if (paceState == null) {
-      chip.hidden = true;
-      chip.textContent = "";
+      delta.hidden = true;
+      delta.textContent = "";
+      delete delta.dataset.peithoPace;
       return;
     }
-    chip.hidden = false;
-    chip.dataset.peithoPace = paceState.kind;
-    if (paceState.emoji != null) {
-      const emoji = this.doc.createElement("span");
-      emoji.dataset.peithoPaceEmoji = "";
-      emoji.textContent = paceState.emoji === "hare" ? "🐇" : "🐢";
-      chip.replaceChildren(emoji, this.doc.createTextNode(` ${paceState.label}`));
-    } else {
-      chip.textContent = paceState.label;
-    }
-  }
-
-  private updatePlanTick(manifest: Manifest, elapsedMs: number): void {
-    const tick = this.root.querySelector<HTMLElement>('[data-peitho-remote="plan-tick"]');
-    if (tick == null) return;
-    const planProgress = plannedProgressAtElapsed(manifest, elapsedMs);
-    tick.hidden = planProgress == null;
-    if (planProgress != null) tick.style.left = `${planProgress * 100}%`;
+    delta.hidden = false;
+    delta.dataset.peithoPace = paceState.kind;
+    delta.textContent = paceState.label;
   }
 
   private renderSection(manifest: Manifest, currentIndex: number | null): void {
@@ -658,6 +692,26 @@ function clampIndex(index: number, total: number): number | null {
   return Math.max(0, Math.min(Math.trunc(index), total - 1));
 }
 
+function slideFraction(manifest: Manifest, currentIndex: number | null): number {
+  if (currentIndex == null) return 0;
+  if (manifest.slideCount <= 1) return 1;
+  return clamp01(currentIndex / (manifest.slideCount - 1));
+}
+
+function chasePercent(ratio: number): number {
+  return Math.round(clamp01(ratio) * 10_000) / 100;
+}
+
+function setChaseMarker(element: HTMLElement, ratio: number): void {
+  const percent = chasePercent(ratio);
+  element.style.left = `${percent}%`;
+  element.style.transform = `translateX(${-percent}%)`;
+}
+
+function setChaseFill(element: HTMLElement, ratio: number): void {
+  element.style.width = `${chasePercent(ratio)}%`;
+}
+
 function setText(root: HTMLElement, key: string, value: string): void {
   const element = root.querySelector<HTMLElement>(`[data-peitho-remote="${key}"]`);
   if (element != null) element.textContent = value;
@@ -728,20 +782,25 @@ export function remotePaceState(
   const expected = expectedElapsedAtSlide(manifest, index);
   if (expected == null) return null;
   if (!running) {
-    return elapsedMs > 0 ? { kind: "paused", label: "Paused", emoji: null } : null;
+    return elapsedMs > 0 ? { kind: "paused", label: "Paused" } : null;
+  }
+  const plannedDurationMs = validPlannedDurationMs(manifest);
+  if (plannedDurationMs != null && isOverrun(elapsedMs, plannedDurationMs)) {
+    return {
+      kind: "overrun",
+      label: `+${formatMinuteSeconds(elapsedMs - plannedDurationMs)} over`
+    };
   }
   const delta = elapsedMs - expected;
   if (delta >= 0) {
     return {
       kind: "behind",
-      label: `${formatMinuteSeconds(delta)} behind`,
-      emoji: "tortoise"
+      label: `${formatMinuteSeconds(delta)} behind`
     };
   }
   return {
     kind: "ahead",
-    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`,
-    emoji: "hare"
+    label: `${formatMinuteSeconds(Math.abs(delta))} ahead`
   };
 }
 

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -23,6 +23,8 @@ export type SlideChangeDetail = {
 
 export type PresentationStartDetail = { total: number; startedAt: number };
 export type PresentationEndDetail = { endedAt: number; elapsedMs: number };
+export type TimerStateDetail = { running: boolean; elapsedMs: number };
+export type TimerAdoptDetail = TimerStateDetail & { previousElapsedMs: number };
 export type TimerControlDetail = { action: "start" | "pause" | "resume" | "reset" };
 
 export type PresentShell = {
@@ -32,11 +34,13 @@ export type PresentShell = {
   elapsedMs(): number;
   isPaused(): boolean;
   startedAt(): number | null;
+  adoptTimerState(state: TimerStateDetail): void;
   destroy(): void;
 };
 
 export type ShellOptions = {
   root: HTMLElement;
+  manifest?: Manifest;
   fetcher?: typeof fetch;
   window?: Window;
   document?: Document;
@@ -68,6 +72,7 @@ class PresentShellController implements PresentShell {
   private readonly slides: SlideView[] = [];
   private readonly root: HTMLElement;
   private readonly fetcher: typeof fetch;
+  private readonly injectedManifest?: Manifest;
   private readonly win: Window;
   private readonly doc: Document;
   private readonly log: Pick<Console, "error">;
@@ -100,6 +105,7 @@ class PresentShellController implements PresentShell {
 
   constructor(options: ShellOptions) {
     this.root = options.root;
+    this.injectedManifest = options.manifest;
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
@@ -121,7 +127,7 @@ class PresentShellController implements PresentShell {
 
   async load(): Promise<void> {
     try {
-      const manifest = await this.fetchJson<Manifest>("manifest.json");
+      const manifest = this.injectedManifest ?? (await this.fetchJson<Manifest>("manifest.json"));
       const dimensions = {
         width: manifest.canvasWidth,
         height: manifest.canvasHeight
@@ -168,6 +174,25 @@ class PresentShellController implements PresentShell {
 
   startedAt(): number | null {
     return this.startedAtValue;
+  }
+
+  adoptTimerState(state: TimerStateDetail): void {
+    const elapsedMs = Math.max(0, state.elapsedMs);
+    const previousElapsedMs = this.elapsedMs();
+    if (!state.running && elapsedMs === 0) {
+      this.startedAtValue = null;
+      this.pausedAtValue = null;
+      this.pausedTotalMs = 0;
+      this.ended = false;
+      this.dispatchTimerAdopt(elapsedMs, state.running, previousElapsedMs);
+      return;
+    }
+    const now = this.now();
+    this.startedAtValue = now - elapsedMs;
+    this.pausedAtValue = state.running ? null : now;
+    this.pausedTotalMs = 0;
+    this.ended = false;
+    this.dispatchTimerAdopt(elapsedMs, state.running, previousElapsedMs);
   }
 
   destroy(): void {
@@ -306,6 +331,7 @@ class PresentShellController implements PresentShell {
         detail: { total: this.slides.length, startedAt: this.startedAtValue }
       })
     );
+    this.dispatchTimerChange();
   }
 
   private endPresentation(): void {
@@ -323,12 +349,14 @@ class PresentShellController implements PresentShell {
   private pauseTimer(): void {
     if (this.startedAtValue === null || this.pausedAtValue !== null) return;
     this.pausedAtValue = this.now();
+    this.dispatchTimerChange();
   }
 
   private resumeTimer(): void {
     if (this.pausedAtValue === null) return;
     this.pausedTotalMs += this.now() - this.pausedAtValue;
     this.pausedAtValue = null;
+    this.dispatchTimerChange();
   }
 
   private resetTimer(): void {
@@ -336,5 +364,29 @@ class PresentShellController implements PresentShell {
     this.pausedAtValue = null;
     this.pausedTotalMs = 0;
     this.ended = false;
+    this.dispatchTimerChange();
+  }
+
+  private dispatchTimerChange(): void {
+    this.bus.dispatchEvent(
+      new CustomEvent<TimerStateDetail>("peitho:timerchange", {
+        detail: {
+          running: this.startedAtValue !== null && this.pausedAtValue === null,
+          elapsedMs: this.elapsedMs()
+        }
+      })
+    );
+  }
+
+  private dispatchTimerAdopt(
+    elapsedMs: number,
+    running: boolean,
+    previousElapsedMs: number
+  ): void {
+    this.bus.dispatchEvent(
+      new CustomEvent<TimerAdoptDetail>("peitho:timeradopt", {
+        detail: { running, elapsedMs, previousElapsedMs }
+      })
+    );
   }
 }

--- a/packages/peitho-present/src/sync.ts
+++ b/packages/peitho-present/src/sync.ts
@@ -1,6 +1,16 @@
 import { swapRoute } from "./swap";
 
-export type SyncMessage = { index: number } | { swapped: boolean } | { close: true };
+export type TimerSyncState = { running: boolean; elapsedMs: number };
+export type TimerSyncSnapshot = TimerSyncState & { atMs: number };
+export type TimerSyncMessage = { timer: TimerSyncState };
+export type TimerReplaySyncMessage = { timer: TimerSyncSnapshot; nowMs: number };
+export type SyncedSyncMessage = { synced: true };
+
+export type SyncMessage =
+  | { index: number }
+  | { swapped: boolean }
+  | TimerSyncMessage
+  | { close: true };
 
 export type SyncChannel = {
   onmessage: ((event: { data: unknown }) => void) | null;
@@ -19,12 +29,26 @@ export type ServerSyncOptions = {
   AbortControllerCtor?: typeof AbortController;
 };
 
+export type SyncBridgeHooks = {
+  closeWindow?: () => void;
+  pathname?: () => string;
+  navigate?: (url: string) => void;
+  adoptTimerState?: (state: TimerSyncState) => void;
+};
+
 type ServerSyncPollResponse = {
   seq: number;
   message: unknown;
   index?: unknown;
   swapped?: unknown;
   generation?: unknown;
+  timer?: unknown;
+  nowMs?: unknown;
+};
+
+type BufferedTimerReplay = {
+  seq: number;
+  data: TimerReplaySyncMessage;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -43,6 +67,34 @@ export function isSwappedSyncMessage(value: unknown): value is { swapped: boolea
   return isRecord(value) && typeof value.swapped === "boolean";
 }
 
+export function isSyncedSyncMessage(value: unknown): value is SyncedSyncMessage {
+  return isRecord(value) && value.synced === true;
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+export function isTimerSyncMessage(value: unknown): value is TimerSyncMessage {
+  return (
+    isRecord(value) &&
+    isRecord(value.timer) &&
+    typeof value.timer.running === "boolean" &&
+    isNonNegativeFiniteNumber(value.timer.elapsedMs)
+  );
+}
+
+export function isTimerReplaySyncMessage(value: unknown): value is TimerReplaySyncMessage {
+  return (
+    isRecord(value) &&
+    isRecord(value.timer) &&
+    typeof value.timer.running === "boolean" &&
+    isNonNegativeFiniteNumber(value.timer.elapsedMs) &&
+    isNonNegativeFiniteNumber(value.timer.atMs) &&
+    isNonNegativeFiniteNumber(value.nowMs)
+  );
+}
+
 export function isGenerationSyncMessage(value: unknown): value is { generation: number } {
   return (
     isRecord(value) &&
@@ -54,6 +106,13 @@ export function isGenerationSyncMessage(value: unknown): value is { generation: 
 function defaultChannelFactory(name: string): SyncChannel {
   const channel = new BroadcastChannel(name);
   let onmessage: ((event: { data: unknown }) => void) | null = null;
+  let syncedDelivered = false;
+  const deliverSynced = (): void => {
+    if (syncedDelivered || onmessage == null) return;
+    syncedDelivered = true;
+    onmessage({ data: { synced: true } });
+  };
+  queueMicrotask(deliverSynced);
   channel.onmessage = (event: MessageEvent): void => {
     onmessage?.({ data: event.data });
   };
@@ -63,6 +122,7 @@ function defaultChannelFactory(name: string): SyncChannel {
     },
     set onmessage(next) {
       onmessage = next;
+      deliverSynced();
     },
     postMessage(message: SyncMessage): void {
       channel.postMessage(message);
@@ -85,14 +145,44 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
     let onmessage: ((event: { data: unknown }) => void) | null = null;
     let closed = false;
     let seq = 0;
+    let synced = false;
+    let highestAckedPostSeq = 0;
+    let pendingTimerPosts = 0;
+    let bufferedTimerReplay: BufferedTimerReplay | null = null;
     let abortController: AbortController | null = null;
     let retryTimer: number | null = null;
 
-    const deliverReplayState = (body: Partial<ServerSyncPollResponse>): void => {
-      if (isIndexSyncMessage(body)) {
+    const flushBufferedTimerReplay = (): void => {
+      if (closed || pendingTimerPosts > 0 || bufferedTimerReplay == null) return;
+      const replay = bufferedTimerReplay;
+      bufferedTimerReplay = null;
+      if (replay.seq >= highestAckedPostSeq) {
+        onmessage?.({ data: replay.data });
+      }
+    };
+
+    const deliverReplayState = (
+      body: Partial<ServerSyncPollResponse>,
+      options: { skipAbsoluteState?: boolean; deferTimerReplay?: boolean } = {}
+    ): void => {
+      const skipAbsoluteState = options.skipAbsoluteState === true;
+      const responseSeq = typeof body.seq === "number" && Number.isFinite(body.seq) ? body.seq : 0;
+      if (isTimerReplaySyncMessage(body)) {
+        if (skipAbsoluteState) {
+          bufferedTimerReplay = null;
+        } else if (options.deferTimerReplay === true) {
+          bufferedTimerReplay = {
+            seq: responseSeq,
+            data: { timer: body.timer, nowMs: body.nowMs }
+          };
+        } else {
+          onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
+        }
+      }
+      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
         onmessage?.({ data: { index: body.index } });
       }
-      if (isSwappedSyncMessage(body)) {
+      if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
       }
       if (isGenerationSyncMessage(body)) {
@@ -124,7 +214,14 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
           return false;
         }
         seq = body.seq;
-        deliverReplayState(body);
+        deliverReplayState(body, {
+          skipAbsoluteState: body.seq < highestAckedPostSeq,
+          deferTimerReplay: pendingTimerPosts > 0
+        });
+        if (!synced) {
+          synced = true;
+          onmessage?.({ data: { synced: true } });
+        }
         return true;
       } catch (error: unknown) {
         if (!closed) {
@@ -165,7 +262,10 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
           if (body.message != null) {
             onmessage?.({ data: body.message });
           }
-          deliverReplayState(body);
+          deliverReplayState(body, {
+            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            deferTimerReplay: pendingTimerPosts > 0
+          });
         } catch (error: unknown) {
           if (!closed) {
             console.error(`Failed to poll sync message: ${String(error)}`);
@@ -185,17 +285,46 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
         onmessage = next;
       },
       postMessage(message: SyncMessage): void {
-        void fetcher(url, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(message),
-          keepalive: true
-        })
-          .then((response) => {
-            if (!response.ok) console.error(`Failed to post sync message: ${response.status}`);
+        const isTimerPost = isTimerSyncMessage(message);
+        if (isTimerPost) pendingTimerPosts += 1;
+        const completeTimerPost = (): void => {
+          if (!isTimerPost) return;
+          pendingTimerPosts = Math.max(0, pendingTimerPosts - 1);
+          flushBufferedTimerReplay();
+        };
+        let request: Promise<Response>;
+        try {
+          request = fetcher(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(message),
+            keepalive: true
+          });
+        } catch (error: unknown) {
+          completeTimerPost();
+          console.error(`Failed to post sync message: ${String(error)}`);
+          return;
+        }
+        void request
+          .then(async (response) => {
+            if (!response.ok) {
+              console.error(`Failed to post sync message: ${response.status}`);
+              return;
+            }
+            try {
+              const body = (await response.json()) as Partial<{ seq: unknown }>;
+              if (typeof body.seq === "number" && Number.isFinite(body.seq)) {
+                highestAckedPostSeq = Math.max(highestAckedPostSeq, body.seq);
+              }
+            } catch (_error: unknown) {
+              // Older dev servers returned 204; lack of an ack simply disables stale-replay filtering.
+            }
           })
           .catch((error: unknown) => {
             console.error(`Failed to post sync message: ${String(error)}`);
+          })
+          .finally(() => {
+            completeTimerPost();
           });
       },
       close(): void {
@@ -214,11 +343,13 @@ export function installSyncBridge(
   win: Window = window,
   channelFactory: SyncChannelFactory = defaultChannelFactory,
   bus: EventTarget = win,
-  closeWindow: () => void = () => win.close(),
-  pathname: () => string = () => win.location.pathname,
-  navigate: (url: string) => void = (url) => win.location.replace(url)
+  hooks: SyncBridgeHooks = {}
 ): () => void {
   const channel = channelFactory("peitho-sync");
+  const closeWindow = hooks.closeWindow ?? (() => win.close());
+  const pathname = hooks.pathname ?? (() => win.location.pathname);
+  const navigate = hooks.navigate ?? ((url) => win.location.replace(url));
+  let synced = false;
   const onSlideChange = (event: Event): void => {
     const detail = (event as CustomEvent<{ index: number }>).detail;
     if (typeof detail?.index !== "number") return;
@@ -235,8 +366,26 @@ export function installSyncBridge(
     }
     channel.postMessage({ swapped: !route.swapped });
   };
+  const onTimerChange = (event: Event): void => {
+    if (!synced) return;
+    const detail = (event as CustomEvent<TimerSyncState>).detail;
+    if (
+      typeof detail?.running !== "boolean" ||
+      !isNonNegativeFiniteNumber(detail.elapsedMs)
+    ) {
+      console.error("Invalid peitho:timerchange event");
+      return;
+    }
+    channel.postMessage({
+      timer: { running: detail.running, elapsedMs: Math.round(detail.elapsedMs) }
+    });
+  };
   channel.onmessage = (event: { data: unknown }): void => {
     const data = event.data;
+    if (isSyncedSyncMessage(data)) {
+      synced = true;
+      return;
+    }
     if (isCloseSyncMessage(data)) {
       closeWindow();
       return;
@@ -260,15 +409,29 @@ export function installSyncBridge(
     if (isGenerationSyncMessage(data)) {
       return;
     }
+    if (isTimerReplaySyncMessage(data)) {
+      if (hooks.adoptTimerState) {
+        const serverElapsed =
+          data.timer.elapsedMs +
+          (data.timer.running ? Math.max(0, data.nowMs - data.timer.atMs) : 0);
+        hooks.adoptTimerState({ running: data.timer.running, elapsedMs: serverElapsed });
+      }
+      return;
+    }
+    if (isTimerSyncMessage(data)) {
+      return;
+    }
     console.error("Invalid peitho sync message");
   };
   bus.addEventListener("peitho:slidechange", onSlideChange);
   bus.addEventListener("peitho:closerequest", onCloseRequest);
   bus.addEventListener("peitho:swaprequest", onSwapRequest);
+  bus.addEventListener("peitho:timerchange", onTimerChange);
   return () => {
     bus.removeEventListener("peitho:slidechange", onSlideChange);
     bus.removeEventListener("peitho:closerequest", onCloseRequest);
     bus.removeEventListener("peitho:swaprequest", onSwapRequest);
+    bus.removeEventListener("peitho:timerchange", onTimerChange);
     channel.onmessage = null;
     channel.close();
   };

--- a/packages/peitho-present/src/timeTracker.ts
+++ b/packages/peitho-present/src/timeTracker.ts
@@ -17,7 +17,7 @@ export type TimeTrackerOptions = {
   variant?: "present" | "presenter";
 };
 
-const clamp01 = (ratio: number): number => Math.min(Math.max(ratio, 0), 1);
+export const clamp01 = (ratio: number): number => Math.min(Math.max(ratio, 0), 1);
 
 export function isOverrun(elapsedMs: number, plannedDurationMs: number): boolean {
   return elapsedMs > plannedDurationMs;

--- a/packages/peitho-present/test/agenda.test.ts
+++ b/packages/peitho-present/test/agenda.test.ts
@@ -418,6 +418,67 @@ it("keeps actuals stable while paused with a non-null startedAt", () => {
   expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:01 / 0:02");
 });
 
+it("rebases elapsed after timer adoption without attributing the adopted delta", () => {
+  let elapsed = 0;
+  const root = document.createElement("div");
+  const bus = new EventTarget();
+  const cleanup = installAgenda({
+    root,
+    shell: {
+      currentIndex: 0,
+      elapsedMs: () => elapsed,
+      startedAt: () => 100
+    },
+    sections: [{ name: "Only", startIndex: 0, endIndex: 0, plannedDurationMs: 60_000 }],
+    bus,
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  elapsed = 1_000;
+  vi.advanceTimersByTime(250);
+  expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:01 / 1:00");
+
+  elapsed = 1_201_000;
+  bus.dispatchEvent(
+    new CustomEvent("peitho:timeradopt", {
+      detail: { running: true, previousElapsedMs: 1_000, elapsedMs: 1_201_000 }
+    })
+  );
+  vi.advanceTimersByTime(250);
+
+  expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:01 / 1:00");
+});
+
+it("attributes pending elapsed time before continuous timer adopt rebases", () => {
+  const root = document.createElement("div");
+  const bus = new EventTarget();
+  const cleanup = installAgenda({
+    root,
+    shell: shell({ currentIndex: 0, startedAt: () => 100 }),
+    sections: [{ name: "Only", startIndex: 0, endIndex: 0, plannedDurationMs: 10_000 }],
+    bus,
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  for (let i = 1; i <= 10; i += 1) {
+    bus.dispatchEvent(
+      new CustomEvent("peitho:timeradopt", {
+        detail: {
+          running: true,
+          previousElapsedMs: i * 210 - 10,
+          elapsedMs: i * 210
+        }
+      })
+    );
+  }
+
+  expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:02 / 0:10");
+});
+
 it("flushes pending elapsed time to the previous section on slidechange", () => {
   let elapsed = 0;
   let currentIndex = 0;

--- a/packages/peitho-present/test/agenda.test.ts
+++ b/packages/peitho-present/test/agenda.test.ts
@@ -451,6 +451,38 @@ it("rebases elapsed after timer adoption without attributing the adopted delta",
   expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:01 / 1:00");
 });
 
+it("clears actuals immediately when a timer reset is adopted", () => {
+  let elapsed = 0;
+  const root = document.createElement("div");
+  const bus = new EventTarget();
+  const cleanup = installAgenda({
+    root,
+    shell: {
+      currentIndex: 0,
+      elapsedMs: () => elapsed,
+      startedAt: () => 100
+    },
+    sections: [{ name: "Only", startIndex: 0, endIndex: 0, plannedDurationMs: 60_000 }],
+    bus,
+    window,
+    document
+  });
+  cleanups.push(cleanup);
+
+  elapsed = 1_000;
+  vi.advanceTimersByTime(250);
+  expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:01 / 1:00");
+
+  elapsed = 0;
+  bus.dispatchEvent(
+    new CustomEvent("peitho:timeradopt", {
+      detail: { running: false, previousElapsedMs: 1_000, elapsedMs: 0 }
+    })
+  );
+
+  expect(root.querySelector("[data-peitho-agenda-time]")?.textContent).toBe("0:00 / 1:00");
+});
+
 it("attributes pending elapsed time before continuous timer adopt rebases", () => {
   const root = document.createElement("div");
   const bus = new EventTarget();

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -623,6 +623,7 @@ it("buttons emit navigate timercontrol and close requests", async () => {
   cleanups.push(() => window.removeEventListener("peitho:timercontrol", onTimerControl));
   cleanups.push(() => window.removeEventListener("peitho:closerequest", onCloseRequest));
   cleanups.push(() => window.removeEventListener("peitho:swaprequest", onSwapRequest));
+  channel.onmessage?.({ data: { synced: true } });
 
   root.querySelector<HTMLButtonElement>('[data-peitho-action="next"]')?.click();
   root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')?.click();
@@ -641,7 +642,55 @@ it("buttons emit navigate timercontrol and close requests", async () => {
   ]);
   expect(closeRequests).toEqual([null]);
   expect(swapRequests).toEqual([null]);
-  expect(channel.sent).toEqual([{ index: 1 }, { swapped: true }, { close: true }]);
+  expect(channel.sent).toEqual([
+    { index: 1 },
+    { timer: { running: true, elapsedMs: 0 } },
+    { timer: { running: false, elapsedMs: 0 } },
+    { timer: { running: true, elapsedMs: 0 } },
+    { timer: { running: false, elapsedMs: 0 } },
+    { swapped: true },
+    { close: true }
+  ]);
+});
+
+it("posts presenter timer transitions and adopts replayed timer state", async () => {
+  let now = 1_000;
+  const root = document.createElement("main");
+  const { channel, factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: standardFetch(),
+    window,
+    now: () => now,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+  const play = root.querySelector<HTMLButtonElement>('[data-peitho-action="playpause"]')!;
+  channel.onmessage?.({ data: { synced: true } });
+
+  play.click();
+  now = 2_500;
+  play.click();
+  now = 3_500;
+  play.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="reset"]')?.click();
+
+  expect(channel.sent).toEqual([
+    { timer: { running: true, elapsedMs: 0 } },
+    { timer: { running: false, elapsedMs: 1500 } },
+    { timer: { running: true, elapsedMs: 1500 } },
+    { timer: { running: false, elapsedMs: 0 } }
+  ]);
+
+  now = 10_000;
+  channel.onmessage?.({
+    data: { timer: { running: true, elapsedMs: 2_000, atMs: 50_000 }, nowMs: 51_000 }
+  });
+  view.tick();
+
+  expect(view.mainShell.elapsedMs()).toBe(3_000);
+  expect(root.querySelector('[data-peitho-presenter="timer"]')?.textContent).toBe("00:03");
 });
 
 it("maps presenter Space to timer playpause without navigating", async () => {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -250,7 +250,7 @@ it("remote controller treats a null replay index as the first non-skipped slide"
   expect(channel.sent).toEqual([{ index: 2 }]);
 });
 
-it("remote renders preview title progress section notes and planned pace chrome", async () => {
+it("remote renders preview title section notes and section-aware chase chrome", async () => {
   const previewNavigations: unknown[] = [];
   const manifest = manifestWithSlides(
     [
@@ -281,10 +281,21 @@ it("remote renders preview title progress section notes and planned pace chrome"
   expect(previewNavigations.at(-1)).toEqual({ to: { index: 1 } });
   expect(root.querySelector('[data-peitho-remote="title"]')?.textContent).toBe("Architecture");
   expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("2 / 3");
-  expect(root.querySelector<HTMLElement>('[data-peitho-remote="progress-fill"]')?.style.width).toBe(
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "41.67%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
     "50%"
   );
-  expect(root.querySelector('[data-peitho-remote="plan-tick"]')).not.toBeNull();
+  expect(
+    root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.transform
+  ).toBe("translateX(-50%)");
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "41.67%"
+  );
+  expect(
+    root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.transform
+  ).toBe("translateX(-41.67%)");
   expect(root.querySelector('[data-peitho-remote="section"]')?.textContent).toBe(
     "Architecture · slide 1 / 2 in section"
   );
@@ -293,7 +304,12 @@ it("remote renders preview title progress section notes and planned pace chrome"
   );
   expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:25");
   expect(root.querySelector('[data-peitho-remote="planned"]')?.textContent).toBe("1:30");
-  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toContain("ahead");
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe(
+    "0:05 ahead"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.dataset.peithoPace).toBe(
+    "ahead"
+  );
 });
 
 it("remote mounts with empty notes placeholders when notes fetch fails", async () => {
@@ -346,13 +362,21 @@ it("remote mounts with empty notes placeholders when notes fetch fails", async (
 });
 
 it("remote omits planned and section rows when the deck has no time or sections", async () => {
-  const { root } = await mountRemoteForTest(
+  const { root, channel } = await mountRemoteForTest(
     manifestWithSlides([{ key: "intro", title: "Intro" }, { key: "end", title: "End" }])
   );
+  channel.deliver({ index: 1 });
 
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="planned"]')?.hidden).toBe(true);
-  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-chip"]')?.hidden).toBe(true);
-  expect(root.querySelector<HTMLElement>('[data-peitho-remote="plan-tick"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase"]')?.dataset.peithoChase).toBe(
+    "slide"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "100%"
+  );
   expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
   expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:00");
   expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')).not.toBeNull();
@@ -396,7 +420,7 @@ it("remote timer button emits requests while the bridge posts absolute timer sta
   timer.click();
   vi.setSystemTime(3_500);
   timer.click();
-  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toBe("Paused");
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe("Paused");
   timer.click();
 
   expect(requests).toEqual([{ action: "start" }, { action: "pause" }, { action: "resume" }]);
@@ -419,21 +443,81 @@ it("remote timer states render stopped running and paused rows", async () => {
   const timer = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')!;
 
   expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
-  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-chip"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.hidden).toBe(true);
 
   channel.deliver({
     timer: { running: true, elapsedMs: 35_000, atMs: 10_000 },
     nowMs: 10_000
   });
   expect(timer.querySelector('[data-peitho-icon="pause"]')).not.toBeNull();
-  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toContain("behind");
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toContain("behind");
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
+    "0%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "100%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "100%"
+  );
 
   channel.deliver({
     timer: { running: false, elapsedMs: 20_000, atMs: 10_000 },
     nowMs: 10_000
   });
   expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
-  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toBe("Paused");
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe("Paused");
+});
+
+it("remote chase renders behind and overrun states", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides(
+      [{ key: "intro", title: "Intro" }, { key: "middle", title: "Middle" }, { key: "end" }],
+      { plannedDurationMs: 60_000 }
+    )
+  );
+
+  channel.deliver({ index: 1 });
+  channel.deliver({
+    timer: { running: true, elapsedMs: 25_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
+    "50%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "62.5%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "62.5%"
+  );
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe(
+    "0:05 behind"
+  );
+
+  channel.deliver({
+    timer: { running: true, elapsedMs: 70_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase"]')?.classList).toContain(
+    "peitho-remote-chase-overrun"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "100%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "100%"
+  );
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe(
+    "+0:10 over"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.dataset.peithoPace).toBe(
+    "overrun"
+  );
 });
 
 it("remote preview shell reuses the already loaded manifest", async () => {
@@ -472,7 +556,7 @@ it("remote preview shell reuses the already loaded manifest", async () => {
   expect(root.querySelector('[data-peitho-remote="preview"] .peitho-slide')).not.toBeNull();
 });
 
-it("remote timer interval updates time chrome without replacing the notes text node", async () => {
+it("remote timer interval updates turtle fill and delta in place without touching rabbit or notes", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(1_000);
   const { root, channel } = await mountRemoteForTest(
@@ -485,15 +569,30 @@ it("remote timer interval updates time chrome without replacing the notes text n
   );
   const notes = root.querySelector<HTMLElement>('[data-peitho-remote="notes"]')!;
   const firstTextNode = notes.firstChild;
+  const rabbit = root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')!;
+  const turtle = root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')!;
+  const fill = root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')!;
+  const delta = root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')!;
   channel.deliver({
     timer: { running: true, elapsedMs: 1_000, atMs: 10_000 },
     nowMs: 10_000
   });
+  const rabbitLeft = rabbit.style.left;
+  const turtleElement = turtle;
+  const fillElement = fill;
+  const deltaElement = delta;
 
   vi.advanceTimersByTime(1000);
 
   expect(notes.firstChild).toBe(firstTextNode);
   expect(notes.textContent).toBe("Long note");
+  expect(rabbit.style.left).toBe(rabbitLeft);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')).toBe(turtleElement);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')).toBe(fillElement);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')).toBe(deltaElement);
+  expect(turtle.style.left).toBe("6.67%");
+  expect(fill.style.width).toBe("6.67%");
+  expect(delta.textContent).toBe("0:02 behind");
   expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:02");
 });
 
@@ -536,6 +635,34 @@ it("remote controller disables buttons and shows ended state on close", async ()
   );
   expect(root.querySelector('[data-peitho-remote="status"]')?.textContent).toBe("Ended");
   expect(root.querySelector<HTMLElement>(".peitho-remote")?.dataset.peithoEnded).toBe("true");
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase"]')?.classList).toContain(
+    "peitho-remote-dim-on-end"
+  );
+});
+
+it("remote ended state freezes the chase track", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }], { plannedDurationMs: 60_000 })
+  );
+  channel.deliver({
+    timer: { running: true, elapsedMs: 10_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+  const turtle = root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')!;
+  const fill = root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')!;
+  const delta = root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')!;
+
+  channel.deliver({ close: true });
+  const turtleLeft = turtle.style.left;
+  const fillWidth = fill.style.width;
+  const deltaText = delta.textContent;
+  vi.advanceTimersByTime(1000);
+
+  expect(turtle.style.left).toBe(turtleLeft);
+  expect(fill.style.width).toBe(fillWidth);
+  expect(delta.textContent).toBe(deltaText);
 });
 
 it("remote controller closes the sync channel and ignores clicks after ended", async () => {
@@ -579,7 +706,7 @@ it("pace math falls back to whole-deck timing without sections", () => {
   expect(expectedElapsedAtSlide(manifest, 2)).toBe(40_000);
 });
 
-it("pace math clamps plan tick progress", () => {
+it("plannedProgressAtElapsed clamps the chase turtle fraction", () => {
   const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
     plannedDurationMs: 60_000
   });
@@ -590,7 +717,7 @@ it("pace math clamps plan tick progress", () => {
   expect(plannedProgressAtElapsed(manifest, 90_000)).toBe(1);
 });
 
-it("pace chip selection covers ahead behind paused and null planned time", () => {
+it("pace state selection covers ahead behind overrun paused and null planned time", () => {
   const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
     plannedDurationMs: 60_000
   });
@@ -598,18 +725,19 @@ it("pace chip selection covers ahead behind paused and null planned time", () =>
 
   expect(remotePaceState(manifest, 1, 25_000, true)).toEqual({
     kind: "behind",
-    label: "0:05 behind",
-    emoji: "tortoise"
+    label: "0:05 behind"
   });
   expect(remotePaceState(manifest, 1, 15_000, true)).toEqual({
     kind: "ahead",
-    label: "0:05 ahead",
-    emoji: "hare"
+    label: "0:05 ahead"
+  });
+  expect(remotePaceState(manifest, 1, 70_000, true)).toEqual({
+    kind: "overrun",
+    label: "+0:10 over"
   });
   expect(remotePaceState(manifest, 1, 15_000, false)).toEqual({
     kind: "paused",
-    label: "Paused",
-    emoji: null
+    label: "Paused"
   });
   expect(remotePaceState(unplanned, 1, 15_000, true)).toBeNull();
 });

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, expect, it, vi } from "vitest";
 import type { Manifest } from "../../../bindings/Manifest";
-import { installRemoteControls, mountRemoteView, type RemoteView } from "../src/remote";
+import type { Notes } from "../../../bindings/Notes";
+import {
+  expectedElapsedAtSlide,
+  installRemoteControls,
+  mountRemoteView,
+  plannedProgressAtElapsed,
+  remotePaceState,
+  type RemoteView
+} from "../src/remote";
+import type { PresentShell, ShellOptions } from "../src/shell";
 import type { SyncChannel } from "../src/sync";
 
 type MockChannel = SyncChannel & {
@@ -17,7 +26,10 @@ function fail(status: number): Response {
   return { ok: false, status, json: async () => ({}) } as Response;
 }
 
-function manifestWithSlides(slides: Array<{ key: string; skip?: boolean }>): Manifest {
+function manifestWithSlides(
+  slides: Array<{ key: string; skip?: boolean; title?: string }>,
+  overrides: Partial<Manifest> = {}
+): Manifest {
   return {
     version: 1,
     peithoVersion: "0.1.0",
@@ -34,15 +46,17 @@ function manifestWithSlides(slides: Array<{ key: string; skip?: boolean }>): Man
       src: `slides/${String(index).padStart(3, "0")}-${slide.key}.html`,
       hasNotes: false,
       skip: slide.skip ?? false,
-      text: { title: "", body: "", code: "" }
+      text: { title: slide.title ?? "", body: "", code: "" }
     })),
-    images: []
+    images: [],
+    ...overrides
   };
 }
 
-function fetchManifest(manifest: Manifest): typeof fetch {
+function fetchManifest(manifest: Manifest, notes: Notes = { version: 1, notes: {} }): typeof fetch {
   return vi.fn(async (url: string) => {
     if (url === "manifest.json") return okJson(manifest);
+    if (url === "notes.json") return okJson(notes);
     return fail(404);
   }) as typeof fetch;
 }
@@ -72,6 +86,7 @@ afterEach(() => {
   while (cleanups.length > 0) cleanups.pop()?.();
   while (views.length > 0) views.pop()?.destroy();
   document.body.replaceChildren();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -83,21 +98,53 @@ function button(root: HTMLElement, action: "prev" | "next"): HTMLButtonElement {
 
 async function mountRemoteForTest(
   manifest: Manifest,
-  channel = mockChannel()
+  channel = mockChannel(),
+  options: {
+    notes?: Notes;
+    mountPresentShell?: (options: ShellOptions) => Promise<PresentShell>;
+    autoSync?: boolean;
+  } = {}
 ): Promise<{ root: HTMLElement; channel: MockChannel; view: RemoteView }> {
   const root = document.createElement("main");
   document.body.appendChild(root);
   const view = await mountRemoteView({
     root,
     manifestUrl: "manifest.json",
-    fetcher: fetchManifest(manifest),
+    notesUrl: "notes.json",
+    fetcher: fetchManifest(manifest, options.notes),
     channelFactory: () => channel,
+    syncChannelFactory: () => channel,
+    mountPresentShell: options.mountPresentShell ?? mockMountPresentShell(),
     window,
     document,
     bus: window
   });
   views.push(view);
+  if (options.autoSync !== false) {
+    channel.deliver({ synced: true });
+  }
   return { root, channel, view };
+}
+
+function mockMountPresentShell(navigations: unknown[] = []): (options: ShellOptions) => Promise<PresentShell> {
+  return vi.fn(async (options: ShellOptions) => {
+    const marker = document.createElement("div");
+    marker.dataset.previewShell = "mounted";
+    options.root.append(marker);
+    options.bus?.addEventListener("peitho:navigate", (event) => {
+      navigations.push((event as CustomEvent).detail);
+    });
+    return {
+      manifest: null,
+      currentIndex: 0,
+      navigate: vi.fn(),
+      elapsedMs: () => 0,
+      isPaused: () => false,
+      startedAt: () => null,
+      adoptTimerState: vi.fn(),
+      destroy: vi.fn()
+    };
+  });
 }
 
 it("remote buttons dispatch navigate request events only", () => {
@@ -109,10 +156,23 @@ it("remote buttons dispatch navigate request events only", () => {
   });
   cleanups.push(installRemoteControls({ root, document, bus }));
 
+  button(root, "prev").disabled = false;
+  button(root, "next").disabled = false;
   button(root, "prev").click();
   button(root, "next").click();
 
   expect(requests).toEqual([{ to: "prev" }, { to: "next" }]);
+});
+
+it("remote controls mount disabled before the synced event arrives", () => {
+  const root = document.createElement("main");
+  cleanups.push(installRemoteControls({ root, document, bus: new EventTarget() }));
+
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(true);
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
+    true
+  );
 });
 
 it("remote controller resolves next and prev across skipped slides and posts absolute indexes", async () => {
@@ -125,6 +185,47 @@ it("remote controller resolves next and prev across skipped slides and posts abs
   button(root, "prev").click();
 
   expect(channel.sent).toEqual([{ index: 2 }, { index: 0 }]);
+});
+
+it("remote controls are disabled and silent before the initial sync snapshot is applied", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }]),
+    mockChannel(),
+    { autoSync: false }
+  );
+
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(true);
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
+    true
+  );
+
+  button(root, "next").click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.click();
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+  window.dispatchEvent(
+    new CustomEvent("peitho:timercontrol", { detail: { action: "start" } })
+  );
+
+  expect(channel.sent).toEqual([]);
+});
+
+it("remote controls enable after synced replay is reported", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }]),
+    mockChannel(),
+    { autoSync: false }
+  );
+
+  channel.deliver({ synced: true });
+
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(false);
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
+    false
+  );
+  button(root, "next").click();
+  expect(channel.sent).toEqual([{ index: 1 }]);
 });
 
 it("remote controller advances optimistically across rapid taps", async () => {
@@ -147,6 +248,253 @@ it("remote controller treats a null replay index as the first non-skipped slide"
   button(root, "next").click();
 
   expect(channel.sent).toEqual([{ index: 2 }]);
+});
+
+it("remote renders preview title progress section notes and planned pace chrome", async () => {
+  const previewNavigations: unknown[] = [];
+  const manifest = manifestWithSlides(
+    [
+      { key: "intro", title: "Opening" },
+      { key: "arch", title: "Architecture" },
+      { key: "end", title: "Summary" }
+    ],
+    {
+      plannedDurationMs: 90_000,
+      sections: [
+        { name: "Intro", startIndex: 0, endIndex: 0, plannedDurationMs: 30_000 },
+        { name: "Architecture", startIndex: 1, endIndex: 2, plannedDurationMs: 60_000 }
+      ]
+    }
+  );
+  const { root, channel } = await mountRemoteForTest(manifest, mockChannel(), {
+    notes: { version: 1, notes: { arch: "Use the typed shell.\nNo shortcuts." } },
+    mountPresentShell: mockMountPresentShell(previewNavigations)
+  });
+
+  channel.deliver({ index: 1 });
+  channel.deliver({
+    timer: { running: true, elapsedMs: 20_000, atMs: 1_000_000 },
+    nowMs: 1_005_000
+  });
+
+  expect(root.querySelector('[data-preview-shell="mounted"]')).not.toBeNull();
+  expect(previewNavigations.at(-1)).toEqual({ to: { index: 1 } });
+  expect(root.querySelector('[data-peitho-remote="title"]')?.textContent).toBe("Architecture");
+  expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("2 / 3");
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="progress-fill"]')?.style.width).toBe(
+    "50%"
+  );
+  expect(root.querySelector('[data-peitho-remote="plan-tick"]')).not.toBeNull();
+  expect(root.querySelector('[data-peitho-remote="section"]')?.textContent).toBe(
+    "Architecture · slide 1 / 2 in section"
+  );
+  expect(root.querySelector('[data-peitho-remote="notes"]')?.textContent).toBe(
+    "Use the typed shell.\nNo shortcuts."
+  );
+  expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:25");
+  expect(root.querySelector('[data-peitho-remote="planned"]')?.textContent).toBe("1:30");
+  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toContain("ahead");
+});
+
+it("remote mounts with empty notes placeholders when notes fetch fails", async () => {
+  const manifest = manifestWithSlides([
+    { key: "intro", title: "Intro" },
+    { key: "details", title: "Details" }
+  ]);
+  const channel = mockChannel();
+  const error = vi.fn();
+  const fetcher = vi.fn(async (url: string) => {
+    if (url === "manifest.json") return okJson(manifest);
+    if (url === "notes.json") throw new Error("offline");
+    return fail(404);
+  }) as typeof fetch;
+  const root = document.createElement("main");
+  document.body.appendChild(root);
+  const view = await mountRemoteView({
+    root,
+    manifestUrl: "manifest.json",
+    notesUrl: "notes.json",
+    fetcher,
+    channelFactory: () => channel,
+    syncChannelFactory: () => channel,
+    mountPresentShell: mockMountPresentShell(),
+    window,
+    document,
+    bus: window,
+    console: { error }
+  });
+  views.push(view);
+  channel.deliver({ synced: true });
+
+  expect(root.querySelector(".peitho-remote")).not.toBeNull();
+  expect(root.querySelector('[data-preview-shell="mounted"]')).not.toBeNull();
+  expect(root.querySelector('[data-peitho-remote="notes"]')?.textContent).toBe(
+    "No notes for this slide"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="notes"]')?.dataset.peithoEmpty).toBe(
+    "true"
+  );
+
+  channel.deliver({ index: 1 });
+
+  expect(root.querySelector('[data-peitho-remote="title"]')?.textContent).toBe("Details");
+  expect(root.querySelector('[data-peitho-remote="notes"]')?.textContent).toBe(
+    "No notes for this slide"
+  );
+  expect(error).toHaveBeenCalledTimes(1);
+  expect(error).toHaveBeenCalledWith("Failed to load notes.json: offline");
+});
+
+it("remote omits planned and section rows when the deck has no time or sections", async () => {
+  const { root } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro", title: "Intro" }, { key: "end", title: "End" }])
+  );
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="planned"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-chip"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="plan-tick"]')?.hidden).toBe(true);
+  expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
+  expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:00");
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')).not.toBeNull();
+});
+
+it("remote disables previous and next based on first and last non-skipped slides", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([
+      { key: "intro" },
+      { key: "skip", skip: true },
+      { key: "middle" },
+      { key: "backup", skip: true }
+    ])
+  );
+
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(false);
+
+  channel.deliver({ index: 2 });
+  expect(button(root, "prev").disabled).toBe(false);
+  expect(button(root, "next").disabled).toBe(true);
+});
+
+it("remote timer button emits requests while the bridge posts absolute timer states", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides(
+      [{ key: "intro", title: "Intro" }, { key: "end", title: "End" }],
+      { plannedDurationMs: 60_000 }
+    )
+  );
+  const requests: unknown[] = [];
+  const onTimerControl = (event: Event): void => {
+    requests.push((event as CustomEvent).detail);
+  };
+  window.addEventListener("peitho:timercontrol", onTimerControl);
+  cleanups.push(() => window.removeEventListener("peitho:timercontrol", onTimerControl));
+  const timer = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')!;
+
+  timer.click();
+  vi.setSystemTime(3_500);
+  timer.click();
+  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toBe("Paused");
+  timer.click();
+
+  expect(requests).toEqual([{ action: "start" }, { action: "pause" }, { action: "resume" }]);
+  expect(channel.sent).toEqual([
+    { timer: { running: true, elapsedMs: 0 } },
+    { timer: { running: false, elapsedMs: 2500 } },
+    { timer: { running: true, elapsedMs: 2500 } }
+  ]);
+});
+
+it("remote timer states render stopped running and paused rows", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides(
+      [{ key: "intro", title: "Intro" }, { key: "end", title: "End" }],
+      { plannedDurationMs: 60_000 }
+    )
+  );
+  const timer = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')!;
+
+  expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-chip"]')?.hidden).toBe(true);
+
+  channel.deliver({
+    timer: { running: true, elapsedMs: 35_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+  expect(timer.querySelector('[data-peitho-icon="pause"]')).not.toBeNull();
+  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toContain("behind");
+
+  channel.deliver({
+    timer: { running: false, elapsedMs: 20_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+  expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
+  expect(root.querySelector('[data-peitho-remote="pace-chip"]')?.textContent).toBe("Paused");
+});
+
+it("remote preview shell reuses the already loaded manifest", async () => {
+  const manifest = manifestWithSlides([{ key: "intro", title: "Intro" }, { key: "end" }]);
+  let manifestFetches = 0;
+  const fetcher = vi.fn(async (url: string) => {
+    if (url === "manifest.json") {
+      manifestFetches += 1;
+      if (manifestFetches > 1) return fail(500);
+      return okJson(manifest);
+    }
+    if (url === "notes.json") return okJson({ version: 1, notes: {} });
+    if (url === "peitho.css") return { ok: true, status: 200, text: async () => "" } as Response;
+    const slide = manifest.slides.find((item) => item.src === url);
+    if (slide) return { ok: true, status: 200, text: async () => "<section></section>" } as Response;
+    return fail(404);
+  }) as typeof fetch;
+  const root = document.createElement("main");
+  document.body.appendChild(root);
+  const channel = mockChannel();
+  const view = await mountRemoteView({
+    root,
+    manifestUrl: "manifest.json",
+    notesUrl: "notes.json",
+    fetcher,
+    channelFactory: () => channel,
+    syncChannelFactory: () => channel,
+    window,
+    document,
+    bus: window
+  });
+  views.push(view);
+
+  expect(root.className).not.toContain("peitho-remote-error");
+  expect(manifestFetches).toBe(1);
+  expect(root.querySelector('[data-peitho-remote="preview"] .peitho-slide')).not.toBeNull();
+});
+
+it("remote timer interval updates time chrome without replacing the notes text node", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides(
+      [{ key: "intro", title: "Intro" }, { key: "end" }],
+      { plannedDurationMs: 60_000 }
+    ),
+    mockChannel(),
+    { notes: { version: 1, notes: { intro: "Long note" } } }
+  );
+  const notes = root.querySelector<HTMLElement>('[data-peitho-remote="notes"]')!;
+  const firstTextNode = notes.firstChild;
+  channel.deliver({
+    timer: { running: true, elapsedMs: 1_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+
+  vi.advanceTimersByTime(1000);
+
+  expect(notes.firstChild).toBe(firstTextNode);
+  expect(notes.textContent).toBe("Long note");
+  expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:02");
 });
 
 it("remote controller no-ops at the ends", async () => {
@@ -183,7 +531,11 @@ it("remote controller disables buttons and shows ended state on close", async ()
 
   expect(button(root, "prev").disabled).toBe(true);
   expect(button(root, "next").disabled).toBe(true);
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
+    true
+  );
   expect(root.querySelector('[data-peitho-remote="status"]')?.textContent).toBe("Ended");
+  expect(root.querySelector<HTMLElement>(".peitho-remote")?.dataset.peithoEnded).toBe("true");
 });
 
 it("remote controller closes the sync channel and ignores clicks after ended", async () => {
@@ -197,6 +549,69 @@ it("remote controller closes the sync channel and ignores clicks after ended", a
 
   expect(channel.closed).toBe(true);
   expect(channel.sent).toEqual([]);
+});
+
+it("pace math uses section piecewise timing", () => {
+  const manifest = manifestWithSlides(
+    [{ key: "a" }, { key: "b" }, { key: "c" }, { key: "d" }],
+    {
+      plannedDurationMs: 60_000,
+      sections: [
+        { name: "One", startIndex: 0, endIndex: 1, plannedDurationMs: 20_000 },
+        { name: "Two", startIndex: 2, endIndex: 3, plannedDurationMs: 40_000 }
+      ]
+    }
+  );
+
+  expect(expectedElapsedAtSlide(manifest, 0)).toBe(0);
+  expect(expectedElapsedAtSlide(manifest, 1)).toBe(10_000);
+  expect(expectedElapsedAtSlide(manifest, 2)).toBe(20_000);
+  expect(expectedElapsedAtSlide(manifest, 3)).toBe(40_000);
+});
+
+it("pace math falls back to whole-deck timing without sections", () => {
+  const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
+    plannedDurationMs: 60_000
+  });
+
+  expect(expectedElapsedAtSlide(manifest, 0)).toBe(0);
+  expect(expectedElapsedAtSlide(manifest, 1)).toBe(20_000);
+  expect(expectedElapsedAtSlide(manifest, 2)).toBe(40_000);
+});
+
+it("pace math clamps plan tick progress", () => {
+  const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
+    plannedDurationMs: 60_000
+  });
+
+  expect(plannedProgressAtElapsed(manifest, -10_000)).toBe(0);
+  expect(plannedProgressAtElapsed(manifest, 0)).toBe(0);
+  expect(plannedProgressAtElapsed(manifest, 30_000)).toBe(0.75);
+  expect(plannedProgressAtElapsed(manifest, 90_000)).toBe(1);
+});
+
+it("pace chip selection covers ahead behind paused and null planned time", () => {
+  const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
+    plannedDurationMs: 60_000
+  });
+  const unplanned = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }]);
+
+  expect(remotePaceState(manifest, 1, 25_000, true)).toEqual({
+    kind: "behind",
+    label: "0:05 behind",
+    emoji: "tortoise"
+  });
+  expect(remotePaceState(manifest, 1, 15_000, true)).toEqual({
+    kind: "ahead",
+    label: "0:05 ahead",
+    emoji: "hare"
+  });
+  expect(remotePaceState(manifest, 1, 15_000, false)).toEqual({
+    kind: "paused",
+    label: "Paused",
+    emoji: null
+  });
+  expect(remotePaceState(unplanned, 1, 15_000, true)).toBeNull();
 });
 
 it("remote manifest fetch failure is visible", async () => {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -5,7 +5,6 @@ import {
   expectedElapsedAtSlide,
   installRemoteControls,
   mountRemoteView,
-  plannedProgressAtElapsed,
   remotePaceState,
   type RemoteView
 } from "../src/remote";
@@ -173,6 +172,9 @@ it("remote controls mount disabled before the synced event arrives", () => {
   expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
     true
   );
+  expect(
+    root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled
+  ).toBe(true);
 });
 
 it("remote controller resolves next and prev across skipped slides and posts absolute indexes", async () => {
@@ -199,12 +201,19 @@ it("remote controls are disabled and silent before the initial sync snapshot is 
   expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
     true
   );
+  expect(
+    root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled
+  ).toBe(true);
 
   button(root, "next").click();
   root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.click();
   window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
   window.dispatchEvent(
     new CustomEvent("peitho:timercontrol", { detail: { action: "start" } })
+  );
+  window.dispatchEvent(
+    new CustomEvent("peitho:timercontrol", { detail: { action: "reset" } })
   );
 
   expect(channel.sent).toEqual([]);
@@ -224,6 +233,9 @@ it("remote controls enable after synced replay is reported", async () => {
   expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
     false
   );
+  expect(
+    root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled
+  ).toBe(true);
   button(root, "next").click();
   expect(channel.sent).toEqual([{ index: 1 }]);
 });
@@ -282,7 +294,7 @@ it("remote renders preview title section notes and section-aware chase chrome", 
   expect(root.querySelector('[data-peitho-remote="title"]')?.textContent).toBe("Architecture");
   expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("2 / 3");
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
-    "41.67%"
+    "27.78%"
   );
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
     "50%"
@@ -291,11 +303,11 @@ it("remote renders preview title section notes and section-aware chase chrome", 
     root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.transform
   ).toBe("translateX(-50%)");
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
-    "41.67%"
+    "27.78%"
   );
   expect(
     root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.transform
-  ).toBe("translateX(-41.67%)");
+  ).toBe("translateX(-27.78%)");
   expect(root.querySelector('[data-peitho-remote="section"]')?.textContent).toBe(
     "Architecture · slide 1 / 2 in section"
   );
@@ -431,6 +443,44 @@ it("remote timer button emits requests while the bridge posts absolute timer sta
   ]);
 });
 
+it("remote reset button emits a reset request and bridge posts zero timer state", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides(
+      [{ key: "intro", title: "Intro" }, { key: "end", title: "End" }],
+      { plannedDurationMs: 60_000 }
+    )
+  );
+  const requests: unknown[] = [];
+  const onTimerControl = (event: Event): void => {
+    requests.push((event as CustomEvent).detail);
+  };
+  window.addEventListener("peitho:timercontrol", onTimerControl);
+  cleanups.push(() => window.removeEventListener("peitho:timercontrol", onTimerControl));
+  const timer = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')!;
+  const reset = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')!;
+
+  expect(reset.disabled).toBe(true);
+  expect(reset.getAttribute("aria-label")).toBe("Reset timer");
+  expect(reset.textContent).toBe("↺");
+
+  timer.click();
+  expect(reset.disabled).toBe(false);
+  vi.setSystemTime(3_500);
+  reset.click();
+
+  expect(requests).toEqual([{ action: "start" }, { action: "reset" }]);
+  expect(channel.sent).toEqual([
+    { timer: { running: true, elapsedMs: 0 } },
+    { timer: { running: false, elapsedMs: 0 } }
+  ]);
+  expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
+  expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:00");
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.hidden).toBe(true);
+  expect(reset.disabled).toBe(true);
+});
+
 it("remote timer states render stopped running and paused rows", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(1_000);
@@ -444,21 +494,27 @@ it("remote timer states render stopped running and paused rows", async () => {
 
   expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.hidden).toBe(true);
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled).toBe(
+    true
+  );
 
   channel.deliver({
     timer: { running: true, elapsedMs: 35_000, atMs: 10_000 },
     nowMs: 10_000
   });
   expect(timer.querySelector('[data-peitho-icon="pause"]')).not.toBeNull();
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled).toBe(
+    false
+  );
   expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toContain("behind");
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
     "0%"
   );
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
-    "100%"
+    "58.33%"
   );
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
-    "100%"
+    "58.33%"
   );
 
   channel.deliver({
@@ -467,9 +523,12 @@ it("remote timer states render stopped running and paused rows", async () => {
   });
   expect(timer.querySelector('[data-peitho-icon="play"]')).not.toBeNull();
   expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe("Paused");
+  expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled).toBe(
+    false
+  );
 });
 
-it("remote chase renders behind and overrun states", async () => {
+it("remote chase renders on-pace behind and overrun states", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(1_000);
   const { root, channel } = await mountRemoteForTest(
@@ -489,11 +548,22 @@ it("remote chase renders behind and overrun states", async () => {
     "50%"
   );
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
-    "62.5%"
+    "41.67%"
   );
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
-    "62.5%"
+    "41.67%"
   );
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe(
+    "on pace"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.dataset.peithoPace).toBe(
+    "onpace"
+  );
+
+  channel.deliver({
+    timer: { running: true, elapsedMs: 45_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
   expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe(
     "0:05 behind"
   );
@@ -590,10 +660,102 @@ it("remote timer interval updates turtle fill and delta in place without touchin
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')).toBe(turtleElement);
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')).toBe(fillElement);
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')).toBe(deltaElement);
-  expect(turtle.style.left).toBe("6.67%");
-  expect(fill.style.width).toBe("6.67%");
-  expect(delta.textContent).toBe("0:02 behind");
+  expect(turtle.style.left).toBe("3.33%");
+  expect(fill.style.width).toBe("3.33%");
+  expect(delta.textContent).toBe("on pace");
   expect(root.querySelector('[data-peitho-remote="elapsed"]')?.textContent).toBe("0:02");
+});
+
+it("remote chase keeps presenter-exact marker semantics on uneven sections", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  const manifest = manifestWithSlides(
+    [
+      { key: "s1" },
+      { key: "s2" },
+      { key: "s3" },
+      { key: "s4" },
+      { key: "s5" },
+      { key: "s6" },
+      { key: "s7" },
+      { key: "s8" },
+      { key: "s9" },
+      { key: "s10" }
+    ],
+    {
+      plannedDurationMs: 30 * 60_000,
+      sections: [
+        { name: "Fast", startIndex: 0, endIndex: 4, plannedDurationMs: 5 * 60_000 },
+        { name: "Deep", startIndex: 5, endIndex: 9, plannedDurationMs: 25 * 60_000 }
+      ]
+    }
+  );
+  const { root, channel } = await mountRemoteForTest(manifest);
+
+  channel.deliver({ index: 5 });
+  channel.deliver({
+    timer: { running: true, elapsedMs: 8 * 60_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "26.67%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "26.67%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
+    "55.56%"
+  );
+  expect(root.querySelector('[data-peitho-remote="pace-delta"]')?.textContent).toBe(
+    "on pace"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.dataset.peithoPace).toBe(
+    "onpace"
+  );
+});
+
+it("remote chase puts the last-slide rabbit at the slide goal", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides(
+      [{ key: "intro" }, { key: "middle" }, { key: "end" }],
+      { plannedDurationMs: 60_000 }
+    )
+  );
+
+  channel.deliver({ index: 2 });
+  channel.deliver({
+    timer: { running: true, elapsedMs: 60_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
+    "100%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "100%"
+  );
+});
+
+it("remote chase pins the single-slide rabbit at the slide goal", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "only" }], { plannedDurationMs: 60_000 })
+  );
+
+  channel.deliver({
+    timer: { running: true, elapsedMs: 15_000, atMs: 10_000 },
+    nowMs: 10_000
+  });
+
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-rabbit"]')?.style.left).toBe(
+    "100%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.left).toBe(
+    "25%"
+  );
+  expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
+    "25%"
+  );
 });
 
 it("remote controller no-ops at the ends", async () => {
@@ -633,6 +795,9 @@ it("remote controller disables buttons and shows ended state on close", async ()
   expect(root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]')?.disabled).toBe(
     true
   );
+  expect(
+    root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled
+  ).toBe(true);
   expect(root.querySelector('[data-peitho-remote="status"]')?.textContent).toBe("Ended");
   expect(root.querySelector<HTMLElement>(".peitho-remote")?.dataset.peithoEnded).toBe("true");
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase"]')?.classList).toContain(
@@ -694,6 +859,7 @@ it("pace math uses section piecewise timing", () => {
   expect(expectedElapsedAtSlide(manifest, 1)).toBe(10_000);
   expect(expectedElapsedAtSlide(manifest, 2)).toBe(20_000);
   expect(expectedElapsedAtSlide(manifest, 3)).toBe(40_000);
+  expect(expectedElapsedAtSlide(manifest, 4)).toBe(60_000);
 });
 
 it("pace math falls back to whole-deck timing without sections", () => {
@@ -704,32 +870,30 @@ it("pace math falls back to whole-deck timing without sections", () => {
   expect(expectedElapsedAtSlide(manifest, 0)).toBe(0);
   expect(expectedElapsedAtSlide(manifest, 1)).toBe(20_000);
   expect(expectedElapsedAtSlide(manifest, 2)).toBe(40_000);
+  expect(expectedElapsedAtSlide(manifest, 3)).toBe(60_000);
 });
 
-it("plannedProgressAtElapsed clamps the chase turtle fraction", () => {
-  const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
-    plannedDurationMs: 60_000
-  });
-
-  expect(plannedProgressAtElapsed(manifest, -10_000)).toBe(0);
-  expect(plannedProgressAtElapsed(manifest, 0)).toBe(0);
-  expect(plannedProgressAtElapsed(manifest, 30_000)).toBe(0.75);
-  expect(plannedProgressAtElapsed(manifest, 90_000)).toBe(1);
-});
-
-it("pace state selection covers ahead behind overrun paused and null planned time", () => {
+it("pace state selection covers ahead on-pace behind overrun paused and null planned time", () => {
   const manifest = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }], {
     plannedDurationMs: 60_000
   });
   const unplanned = manifestWithSlides([{ key: "a" }, { key: "b" }, { key: "c" }]);
 
-  expect(remotePaceState(manifest, 1, 25_000, true)).toEqual({
-    kind: "behind",
-    label: "0:05 behind"
-  });
   expect(remotePaceState(manifest, 1, 15_000, true)).toEqual({
     kind: "ahead",
     label: "0:05 ahead"
+  });
+  expect(remotePaceState(manifest, 1, 20_000, true)).toEqual({
+    kind: "onpace",
+    label: "on pace"
+  });
+  expect(remotePaceState(manifest, 1, 25_000, true)).toEqual({
+    kind: "onpace",
+    label: "on pace"
+  });
+  expect(remotePaceState(manifest, 1, 45_000, true)).toEqual({
+    kind: "behind",
+    label: "0:05 behind"
   });
   expect(remotePaceState(manifest, 1, 70_000, true)).toEqual({
     kind: "overrun",
@@ -740,6 +904,43 @@ it("pace state selection covers ahead behind overrun paused and null planned tim
     label: "Paused"
   });
   expect(remotePaceState(unplanned, 1, 15_000, true)).toBeNull();
+});
+
+it("pace state selection uses uneven-section slide windows", () => {
+  const manifest = manifestWithSlides(
+    [
+      { key: "s1" },
+      { key: "s2" },
+      { key: "s3" },
+      { key: "s4" },
+      { key: "s5" },
+      { key: "s6" },
+      { key: "s7" },
+      { key: "s8" },
+      { key: "s9" },
+      { key: "s10" }
+    ],
+    {
+      plannedDurationMs: 30 * 60_000,
+      sections: [
+        { name: "Fast", startIndex: 0, endIndex: 4, plannedDurationMs: 5 * 60_000 },
+        { name: "Deep", startIndex: 5, endIndex: 9, plannedDurationMs: 25 * 60_000 }
+      ]
+    }
+  );
+
+  expect(remotePaceState(manifest, 5, 4 * 60_000, true)).toEqual({
+    kind: "ahead",
+    label: "1:00 ahead"
+  });
+  expect(remotePaceState(manifest, 5, 8 * 60_000, true)).toEqual({
+    kind: "onpace",
+    label: "on pace"
+  });
+  expect(remotePaceState(manifest, 5, 12 * 60_000, true)).toEqual({
+    kind: "behind",
+    label: "2:00 behind"
+  });
 });
 
 it("remote manifest fetch failure is visible", async () => {

--- a/packages/peitho-present/test/session.test.ts
+++ b/packages/peitho-present/test/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, it, vi } from "vitest";
+import type { Manifest } from "../../../bindings/Manifest";
 import { mountPresentShell } from "../src/index";
 import type { PresentShell } from "../src/index";
 
@@ -10,7 +11,7 @@ function okText(value: string): Response {
   return { ok: true, status: 200, text: async () => value } as Response;
 }
 
-const manifest = {
+const manifest: Manifest = {
   version: 1,
   peithoVersion: "0.1.0",
   title: "Demo",
@@ -26,6 +27,7 @@ const manifest = {
       key: "intro",
       src: "slides/000-intro.html",
       hasNotes: false,
+      skip: false,
       text: { title: "", body: "", code: "" }
     },
     {
@@ -33,9 +35,11 @@ const manifest = {
       key: "details",
       src: "slides/001-details.html",
       hasNotes: false,
+      skip: false,
       text: { title: "", body: "", code: "" }
     }
-  ]
+  ],
+  images: []
 };
 
 function standardFetch(): typeof fetch {
@@ -140,6 +144,92 @@ it("pauses resumes and resets only after a manual start", async () => {
     { total: 2, startedAt: 1000 },
     { total: 2, startedAt: 3000 }
   ]);
+});
+
+it("adopts absolute timer state while stopped running and paused", async () => {
+  let now = 10_000;
+  const shell = await mountPresentShell({
+    root: document.createElement("main"),
+    fetcher: standardFetch(),
+    window,
+    now: () => now
+  });
+  shells.push(shell);
+
+  shell.adoptTimerState({ running: false, elapsedMs: 0 });
+  expect(shell.startedAt()).toBeNull();
+  expect(shell.isPaused()).toBe(false);
+  expect(shell.elapsedMs()).toBe(0);
+
+  shell.adoptTimerState({ running: true, elapsedMs: 2_000 });
+  expect(shell.startedAt()).toBe(8_000);
+  expect(shell.isPaused()).toBe(false);
+  expect(shell.elapsedMs()).toBe(2_000);
+  now = 11_500;
+  expect(shell.elapsedMs()).toBe(3_500);
+
+  shell.adoptTimerState({ running: false, elapsedMs: 4_000 });
+  expect(shell.startedAt()).toBe(7_500);
+  expect(shell.isPaused()).toBe(true);
+  expect(shell.elapsedMs()).toBe(4_000);
+  now = 20_000;
+  expect(shell.elapsedMs()).toBe(4_000);
+
+  shell.adoptTimerState({ running: true, elapsedMs: 6_000 });
+  expect(shell.startedAt()).toBe(14_000);
+  expect(shell.isPaused()).toBe(false);
+  expect(shell.elapsedMs()).toBe(6_000);
+});
+
+it("emits timeradopt without emitting timerchange when adopting absolute state", async () => {
+  const bus = new EventTarget();
+  const adopted: unknown[] = [];
+  const changes: unknown[] = [];
+  let now = 10_000;
+  bus.addEventListener("peitho:timeradopt", (event) =>
+    adopted.push((event as CustomEvent).detail)
+  );
+  bus.addEventListener("peitho:timerchange", (event) =>
+    changes.push((event as CustomEvent).detail)
+  );
+  const shell = await mountPresentShell({
+    root: document.createElement("main"),
+    fetcher: standardFetch(),
+    window,
+    bus,
+    now: () => now
+  });
+  shells.push(shell);
+
+  bus.dispatchEvent(new CustomEvent("peitho:timercontrol", { detail: { action: "start" } }));
+  now = 12_500;
+  adopted.length = 0;
+  changes.length = 0;
+  shell.adoptTimerState({ running: true, elapsedMs: 4_000 });
+
+  expect(adopted).toEqual([{ running: true, elapsedMs: 4_000, previousElapsedMs: 2_500 }]);
+  expect(changes).toEqual([]);
+});
+
+it("uses an injected manifest without fetching manifest.json", async () => {
+  const fetcher = vi.fn(async (url: string) => {
+    if (url === "manifest.json") return { ok: false, status: 500, text: async () => "" } as Response;
+    if (url === "peitho.css") return okText(".slot-title { color: red; }");
+    if (url === "slides/000-intro.html") return okText("<section><h1>Intro</h1></section>");
+    if (url === "slides/001-details.html")
+      return okText("<section><h1>Details</h1></section>");
+    return { ok: false, status: 404, text: async () => "" } as Response;
+  }) as typeof fetch;
+  const shell = await mountPresentShell({
+    root: document.createElement("main"),
+    manifest,
+    fetcher,
+    window
+  });
+  shells.push(shell);
+
+  expect(shell.manifest?.title).toBe("Demo");
+  expect(fetcher).not.toHaveBeenCalledWith("manifest.json");
 });
 
 it("emits presentationend only once and only after start", async () => {

--- a/packages/peitho-present/test/sync.test.ts
+++ b/packages/peitho-present/test/sync.test.ts
@@ -10,7 +10,10 @@ import {
   isCloseSyncMessage,
   isGenerationSyncMessage,
   isIndexSyncMessage,
+  isSyncedSyncMessage,
   isSwappedSyncMessage,
+  isTimerReplaySyncMessage,
+  isTimerSyncMessage,
   type SyncChannel
 } from "../src/sync";
 
@@ -20,6 +23,11 @@ function okJson(value: unknown): Response {
 
 function okText(value: string): Response {
   return { ok: true, status: 200, text: async () => value } as Response;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 const manifest = {
@@ -86,6 +94,33 @@ it("exports strict sync message guards", () => {
   expect(isSwappedSyncMessage({ swapped: true })).toBe(true);
   expect(isSwappedSyncMessage({ swapped: "true" })).toBe(false);
 
+  expect(isTimerSyncMessage({ timer: { running: true, elapsedMs: 1000 } })).toBe(true);
+  expect(isTimerSyncMessage({ timer: { running: true, elapsedMs: -1 } })).toBe(false);
+  expect(isTimerSyncMessage({ timer: { running: true, elapsedMs: Number.NaN } })).toBe(false);
+  expect(isTimerSyncMessage({ timer: { running: "true", elapsedMs: 1000 } })).toBe(false);
+
+  expect(
+    isTimerReplaySyncMessage({
+      timer: { running: true, elapsedMs: 1000, atMs: 5000 },
+      nowMs: 5500
+    })
+  ).toBe(true);
+  expect(
+    isTimerReplaySyncMessage({
+      timer: { running: true, elapsedMs: 1000 },
+      nowMs: 5500
+    })
+  ).toBe(false);
+  expect(
+    isTimerReplaySyncMessage({
+      timer: { running: true, elapsedMs: 1000, atMs: 5000 },
+      nowMs: Number.NaN
+    })
+  ).toBe(false);
+
+  expect(isSyncedSyncMessage({ synced: true })).toBe(true);
+  expect(isSyncedSyncMessage({ synced: false })).toBe(false);
+
   expect(isGenerationSyncMessage({ generation: 1 })).toBe(true);
   expect(isGenerationSyncMessage({ generation: Number.NaN })).toBe(false);
 });
@@ -129,7 +164,7 @@ it("server sync channel polls and forwards long-poll messages", async () => {
   const received: unknown[] = [];
   channel.onmessage = (event) => received.push(event.data);
 
-  await vi.waitFor(() => expect(received).toEqual([{ index: 1 }]));
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
 
   expect(fetcher).toHaveBeenCalledWith("/sync");
   expect(fetcher).toHaveBeenCalledWith("/sync?seq=5", expect.objectContaining({ signal: expect.any(AbortSignal) }));
@@ -151,7 +186,96 @@ it("server sync channel replays poll response state after the poll message", asy
   channel.onmessage = (event) => received.push(event.data);
 
   await vi.waitFor(() =>
-    expect(received).toEqual([{ index: 1 }, { index: 2 }, { swapped: true }])
+    expect(received).toEqual([
+      { synced: true },
+      { index: 1 },
+      { index: 2 },
+      { swapped: true }
+    ])
+  );
+
+  channel.close();
+});
+
+it("server sync channel replays timer state from handshake and poll responses", async () => {
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") return Promise.resolve({ ok: true, status: 204 } as Response);
+    if (url === "/sync") {
+      return Promise.resolve(
+        okJson({
+          seq: 5,
+          message: null,
+          timer: { running: true, elapsedMs: 1000, atMs: 4000 },
+          nowMs: 4500
+        })
+      );
+    }
+    if (url === "/sync?seq=5") {
+      return Promise.resolve(
+        okJson({
+          seq: 6,
+          message: { timer: { running: false, elapsedMs: 3000 } },
+          timer: { running: false, elapsedMs: 3000, atMs: 9000 },
+          nowMs: 9500
+        })
+      );
+    }
+    if (url === "/sync?seq=6") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      {
+        timer: { running: true, elapsedMs: 1000, atMs: 4000 },
+        nowMs: 4500
+      },
+      { synced: true },
+      { timer: { running: false, elapsedMs: 3000 } },
+      {
+        timer: { running: false, elapsedMs: 3000, atMs: 9000 },
+        nowMs: 9500
+      }
+    ])
+  );
+
+  channel.close();
+});
+
+it("server sync channel delivers handshake replay timer before index and synced last", async () => {
+  const fetcher = vi.fn((url: string) => {
+    if (url === "/sync") {
+      return Promise.resolve(
+        okJson({
+          seq: 4,
+          message: null,
+          index: 2,
+          swapped: true,
+          timer: { running: true, elapsedMs: 600_000, atMs: 10_000 },
+          nowMs: 11_000
+        })
+      );
+    }
+    if (url === "/sync?seq=4") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      {
+        timer: { running: true, elapsedMs: 600_000, atMs: 10_000 },
+        nowMs: 11_000
+      },
+      { index: 2 },
+      { swapped: true },
+      { synced: true }
+    ])
   );
 
   channel.close();
@@ -171,7 +295,7 @@ it("server sync channel does not replay backlog close messages after handshake",
     expect(fetcher).toHaveBeenCalledWith("/sync?seq=9", expect.objectContaining({ signal: expect.any(AbortSignal) }))
   );
 
-  expect(received).toEqual([]);
+  expect(received).toEqual([{ synced: true }]);
   expect(fetcher).not.toHaveBeenCalledWith("/sync?seq=0", expect.anything());
   channel.close();
 });
@@ -188,7 +312,9 @@ it("server sync channel replays handshake index then swapped through onmessage",
   const received: unknown[] = [];
   channel.onmessage = (event) => received.push(event.data);
 
-  await vi.waitFor(() => expect(received).toEqual([{ index: 2 }, { swapped: true }]));
+  await vi.waitFor(() =>
+    expect(received).toEqual([{ index: 2 }, { swapped: true }, { synced: true }])
+  );
 
   expect(fetcher).toHaveBeenCalledWith("/sync");
   expect(fetcher).toHaveBeenCalledWith(
@@ -213,7 +339,9 @@ it("server sync channel forwards generation replay values", async () => {
   const received: unknown[] = [];
   channel.onmessage = (event) => received.push(event.data);
 
-  await vi.waitFor(() => expect(received).toEqual([{ generation: 8 }, { generation: 9 }]));
+  await vi.waitFor(() =>
+    expect(received).toEqual([{ generation: 8 }, { synced: true }, { generation: 9 }])
+  );
 
   channel.close();
 });
@@ -245,6 +373,7 @@ it("server sync channel re-handshakes after a poll network error", async () => {
   const received: unknown[] = [];
   channel.onmessage = (event) => received.push(event.data);
 
+  await vi.waitFor(() => expect(received).toContainEqual({ synced: true }));
   await vi.waitFor(() => expect(received).toContainEqual({ generation: 2 }));
 
   expect(fetcher).toHaveBeenCalledWith("/sync");
@@ -324,6 +453,358 @@ it("posts close sync messages from closerequest", () => {
   expect(channel.sent).toEqual([{ close: true }]);
 });
 
+it("posts absolute timer sync messages from timer changes", () => {
+  const channel = mockChannel();
+  const bus = new EventTarget();
+  const cleanup = installSyncBridge(window, () => channel, bus);
+  cleanups.push(cleanup);
+  channel.onmessage?.({ data: { synced: true } });
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:timerchange", {
+      detail: { running: true, elapsedMs: 1250.6 }
+    })
+  );
+
+  expect(channel.sent).toEqual([{ timer: { running: true, elapsedMs: 1251 } }]);
+});
+
+it("drops timerchange posts until the initial sync snapshot has been applied", () => {
+  const channel = mockChannel();
+  const bus = new EventTarget();
+  const cleanup = installSyncBridge(window, () => channel, bus);
+  cleanups.push(cleanup);
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:timerchange", {
+      detail: { running: true, elapsedMs: 0 }
+    })
+  );
+
+  expect(channel.sent).toEqual([]);
+  channel.onmessage?.({ data: { synced: true } });
+  bus.dispatchEvent(
+    new CustomEvent("peitho:timerchange", {
+      detail: { running: true, elapsedMs: 1000 }
+    })
+  );
+
+  expect(channel.sent).toEqual([{ timer: { running: true, elapsedMs: 1000 } }]);
+});
+
+it("does not repost an auto-start timerchange caused by pre-synced index replay", async () => {
+  const channel = mockChannel();
+  const root = document.createElement("main");
+  const shell = await mountPresentShell({ root, fetcher: standardFetch(), window });
+  shells.push(shell);
+  cleanups.push(installSyncBridge(window, () => channel));
+
+  channel.onmessage?.({ data: { index: 1 } });
+  window.dispatchEvent(
+    new CustomEvent("peitho:timerchange", {
+      detail: { running: true, elapsedMs: 0 }
+    })
+  );
+
+  expect(channel.sent).not.toContainEqual({ timer: { running: true, elapsedMs: 0 } });
+});
+
+it("skips stale poll replay state older than the highest acknowledged post seq", async () => {
+  let resolvePoll!: (response: Response) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") return Promise.resolve(okJson({ seq: 8 }));
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((resolve) => {
+        resolvePoll = resolve;
+      });
+    }
+    if (url === "/sync?seq=7") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  channel.postMessage({ timer: { running: false, elapsedMs: 20_000 } });
+  await vi.waitFor(() => expect(fetcher).toHaveBeenCalledWith("/sync", expect.objectContaining({ method: "POST" })));
+  await vi.waitFor(() => expect(resolvePoll).toBeTypeOf("function"));
+  resolvePoll(
+    okJson({
+      seq: 7,
+      message: null,
+      timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
+      nowMs: 1000,
+      index: 1,
+      swapped: true
+    })
+  );
+  await vi.waitFor(() => expect(fetcher).toHaveBeenCalledWith("/sync?seq=7", expect.anything()));
+
+  expect(received).toEqual([{ synced: true }]);
+  channel.close();
+});
+
+it("applies fresh poll replay state at or after the highest acknowledged post seq", async () => {
+  let resolvePoll!: (response: Response) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") return Promise.resolve(okJson({ seq: 8 }));
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((resolve) => {
+        resolvePoll = resolve;
+      });
+    }
+    if (url === "/sync?seq=8") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  channel.postMessage({ timer: { running: false, elapsedMs: 20_000 } });
+  await flushPromises();
+  await vi.waitFor(() => expect(resolvePoll).toBeTypeOf("function"));
+  resolvePoll(
+    okJson({
+      seq: 8,
+      message: null,
+      timer: { running: false, elapsedMs: 20_000, atMs: 1000 },
+      nowMs: 1000
+    })
+  );
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      { synced: true },
+      {
+        timer: { running: false, elapsedMs: 20_000, atMs: 1000 },
+        nowMs: 1000
+      }
+    ])
+  );
+  channel.close();
+});
+
+it("buffers newer timer replay while a timer post is awaiting ack and delivers it once after ack", async () => {
+  let resolvePost!: (response: Response) => void;
+  let resolvePendingPoll!: (response: Response) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      return new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      });
+    }
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((resolve) => {
+        resolvePendingPoll = resolve;
+      });
+    }
+    if (url === "/sync?seq=8") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  await vi.waitFor(() => expect(resolvePendingPoll).toBeTypeOf("function"));
+  channel.postMessage({ timer: { running: false, elapsedMs: 20_000 } });
+  await vi.waitFor(() => expect(resolvePost).toBeTypeOf("function"));
+  resolvePendingPoll(
+    okJson({
+      seq: 8,
+      message: null,
+      timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
+      nowMs: 2000,
+      index: 1
+    })
+  );
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  resolvePost(okJson({ seq: 7 }));
+
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      { synced: true },
+      { index: 1 },
+      {
+        timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
+        nowMs: 2000
+      }
+    ])
+  );
+  await flushPromises();
+  expect(received).toEqual([
+    { synced: true },
+    { index: 1 },
+    {
+      timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
+      nowMs: 2000
+    }
+  ]);
+  channel.close();
+});
+
+it("buffers re-handshake timer replay while a timer post is awaiting ack", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  let handshakeCount = 0;
+  let resolvePost!: (response: Response) => void;
+  let rejectPoll!: (error: Error) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      return new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      });
+    }
+    if (url === "/sync") {
+      handshakeCount += 1;
+      if (handshakeCount === 1) return Promise.resolve(okJson({ seq: 5, message: null }));
+      return Promise.resolve(
+        okJson({
+          seq: 8,
+          message: null,
+          timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
+          nowMs: 2000,
+          index: 1
+        })
+      );
+    }
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((_resolve, reject) => {
+        rejectPoll = reject;
+      });
+    }
+    if (url === "/sync?seq=8") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher, retryMs: 0 })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  await vi.waitFor(() => expect(rejectPoll).toBeTypeOf("function"));
+  channel.postMessage({ timer: { running: false, elapsedMs: 20_000 } });
+  await vi.waitFor(() => expect(resolvePost).toBeTypeOf("function"));
+  rejectPoll(new Error("poll lost"));
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  expect(error).toHaveBeenCalledWith("Failed to poll sync message: Error: poll lost");
+  resolvePost(okJson({ seq: 7 }));
+
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      { synced: true },
+      { index: 1 },
+      {
+        timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
+        nowMs: 2000
+      }
+    ])
+  );
+  channel.close();
+});
+
+it("discards buffered timer replay older than the acknowledged timer post", async () => {
+  let resolvePost!: (response: Response) => void;
+  let resolvePendingPoll!: (response: Response) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      return new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      });
+    }
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((resolve) => {
+        resolvePendingPoll = resolve;
+      });
+    }
+    if (url === "/sync?seq=6") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  await vi.waitFor(() => expect(resolvePendingPoll).toBeTypeOf("function"));
+  channel.postMessage({ timer: { running: false, elapsedMs: 20_000 } });
+  await vi.waitFor(() => expect(resolvePost).toBeTypeOf("function"));
+  resolvePendingPoll(
+    okJson({
+      seq: 6,
+      message: null,
+      timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
+      nowMs: 1000,
+      index: 1
+    })
+  );
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  resolvePost(okJson({ seq: 7 }));
+  await flushPromises();
+
+  expect(received).toEqual([{ synced: true }, { index: 1 }]);
+  channel.close();
+});
+
+it("delivers buffered timer replay after a pending timer post fails", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  let rejectPost!: (error: Error) => void;
+  let resolvePendingPoll!: (response: Response) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      return new Promise<Response>((_resolve, reject) => {
+        rejectPost = reject;
+      });
+    }
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((resolve) => {
+        resolvePendingPoll = resolve;
+      });
+    }
+    if (url === "/sync?seq=6") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  await vi.waitFor(() => expect(resolvePendingPoll).toBeTypeOf("function"));
+  channel.postMessage({ timer: { running: false, elapsedMs: 20_000 } });
+  await vi.waitFor(() => expect(rejectPost).toBeTypeOf("function"));
+  resolvePendingPoll(
+    okJson({
+      seq: 6,
+      message: null,
+      timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
+      nowMs: 1000,
+      index: 1
+    })
+  );
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  rejectPost(new Error("offline"));
+  await vi.waitFor(() => expect(error).toHaveBeenCalledWith("Failed to post sync message: Error: offline"));
+
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      { synced: true },
+      { index: 1 },
+      {
+        timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
+        nowMs: 1000
+      }
+    ])
+  );
+  channel.close();
+});
+
 it("posts absolute swap state from swaprequest based on the current route", () => {
   for (const [path, expected] of [
     ["/present.html", { swapped: true }],
@@ -335,9 +816,11 @@ it("posts absolute swap state from swaprequest based on the current route", () =
       window,
       () => channel,
       bus,
-      () => undefined,
-      () => path,
-      () => undefined
+      {
+        closeWindow: () => undefined,
+        pathname: () => path,
+        navigate: () => undefined
+      }
     );
 
     bus.dispatchEvent(new CustomEvent("peitho:swaprequest"));
@@ -355,9 +838,11 @@ it("does not post swap state on unknown routes", () => {
     window,
     () => channel,
     bus,
-    () => undefined,
-    () => "/unknown",
-    () => undefined
+    {
+      closeWindow: () => undefined,
+      pathname: () => "/unknown",
+      navigate: () => undefined
+    }
   );
   cleanups.push(cleanup);
 
@@ -370,7 +855,7 @@ it("does not post swap state on unknown routes", () => {
 it("closes the window when a remote close sync message arrives", () => {
   const channel = mockChannel();
   const closeWindow = vi.fn();
-  const cleanup = installSyncBridge(window, () => channel, window, closeWindow);
+  const cleanup = installSyncBridge(window, () => channel, window, { closeWindow });
   cleanups.push(cleanup);
 
   channel.onmessage?.({ data: { close: true } });
@@ -389,6 +874,41 @@ it("turns remote index messages into navigate requests", () => {
   channel.onmessage?.({ data: { index: 1 } });
 
   expect(requests).toEqual([{ to: { index: 1 } }]);
+});
+
+it("adopts replayed timer sync state through the injected callback", () => {
+  const channel = mockChannel();
+  const bus = new EventTarget();
+  const adoptTimerState = vi.fn();
+  const cleanup = installSyncBridge(
+    window,
+    () => channel,
+    bus,
+    {
+      closeWindow: () => undefined,
+      pathname: () => "/present.html",
+      navigate: () => undefined,
+      adoptTimerState
+    }
+  );
+  cleanups.push(cleanup);
+
+  channel.onmessage?.({
+    data: { timer: { running: true, elapsedMs: 1000, atMs: 4000 }, nowMs: 4750 }
+  });
+
+  expect(adoptTimerState).toHaveBeenCalledWith({ running: true, elapsedMs: 1750 });
+});
+
+it("ignores raw timer sync messages on the present sync bridge", () => {
+  const channel = mockChannel();
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const cleanup = installSyncBridge(window, () => channel);
+  cleanups.push(cleanup);
+
+  channel.onmessage?.({ data: { timer: { running: false, elapsedMs: 3000 } } });
+
+  expect(error).not.toHaveBeenCalled();
 });
 
 it("ignores generation sync messages on the present sync bridge", () => {
@@ -420,9 +940,11 @@ it("navigates to the same-window counterpart when remote swapped state differs",
       window,
       () => channel,
       bus,
-      () => undefined,
-      () => testCase.path,
-      navigate
+      {
+        closeWindow: () => undefined,
+        pathname: () => testCase.path,
+        navigate
+      }
     );
 
     channel.onmessage?.({ data: { swapped: testCase.swapped } });
@@ -450,9 +972,11 @@ it("does not navigate when remote swapped state already matches the route", () =
       window,
       () => channel,
       bus,
-      () => undefined,
-      () => testCase.path,
-      navigate
+      {
+        closeWindow: () => undefined,
+        pathname: () => testCase.path,
+        navigate
+      }
     );
 
     channel.onmessage?.({ data: { swapped: testCase.swapped } });
@@ -471,9 +995,11 @@ it("does not navigate on swapped messages received on unknown routes", () => {
     window,
     () => channel,
     bus,
-    () => undefined,
-    () => "/unknown",
-    navigate
+    {
+      closeWindow: () => undefined,
+      pathname: () => "/unknown",
+      navigate
+    }
   );
   cleanups.push(cleanup);
 
@@ -501,9 +1027,11 @@ it("does not navigate when replayed swapped state equals the current route", asy
     window,
     serverSyncChannelFactory({ fetcher }),
     bus,
-    () => undefined,
-    () => "/present.html",
-    navigate
+    {
+      closeWindow: () => undefined,
+      pathname: () => "/present.html",
+      navigate
+    }
   );
   cleanups.push(cleanup);
 
@@ -529,9 +1057,11 @@ it("converges from poll response swapped state when the poll message is unrelate
     window,
     serverSyncChannelFactory({ fetcher }),
     bus,
-    () => undefined,
-    () => "/present.html",
-    navigate
+    {
+      closeWindow: () => undefined,
+      pathname: () => "/present.html",
+      navigate
+    }
   );
   cleanups.push(cleanup);
 


### PR DESCRIPTION
Closes #299

## What

The `/remote` phone page grows from a bare counter + prev/next (the deliberately minimal v1 from #297) into a full presentation companion, top to bottom:

- **Live slide preview** — a scaled rendering of the current slide via the present-shell canvas (same approach as the presenter's preview pane), reusing the controller's already-fetched manifest
- **Slide title + progress bar** — with a **plan tick** marking where the schedule says you should be
- **Pace row** — start/pause/resume timer button (44px, §16 request events only), elapsed / planned time, and a hare🐇/tortoise🐢 ahead-behind chip
- **Section indicator** — one line (`Architecture · slide 3 / 6 in section`), omitted for decks without agenda markers
- **Notes panel** — notes-first flexible area, plaintext `textContent` (same v1 policy as the presenter), dimmed placeholder when empty
- **Skip-aware buttons** — Previous/Next disable at the first/last non-skipped slide; everything disables on Ended (server closed)

Design is the author-approved "Sky Tonal Pill" mock (Claude Design, 2026-07-16). Notes get no gating beyond the existing `--host` opt-in, per the #289 discussion. Design record: `docs/plans/2026-07-16-remote-rich-view.md`.

## Protocol change (the one server change)

Timer state rides `/sync` as a third **absolute** state, mirroring `index`/`swapped` (command forwarding is ruled out by the coalescing invariant):

- `POST /sync` accepts `{"timer":{"running":bool,"elapsedMs":u64}}` and now responds `{"seq":N}`
- The server stamps `atMs` and emits `nowMs` from a process-wide **monotonic clock** (NTP steps can't shift reconstructed elapsed); every JSON GET response replays `timer` + `nowMs`
- Clients: controls and outgoing posts are gated on a one-time `{synced:true}` handshake signal (replay order timer→index→swapped); stale replays below the acked post seq are skipped (transient messages, esp. `close`, never are); timer replays are deferred while the client's own timer post is in flight and flushed after the ack
- `adoptTimerState` announces discontinuous rebases via `peitho:timeradopt` carrying the pre-adopt elapsed, so the presenter agenda's per-section actuals stay exact across swaps/reloads
- The present.html loader feature-detects `shell.adoptTimerState` so a stale `--shell` bundle degrades to a visible error

## Verification

- All gates: `cargo test --workspace` ×3, clippy `-D warnings`, fmt, bindings drift, `npm run build && npm test` (247) + typecheck, embedded dist drift
- Adversarial review (multi-agent, high effort) + 5 fresh review rounds; all confirmed findings fixed at the root (handshake gating, seq ack, monotonic clock, timeradopt accounting, deferred replays, bounded height chain)
- Live E2E on `peitho present --no-open`: real-browser checks of preview/title/section/notes following `POST /sync` navigation, timer button posting pause/resume with correct elapsed, first/last-slide button disabling, Ended teardown, and phone-metrics rendering at 390×844 (portrait) and 844×390 (landscape — buttons stay visible, preview letterboxes down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC