### PR TITLE
feat(present): terminal QR code for the /remote control URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,7 @@ dependencies = [
  "notify-debouncer-mini",
  "peitho-core",
  "predicates",
+ "qrcodegen",
  "serde",
  "serde_json",
  "sha2",
@@ -2082,6 +2083,12 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "qrcodegen"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
 
 [[package]]
 name = "quick-xml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ notify = "8.2.0"
 notify-debouncer-mini = "0.7.0"
 predicates = "3"
 pulldown-cmark = "0.13"
+qrcodegen = "1.8"
 serde = { version = "1", features = ["derive"] }
 serde_norway = "0.9"
 serde_json = "1"

--- a/crates/peitho/Cargo.toml
+++ b/crates/peitho/Cargo.toml
@@ -17,6 +17,7 @@ miette.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 peitho-core = { path = "../peitho-core" }
+qrcodegen.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.11.0"

--- a/crates/peitho/src/lib.rs
+++ b/crates/peitho/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod browser;
 pub mod displays;
+pub mod qr;
 pub mod remote_url;
 pub mod server;

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -2489,13 +2489,23 @@ fn present(options: PresentOptions) -> miette::Result<()> {
     println!("serving presentation at {url}");
     if let Some(host) = options.host {
         let port = server.addr().port();
-        let target = if host.is_unspecified() {
-            RemoteControlTarget::Candidates(remote_url_candidates_from_interfaces(port, host))
-        } else {
-            RemoteControlTarget::Specific(host)
-        };
-        for line in format_remote_control_lines(target, port) {
+        let target = remote_control_target_for_host(host, port);
+        let (lines, qr_url) = remote_control_output(&target);
+        for line in lines {
             println!("{line}");
+        }
+        if let Some(url) = qr_url {
+            match peitho::qr::qr_unicode_lines(url.as_str()) {
+                Ok(lines) => {
+                    println!();
+                    for line in lines {
+                        println!("{line}");
+                    }
+                }
+                Err(err) => {
+                    eprintln!("warning: failed to render remote control QR for {url}: {err}");
+                }
+            }
         }
     }
     std::io::stdout().flush().into_diagnostic()?;
@@ -2527,26 +2537,43 @@ fn validate_present_options(options: &PresentOptions) -> miette::Result<()> {
 }
 
 enum RemoteControlTarget {
-    Specific(IpAddr),
+    Specific(peitho::remote_url::RemoteUrl),
     Candidates(Vec<peitho::remote_url::RemoteUrlCandidate>),
 }
 
-fn format_remote_control_lines(target: RemoteControlTarget, port: u16) -> Vec<String> {
+fn remote_control_target_for_host(host: IpAddr, port: u16) -> RemoteControlTarget {
+    if host.is_unspecified() {
+        RemoteControlTarget::Candidates(remote_url_candidates_from_interfaces(port, host))
+    } else {
+        RemoteControlTarget::Specific(peitho::remote_url::remote_url_for_addr(host, port))
+    }
+}
+
+fn remote_control_output(
+    target: &RemoteControlTarget,
+) -> (Vec<String>, Option<&peitho::remote_url::RemoteUrl>) {
     match target {
-        RemoteControlTarget::Specific(host) => vec![format!(
-            "remote control: {}",
-            peitho::remote_url::remote_url_for_addr(host, port)
-        )],
-        RemoteControlTarget::Candidates(candidates) if candidates.is_empty() => {
-            vec!["remote control: no non-loopback network addresses found".to_owned()]
+        RemoteControlTarget::Specific(url) => (vec![format!("remote control: {url}")], Some(url)),
+        RemoteControlTarget::Candidates(candidates) if candidates.is_empty() => (
+            vec!["remote control: no non-loopback network addresses found".to_owned()],
+            None,
+        ),
+        RemoteControlTarget::Candidates(candidates) => {
+            let mut lines = Vec::with_capacity(candidates.len());
+            let mut qr_url = None;
+            for candidate in candidates {
+                if qr_url.is_none() {
+                    qr_url = Some(&candidate.url);
+                }
+                lines.push(match candidate.label {
+                    Some(label) => {
+                        format!("remote control ({}): {}", label.as_str(), candidate.url)
+                    }
+                    None => format!("remote control: {}", candidate.url),
+                });
+            }
+            (lines, qr_url)
         }
-        RemoteControlTarget::Candidates(candidates) => candidates
-            .iter()
-            .map(|candidate| match candidate.label {
-                Some(label) => format!("remote control ({}): {}", label.as_str(), candidate.url),
-                None => format!("remote control: {}", candidate.url),
-            })
-            .collect(),
     }
 }
 
@@ -4895,24 +4922,29 @@ contexts:
 
     #[test]
     fn remote_control_lines_format_specific_host() {
-        let lines = format_remote_control_lines(
-            RemoteControlTarget::Specific("100.64.0.5".parse().unwrap()),
-            3000,
-        );
+        let target = remote_control_target_for_host("100.64.0.5".parse().unwrap(), 3000);
+        let (lines, qr_url) = remote_control_output(&target);
 
         assert_eq!(lines, vec!["remote control: http://100.64.0.5:3000/remote"]);
+        assert_eq!(
+            qr_url.unwrap().as_str(),
+            remote_url_from_control_line(&lines[0])
+        );
     }
 
     #[test]
     fn remote_control_lines_bracket_specific_ipv6_host() {
-        let lines = format_remote_control_lines(
-            RemoteControlTarget::Specific("2001:db8::5".parse().unwrap()),
-            3000,
-        );
+        let target = remote_control_target_for_host("2001:db8::5".parse().unwrap(), 3000);
+        let (lines, qr_url) = remote_control_output(&target);
 
         assert_eq!(
             lines,
             vec!["remote control: http://[2001:db8::5]:3000/remote"]
+        );
+        assert_eq!(qr_url.unwrap().as_str(), "http://[2001:db8::5]:3000/remote");
+        assert_eq!(
+            qr_url.unwrap().as_str(),
+            remote_url_from_control_line(&lines[0])
         );
     }
 
@@ -4929,7 +4961,8 @@ contexts:
             None,
         );
 
-        let lines = format_remote_control_lines(RemoteControlTarget::Candidates(candidates), 3000);
+        let target = RemoteControlTarget::Candidates(candidates);
+        let (lines, qr_url) = remote_control_output(&target);
 
         assert_eq!(
             lines,
@@ -4939,16 +4972,29 @@ contexts:
                 "remote control: http://192.168.1.20:3000/remote"
             ]
         );
+        assert_eq!(
+            qr_url.unwrap().as_str(),
+            remote_url_from_control_line(&lines[0])
+        );
     }
 
     #[test]
     fn remote_control_lines_show_when_unspecified_host_has_no_candidates() {
-        let lines = format_remote_control_lines(RemoteControlTarget::Candidates(Vec::new()), 3000);
+        let target = RemoteControlTarget::Candidates(Vec::new());
+        let (lines, qr_url) = remote_control_output(&target);
 
         assert_eq!(
             lines,
             vec!["remote control: no non-loopback network addresses found"]
         );
+        assert!(qr_url.is_none());
+    }
+
+    fn remote_url_from_control_line(line: &str) -> &str {
+        let start = line
+            .find("http://")
+            .unwrap_or_else(|| panic!("remote control line did not contain a URL: {line}"));
+        &line[start..]
     }
 
     #[test]

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -406,7 +406,13 @@ enum Command {
         no_presenter: bool,
         #[arg(long)]
         presenter_windowed: bool,
-        #[arg(long, value_name = "IP")]
+        #[arg(
+            long,
+            value_name = "IP",
+            num_args = 0..=1,
+            default_missing_value = "0.0.0.0",
+            help = "Expose /remote on an optional IP; bare --host uses 0.0.0.0"
+        )]
         host: Option<IpAddr>,
     },
     Publish {
@@ -4873,6 +4879,23 @@ contexts:
     }
 
     #[test]
+    fn present_command_accepts_bare_host_as_ipv4_wildcard() {
+        let bare = Cli::parse_from(["peitho", "present", "deck.md", "--host"]);
+        let explicit = Cli::parse_from(["peitho", "present", "deck.md", "--host", "0.0.0.0"]);
+        let bare_host = present_host_from_cli(bare);
+
+        assert_eq!(bare_host, Some("0.0.0.0".parse().unwrap()));
+        assert_eq!(present_host_from_cli(explicit), bare_host);
+    }
+
+    #[test]
+    fn present_command_without_host_keeps_host_none() {
+        let cli = Cli::parse_from(["peitho", "present", "deck.md"]);
+
+        assert_eq!(present_host_from_cli(cli), None);
+    }
+
+    #[test]
     fn present_command_rejects_invalid_host_ip() {
         let err = Cli::try_parse_from(["peitho", "present", "deck.md", "--host", "not-an-ip"])
             .unwrap_err();
@@ -4967,8 +4990,8 @@ contexts:
         assert_eq!(
             lines,
             vec![
-                "remote control: http://10.0.0.15:3000/remote",
                 "remote control (Tailscale): http://100.100.10.5:3000/remote",
+                "remote control: http://10.0.0.15:3000/remote",
                 "remote control: http://192.168.1.20:3000/remote"
             ]
         );
@@ -4995,6 +5018,23 @@ contexts:
             .find("http://")
             .unwrap_or_else(|| panic!("remote control line did not contain a URL: {line}"));
         &line[start..]
+    }
+
+    fn present_host_from_cli(cli: Cli) -> Option<IpAddr> {
+        match cli.command {
+            Command::Present { host, .. } => host,
+            Command::Build { .. }
+            | Command::Lint { .. }
+            | Command::New { .. }
+            | Command::Layouts { .. }
+            | Command::Doctor { .. }
+            | Command::Preview { .. }
+            | Command::Publish { .. }
+            | Command::Export { .. }
+            | Command::Completions { .. } => {
+                panic!("expected present command");
+            }
+        }
     }
 
     #[test]

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -324,7 +324,7 @@ struct PresentOptions {
     no_serve: bool,
     no_presenter: bool,
     presenter_windowed: bool,
-    host: Option<IpAddr>,
+    host: Option<Option<IpAddr>>,
 }
 
 struct PreviewOptions {
@@ -410,10 +410,9 @@ enum Command {
             long,
             value_name = "IP",
             num_args = 0..=1,
-            default_missing_value = "0.0.0.0",
-            help = "Expose /remote on an optional IP; bare --host uses 0.0.0.0"
+            help = "Expose /remote on an optional IP; bare --host picks the best address automatically (VPN, e.g. Tailscale, preferred)"
         )]
-        host: Option<IpAddr>,
+        host: Option<Option<IpAddr>>,
     },
     Publish {
         #[arg(long, default_value = "dist")]
@@ -2454,6 +2453,7 @@ fn require_slides_dir_with_files(dist: &Path) -> miette::Result<()> {
 
 fn present(options: PresentOptions) -> miette::Result<()> {
     validate_present_options(&options)?;
+    let resolved_host = resolve_present_host(options.host)?;
 
     let cache = PathBuf::from(PRESENT_CACHE);
     if cache.exists() {
@@ -2472,7 +2472,7 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         cache.clone(),
         options.port,
         "present.html",
-        options.host,
+        resolved_host.bind_host(),
     )?;
     let url = server.url();
     let presenter_url = browser::presenter_url(&url);
@@ -2493,23 +2493,27 @@ fn present(options: PresentOptions) -> miette::Result<()> {
         .is_some_and(|plan| plan.opens_presenter);
     emit_present_cache(&cache, &artifacts, options.shell.as_deref(), presenter_open)?;
     println!("serving presentation at {url}");
-    if let Some(host) = options.host {
-        let port = server.addr().port();
-        let target = remote_control_target_for_host(host, port);
-        let (lines, qr_url) = remote_control_output(&target);
-        for line in lines {
+    if let Some(target) =
+        remote_control_target_for_resolved_host(&resolved_host, server.addr().port())
+    {
+        let output = remote_control_output(&target);
+        for line in output.lines {
             println!("{line}");
         }
-        if let Some(url) = qr_url {
-            match peitho::qr::qr_unicode_lines(url.as_str()) {
+        if let Some(qr) = output.qr {
+            match peitho::qr::qr_unicode_lines(qr.url.as_str()) {
                 Ok(lines) => {
                     println!();
+                    println!("{}", qr.caption);
                     for line in lines {
                         println!("{line}");
                     }
                 }
                 Err(err) => {
-                    eprintln!("warning: failed to render remote control QR for {url}: {err}");
+                    eprintln!(
+                        "warning: failed to render remote control QR for {}: {err}",
+                        qr.url
+                    );
                 }
             }
         }
@@ -2534,52 +2538,187 @@ fn validate_present_options(options: &PresentOptions) -> miette::Result<()> {
             "--host requires the present server\nhelp: remove --no-serve or omit --host"
         ));
     }
-    if host.is_loopback() {
+    if host.is_some_and(|host| host.is_loopback()) {
         return Err(miette::miette!(
-            "--host must be non-loopback\nhelp: use the default loopback server without --host, or pass a reachable Tailscale/LAN IP address"
+            "--host must be non-loopback\nhelp: use the default loopback server without --host, or pass a reachable VPN/LAN IP address"
         ));
     }
     Ok(())
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AutoHostCandidate {
+    address: IpAddr,
+    label: Option<peitho::remote_url::RemoteUrlLabel>,
+}
+
+enum ResolvedPresentHost {
+    None,
+    Explicit(IpAddr),
+    Auto(AutoHostCandidate),
+}
+
+impl ResolvedPresentHost {
+    fn bind_host(&self) -> Option<IpAddr> {
+        match self {
+            Self::None => None,
+            Self::Explicit(host) => Some(*host),
+            Self::Auto(candidate) => Some(candidate.address),
+        }
+    }
+}
+
+struct RemoteControlEndpoint {
+    url: peitho::remote_url::RemoteUrl,
+    label: Option<peitho::remote_url::RemoteUrlLabel>,
+}
+
 enum RemoteControlTarget {
-    Specific(peitho::remote_url::RemoteUrl),
+    Specific(RemoteControlEndpoint),
     Candidates(Vec<peitho::remote_url::RemoteUrlCandidate>),
+}
+
+struct RemoteControlOutput<'a> {
+    lines: Vec<String>,
+    qr: Option<RemoteControlQr<'a>>,
+}
+
+struct RemoteControlQr<'a> {
+    url: &'a peitho::remote_url::RemoteUrl,
+    caption: String,
+}
+
+fn resolve_present_host(host: Option<Option<IpAddr>>) -> miette::Result<ResolvedPresentHost> {
+    match host {
+        None => Ok(ResolvedPresentHost::None),
+        Some(Some(host)) => Ok(ResolvedPresentHost::Explicit(host)),
+        Some(None) => Ok(ResolvedPresentHost::Auto(
+            auto_host_candidate_from_interfaces()?,
+        )),
+    }
+}
+
+fn auto_host_candidate_from_interfaces() -> miette::Result<AutoHostCandidate> {
+    let addrs = if_addrs::get_if_addrs()
+        .into_diagnostic()
+        .map_err(|err| {
+            miette::miette!(
+                "failed to enumerate network interfaces for --host\nhelp: pass --host <IP> explicitly or check the network\ncaused by: {err}"
+            )
+        })?
+        .into_iter()
+        .map(|addr| addr.ip())
+        .collect::<Vec<_>>();
+    auto_host_candidate_from_addresses(&addrs, default_route_ipv4())
+}
+
+fn auto_host_candidate_from_addresses(
+    addrs: &[IpAddr],
+    default_route: Option<IpAddr>,
+) -> miette::Result<AutoHostCandidate> {
+    let candidate = peitho::remote_url::remote_url_candidates(addrs, default_route, 0, None)
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            miette::miette!(
+                "no non-loopback network address found for --host\nhelp: pass --host <IP> explicitly or check the network"
+            )
+        })?;
+    Ok(AutoHostCandidate {
+        address: candidate.address,
+        label: candidate.label,
+    })
+}
+
+fn remote_control_target_for_resolved_host(
+    host: &ResolvedPresentHost,
+    port: u16,
+) -> Option<RemoteControlTarget> {
+    match host {
+        ResolvedPresentHost::None => None,
+        ResolvedPresentHost::Explicit(host) => Some(remote_control_target_for_host(*host, port)),
+        ResolvedPresentHost::Auto(candidate) => Some(RemoteControlTarget::Specific(
+            remote_control_endpoint(candidate.address, port, candidate.label),
+        )),
+    }
 }
 
 fn remote_control_target_for_host(host: IpAddr, port: u16) -> RemoteControlTarget {
     if host.is_unspecified() {
         RemoteControlTarget::Candidates(remote_url_candidates_from_interfaces(port, host))
     } else {
-        RemoteControlTarget::Specific(peitho::remote_url::remote_url_for_addr(host, port))
+        RemoteControlTarget::Specific(remote_control_endpoint(
+            host,
+            port,
+            peitho::remote_url::remote_url_label(host),
+        ))
     }
 }
 
-fn remote_control_output(
-    target: &RemoteControlTarget,
-) -> (Vec<String>, Option<&peitho::remote_url::RemoteUrl>) {
+fn remote_control_endpoint(
+    host: IpAddr,
+    port: u16,
+    label: Option<peitho::remote_url::RemoteUrlLabel>,
+) -> RemoteControlEndpoint {
+    RemoteControlEndpoint {
+        url: peitho::remote_url::remote_url_for_addr(host, port),
+        label,
+    }
+}
+
+fn remote_control_output(target: &RemoteControlTarget) -> RemoteControlOutput<'_> {
     match target {
-        RemoteControlTarget::Specific(url) => (vec![format!("remote control: {url}")], Some(url)),
-        RemoteControlTarget::Candidates(candidates) if candidates.is_empty() => (
-            vec!["remote control: no non-loopback network addresses found".to_owned()],
-            None,
-        ),
+        RemoteControlTarget::Specific(endpoint) => RemoteControlOutput {
+            lines: vec![format_remote_control_line(endpoint.label, &endpoint.url)],
+            qr: Some(remote_control_qr(endpoint.label, &endpoint.url)),
+        },
+        RemoteControlTarget::Candidates(candidates) if candidates.is_empty() => {
+            RemoteControlOutput {
+                lines: vec!["remote control: no non-loopback network addresses found".to_owned()],
+                qr: None,
+            }
+        }
         RemoteControlTarget::Candidates(candidates) => {
             let mut lines = Vec::with_capacity(candidates.len());
-            let mut qr_url = None;
+            let mut qr = None;
             for candidate in candidates {
-                if qr_url.is_none() {
-                    qr_url = Some(&candidate.url);
+                if qr.is_none() {
+                    qr = Some(remote_control_qr(candidate.label, &candidate.url));
                 }
-                lines.push(match candidate.label {
-                    Some(label) => {
-                        format!("remote control ({}): {}", label.as_str(), candidate.url)
-                    }
-                    None => format!("remote control: {}", candidate.url),
-                });
+                lines.push(format_remote_control_line(candidate.label, &candidate.url));
             }
-            (lines, qr_url)
+            RemoteControlOutput { lines, qr }
         }
+    }
+}
+
+fn format_remote_control_line(
+    label: Option<peitho::remote_url::RemoteUrlLabel>,
+    url: &peitho::remote_url::RemoteUrl,
+) -> String {
+    match label {
+        Some(label) => format!("remote control ({}): {url}", label.as_str()),
+        None => format!("remote control: {url}"),
+    }
+}
+
+fn remote_control_qr(
+    label: Option<peitho::remote_url::RemoteUrlLabel>,
+    url: &peitho::remote_url::RemoteUrl,
+) -> RemoteControlQr<'_> {
+    RemoteControlQr {
+        url,
+        caption: format_qr_caption(label, url),
+    }
+}
+
+fn format_qr_caption(
+    label: Option<peitho::remote_url::RemoteUrlLabel>,
+    url: &peitho::remote_url::RemoteUrl,
+) -> String {
+    match label {
+        Some(label) => format!("scan to open ({}): {url}", label.as_str()),
+        None => format!("scan to open: {url}"),
     }
 }
 
@@ -4862,7 +5001,7 @@ contexts:
         match cli.command {
             Command::Present { input, host, .. } => {
                 assert_eq!(input, PathBuf::from("deck.md"));
-                assert_eq!(host, Some("100.64.0.5".parse().unwrap()));
+                assert_eq!(host, Some(Some("100.64.0.5".parse().unwrap())));
             }
             Command::Build { .. }
             | Command::Lint { .. }
@@ -4879,13 +5018,10 @@ contexts:
     }
 
     #[test]
-    fn present_command_accepts_bare_host_as_ipv4_wildcard() {
-        let bare = Cli::parse_from(["peitho", "present", "deck.md", "--host"]);
-        let explicit = Cli::parse_from(["peitho", "present", "deck.md", "--host", "0.0.0.0"]);
-        let bare_host = present_host_from_cli(bare);
+    fn present_command_accepts_bare_host_as_auto_select() {
+        let cli = Cli::parse_from(["peitho", "present", "deck.md", "--host"]);
 
-        assert_eq!(bare_host, Some("0.0.0.0".parse().unwrap()));
-        assert_eq!(present_host_from_cli(explicit), bare_host);
+        assert_eq!(present_host_from_cli(cli), Some(None));
     }
 
     #[test]
@@ -4913,7 +5049,7 @@ contexts:
             no_serve: true,
             no_presenter: false,
             presenter_windowed: false,
-            host: Some("100.64.0.5".parse().unwrap()),
+            host: Some(Some("100.64.0.5".parse().unwrap())),
         };
 
         let err = validate_present_options(&options).unwrap_err();
@@ -4934,7 +5070,7 @@ contexts:
             no_serve: false,
             no_presenter: false,
             presenter_windowed: false,
-            host: Some("127.0.0.1".parse().unwrap()),
+            host: Some(Some("127.0.0.1".parse().unwrap())),
         };
 
         let err = validate_present_options(&options).unwrap_err();
@@ -4944,30 +5080,115 @@ contexts:
     }
 
     #[test]
-    fn remote_control_lines_format_specific_host() {
-        let target = remote_control_target_for_host("100.64.0.5".parse().unwrap(), 3000);
-        let (lines, qr_url) = remote_control_output(&target);
+    fn auto_host_candidate_selects_vpn_over_lan_default_route() {
+        let candidate = auto_host_candidate_from_addresses(
+            &[
+                "192.168.1.20".parse().unwrap(),
+                "100.100.10.5".parse().unwrap(),
+            ],
+            Some("192.168.1.20".parse().unwrap()),
+        )
+        .unwrap();
 
-        assert_eq!(lines, vec!["remote control: http://100.64.0.5:3000/remote"]);
+        assert_eq!(candidate.address, "100.100.10.5".parse::<IpAddr>().unwrap());
         assert_eq!(
-            qr_url.unwrap().as_str(),
-            remote_url_from_control_line(&lines[0])
+            candidate.label,
+            Some(peitho::remote_url::RemoteUrlLabel::Vpn)
+        );
+    }
+
+    #[test]
+    fn auto_host_candidate_selects_lan_default_route_without_vpn() {
+        let candidate = auto_host_candidate_from_addresses(
+            &[
+                "192.168.1.20".parse().unwrap(),
+                "10.0.0.15".parse().unwrap(),
+            ],
+            Some("10.0.0.15".parse().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(candidate.address, "10.0.0.15".parse::<IpAddr>().unwrap());
+        assert_eq!(candidate.label, None);
+    }
+
+    #[test]
+    fn auto_host_candidate_errors_without_non_loopback_addresses() {
+        let err = auto_host_candidate_from_addresses(
+            &[
+                "127.0.0.1".parse().unwrap(),
+                "169.254.10.20".parse().unwrap(),
+                "::1".parse().unwrap(),
+                "fe80::1".parse().unwrap(),
+            ],
+            None,
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("no non-loopback network address"));
+        assert!(message.contains("help: pass --host <IP>"));
+        assert!(message.contains("check the network"));
+    }
+
+    #[test]
+    fn remote_control_lines_label_specific_vpn_host() {
+        let target = remote_control_target_for_host("100.64.0.5".parse().unwrap(), 3000);
+        let output = remote_control_output(&target);
+
+        assert_eq!(
+            output.lines,
+            vec!["remote control (VPN): http://100.64.0.5:3000/remote"]
+        );
+        assert_eq!(
+            output.qr.as_ref().unwrap().url.as_str(),
+            remote_url_from_control_line(&output.lines[0])
+        );
+        assert_eq!(
+            output.qr.unwrap().caption,
+            "scan to open (VPN): http://100.64.0.5:3000/remote"
+        );
+    }
+
+    #[test]
+    fn remote_control_lines_leave_specific_lan_host_unlabeled() {
+        let target = remote_control_target_for_host("192.168.1.20".parse().unwrap(), 3000);
+        let output = remote_control_output(&target);
+
+        assert_eq!(
+            output.lines,
+            vec!["remote control: http://192.168.1.20:3000/remote"]
+        );
+        assert_eq!(
+            output.qr.as_ref().unwrap().url.as_str(),
+            remote_url_from_control_line(&output.lines[0])
+        );
+        assert_eq!(
+            output.qr.unwrap().caption,
+            "scan to open: http://192.168.1.20:3000/remote"
         );
     }
 
     #[test]
     fn remote_control_lines_bracket_specific_ipv6_host() {
         let target = remote_control_target_for_host("2001:db8::5".parse().unwrap(), 3000);
-        let (lines, qr_url) = remote_control_output(&target);
+        let output = remote_control_output(&target);
 
         assert_eq!(
-            lines,
+            output.lines,
             vec!["remote control: http://[2001:db8::5]:3000/remote"]
         );
-        assert_eq!(qr_url.unwrap().as_str(), "http://[2001:db8::5]:3000/remote");
         assert_eq!(
-            qr_url.unwrap().as_str(),
-            remote_url_from_control_line(&lines[0])
+            output.qr.as_ref().unwrap().url.as_str(),
+            "http://[2001:db8::5]:3000/remote"
+        );
+        assert_eq!(
+            output.qr.as_ref().unwrap().url.as_str(),
+            remote_url_from_control_line(&output.lines[0])
+        );
+        assert_eq!(
+            output.qr.unwrap().caption,
+            "scan to open: http://[2001:db8::5]:3000/remote"
         );
     }
 
@@ -4985,32 +5206,36 @@ contexts:
         );
 
         let target = RemoteControlTarget::Candidates(candidates);
-        let (lines, qr_url) = remote_control_output(&target);
+        let output = remote_control_output(&target);
 
         assert_eq!(
-            lines,
+            output.lines,
             vec![
-                "remote control (Tailscale): http://100.100.10.5:3000/remote",
+                "remote control (VPN): http://100.100.10.5:3000/remote",
                 "remote control: http://10.0.0.15:3000/remote",
                 "remote control: http://192.168.1.20:3000/remote"
             ]
         );
         assert_eq!(
-            qr_url.unwrap().as_str(),
-            remote_url_from_control_line(&lines[0])
+            output.qr.as_ref().unwrap().url.as_str(),
+            remote_url_from_control_line(&output.lines[0])
+        );
+        assert_eq!(
+            output.qr.unwrap().caption,
+            "scan to open (VPN): http://100.100.10.5:3000/remote"
         );
     }
 
     #[test]
     fn remote_control_lines_show_when_unspecified_host_has_no_candidates() {
         let target = RemoteControlTarget::Candidates(Vec::new());
-        let (lines, qr_url) = remote_control_output(&target);
+        let output = remote_control_output(&target);
 
         assert_eq!(
-            lines,
+            output.lines,
             vec!["remote control: no non-loopback network addresses found"]
         );
-        assert!(qr_url.is_none());
+        assert!(output.qr.is_none());
     }
 
     fn remote_url_from_control_line(line: &str) -> &str {
@@ -5020,7 +5245,7 @@ contexts:
         &line[start..]
     }
 
-    fn present_host_from_cli(cli: Cli) -> Option<IpAddr> {
+    fn present_host_from_cli(cli: Cli) -> Option<Option<IpAddr>> {
         match cli.command {
             Command::Present { host, .. } => host,
             Command::Build { .. }

--- a/crates/peitho/src/qr.rs
+++ b/crates/peitho/src/qr.rs
@@ -1,0 +1,110 @@
+use qrcodegen::{QrCode, QrCodeEcc};
+
+const QUIET_ZONE_MODULES: i32 = 2;
+
+pub fn qr_unicode_lines(text: &str) -> Result<Vec<String>, qrcodegen::DataTooLong> {
+    let qr = QrCode::encode_text(text, QrCodeEcc::Low)?;
+    let size = qr.size();
+    let total_modules = size + QUIET_ZONE_MODULES * 2;
+    let mut lines = Vec::with_capacity(half_block_line_count(total_modules));
+
+    let mut top_y = -QUIET_ZONE_MODULES;
+    while top_y < size + QUIET_ZONE_MODULES {
+        let bottom_y = top_y + 1;
+        let mut line = String::with_capacity(total_modules as usize * 3);
+        for x in -QUIET_ZONE_MODULES..size + QUIET_ZONE_MODULES {
+            let top = module_with_quiet_zone(&qr, x, top_y);
+            let bottom = module_with_quiet_zone(&qr, x, bottom_y);
+            line.push(match (top, bottom) {
+                (true, true) => '█',
+                (true, false) => '▀',
+                (false, true) => '▄',
+                (false, false) => ' ',
+            });
+        }
+        lines.push(line);
+        top_y += 2;
+    }
+
+    Ok(lines)
+}
+
+fn module_with_quiet_zone(qr: &QrCode, x: i32, y: i32) -> bool {
+    (0..qr.size()).contains(&x) && (0..qr.size()).contains(&y) && qr.get_module(x, y)
+}
+
+fn half_block_line_count(module_count: i32) -> usize {
+    debug_assert!(module_count >= 0);
+    ((module_count / 2) + (module_count % 2)) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qrcodegen::{QrCode, QrCodeEcc};
+
+    const QUIET_ZONE: usize = 2;
+
+    #[test]
+    fn qr_unicode_lines_renders_structural_shape_with_quiet_zone() {
+        let text = "http://100.64.0.5:3000/remote";
+        let qr = QrCode::encode_text(text, QrCodeEcc::Low).unwrap();
+        let expected_width = qr.size() as usize + QUIET_ZONE * 2;
+        let expected_height = expected_width / 2 + usize::from(expected_width & 1 != 0);
+
+        let lines = qr_unicode_lines(text).unwrap();
+
+        assert_eq!(lines.len(), expected_height);
+        assert!(lines[0].chars().all(|ch| ch == ' '));
+        assert!(lines[1].starts_with("  █▀▀▀▀▀█"));
+        assert!(lines.iter().all(|line| !line.contains('\u{1b}')));
+        assert!(lines
+            .iter()
+            .all(|line| line.chars().count() == expected_width));
+    }
+
+    #[test]
+    fn qr_unicode_lines_uses_half_blocks_for_odd_content_row() {
+        let text = "https://x.test/r";
+        let qr = QrCode::encode_text(text, QrCodeEcc::Low).unwrap();
+        let total_modules = qr.size() as usize + QUIET_ZONE * 2;
+
+        let lines = qr_unicode_lines(text).unwrap();
+
+        assert_eq!(total_modules % 2, 1);
+        assert!(lines.len() >= 2);
+        assert!(lines[lines.len() - 2].contains('▀'));
+        assert!(lines.last().unwrap().chars().all(|ch| ch == ' '));
+    }
+
+    #[test]
+    fn qr_unicode_lines_is_deterministic_for_short_text() {
+        let expected = [
+            ".........................",
+            "..█▀▀▀▀▀█.██.▄..█▀▀▀▀▀█..",
+            "..█.███.█.▀█▀▀█.█.███.█..",
+            "..█.▀▀▀.█.▄█▀.▀.█.▀▀▀.█..",
+            "..▀▀▀▀▀▀▀.█.█▄█.▀▀▀▀▀▀▀..",
+            "..▄▄█▀▀▄▀▄▀▀.█.█▀█.▄█▀█..",
+            "..▀█▀█▄▄▀█▄▀█▄..▄▄███▀...",
+            "..▀▀..▀.▀▀▄▀▄█▄▄▀▄▀..▄▄..",
+            "..█▀▀▀▀▀█..█▄▀..▀▀▄██▀▄..",
+            "..█.███.█.██.▄..▄▄██▄▀...",
+            "..█.▀▀▀.█.▀▀█▀██▄▄.▄█....",
+            "..▀▀▀▀▀▀▀...▀▀.▀▀▀▀..▀...",
+            ".........................",
+        ]
+        .into_iter()
+        .map(|line| line.replace('.', " "))
+        .collect::<Vec<_>>();
+
+        assert_eq!(qr_unicode_lines("peitho").unwrap(), expected);
+    }
+
+    #[test]
+    fn qr_unicode_lines_returns_error_for_over_capacity_text() {
+        let text = "x".repeat(3 * 1024 + 1);
+
+        assert!(qr_unicode_lines(&text).is_err());
+    }
+}

--- a/crates/peitho/src/remote_url.rs
+++ b/crates/peitho/src/remote_url.rs
@@ -1,10 +1,25 @@
-use std::{collections::HashSet, net::IpAddr};
+use std::{collections::HashSet, fmt, net::IpAddr};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteUrl(String);
+
+impl RemoteUrl {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for RemoteUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteUrlCandidate {
     pub address: IpAddr,
     pub label: Option<RemoteUrlLabel>,
-    pub url: String,
+    pub url: RemoteUrl,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,11 +84,11 @@ fn remote_url_label(address: IpAddr) -> Option<RemoteUrlLabel> {
     is_tailscale_addr(address).then_some(RemoteUrlLabel::Tailscale)
 }
 
-pub fn remote_url_for_addr(address: IpAddr, port: u16) -> String {
-    match address {
+pub fn remote_url_for_addr(address: IpAddr, port: u16) -> RemoteUrl {
+    RemoteUrl(match address {
         IpAddr::V4(address) => format!("http://{address}:{port}/remote"),
         IpAddr::V6(address) => format!("http://[{address}]:{port}/remote"),
-    }
+    })
 }
 
 fn is_excluded_addr(address: IpAddr) -> bool {
@@ -274,6 +289,9 @@ mod tests {
     fn remote_url_candidates_bracket_ipv6_urls() {
         let candidates = remote_url_candidates(&["2001:db8::5".parse().unwrap()], None, 8080, None);
 
-        assert_eq!(candidates[0].url, "http://[2001:db8::5]:8080/remote");
+        assert_eq!(
+            candidates[0].url.as_str(),
+            "http://[2001:db8::5]:8080/remote"
+        );
     }
 }

--- a/crates/peitho/src/remote_url.rs
+++ b/crates/peitho/src/remote_url.rs
@@ -71,9 +71,9 @@ fn matches_bound_wildcard_family(address: IpAddr, bound_wildcard: Option<IpAddr>
 }
 
 fn candidate_rank(address: IpAddr, default_route: Option<IpAddr>) -> u8 {
-    if Some(address) == default_route {
+    if is_tailscale_addr(address) {
         0
-    } else if is_tailscale_addr(address) {
+    } else if Some(address) == default_route {
         1
     } else {
         2
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_url_candidates_order_default_route_then_tailscale_then_rest() {
+    fn remote_url_candidates_order_tailscale_then_default_route_then_rest() {
         let candidates = remote_url_candidates(
             &[v4(192, 168, 1, 20), v4(100, 100, 10, 5), v4(10, 0, 0, 15)],
             Some(v4(10, 0, 0, 15)),
@@ -187,12 +187,34 @@ mod tests {
                 .map(|candidate| candidate.url.as_str())
                 .collect::<Vec<_>>(),
             vec![
-                "http://10.0.0.15:3000/remote",
                 "http://100.100.10.5:3000/remote",
+                "http://10.0.0.15:3000/remote",
                 "http://192.168.1.20:3000/remote"
             ]
         );
-        assert_eq!(candidates[1].label, Some(RemoteUrlLabel::Tailscale));
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+    }
+
+    #[test]
+    fn remote_url_candidates_order_default_route_first_without_tailscale() {
+        let candidates = remote_url_candidates(
+            &[v4(192, 168, 1, 20), v4(10, 0, 0, 15), v4(172, 16, 0, 7)],
+            Some(v4(10, 0, 0, 15)),
+            3000,
+            None,
+        );
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "http://10.0.0.15:3000/remote",
+                "http://192.168.1.20:3000/remote",
+                "http://172.16.0.7:3000/remote"
+            ]
+        );
     }
 
     #[test]

--- a/crates/peitho/src/remote_url.rs
+++ b/crates/peitho/src/remote_url.rs
@@ -24,13 +24,13 @@ pub struct RemoteUrlCandidate {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteUrlLabel {
-    Tailscale,
+    Vpn,
 }
 
 impl RemoteUrlLabel {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Tailscale => "Tailscale",
+            Self::Vpn => "VPN",
         }
     }
 }
@@ -71,7 +71,7 @@ fn matches_bound_wildcard_family(address: IpAddr, bound_wildcard: Option<IpAddr>
 }
 
 fn candidate_rank(address: IpAddr, default_route: Option<IpAddr>) -> u8 {
-    if is_tailscale_addr(address) {
+    if is_mesh_vpn_addr(address) {
         0
     } else if Some(address) == default_route {
         1
@@ -80,8 +80,8 @@ fn candidate_rank(address: IpAddr, default_route: Option<IpAddr>) -> u8 {
     }
 }
 
-fn remote_url_label(address: IpAddr) -> Option<RemoteUrlLabel> {
-    is_tailscale_addr(address).then_some(RemoteUrlLabel::Tailscale)
+pub fn remote_url_label(address: IpAddr) -> Option<RemoteUrlLabel> {
+    is_mesh_vpn_addr(address).then_some(RemoteUrlLabel::Vpn)
 }
 
 pub fn remote_url_for_addr(address: IpAddr, port: u16) -> RemoteUrl {
@@ -108,13 +108,15 @@ fn is_link_local_addr(address: IpAddr) -> bool {
     }
 }
 
-fn is_tailscale_addr(address: IpAddr) -> bool {
+fn is_mesh_vpn_addr(address: IpAddr) -> bool {
     match address {
         IpAddr::V4(address) => {
+            // Tailscale's CGNAT range; other mesh VPNs can share this heuristic range.
             let octets = address.octets();
             octets[0] == 100 && (64..=127).contains(&octets[1])
         }
         IpAddr::V6(address) => {
+            // Tailscale's ULA prefix; label remains generic because this is heuristic.
             let segments = address.segments();
             segments[0] == 0xfd7a && segments[1] == 0x115c && segments[2] == 0xa1e0
         }
@@ -155,25 +157,25 @@ mod tests {
     }
 
     #[test]
-    fn remote_url_candidates_label_cgnat_as_tailscale() {
+    fn remote_url_candidates_label_cgnat_as_vpn() {
         let candidates =
             remote_url_candidates(&[v4(100, 64, 0, 1), v4(100, 127, 255, 254)], None, 80, None);
 
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
-        assert_eq!(candidates[1].label, Some(RemoteUrlLabel::Tailscale));
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Vpn));
+        assert_eq!(candidates[1].label, Some(RemoteUrlLabel::Vpn));
     }
 
     #[test]
-    fn remote_url_candidates_label_tailscale_ipv6_ula() {
+    fn remote_url_candidates_label_mesh_vpn_ipv6_ula() {
         let candidates =
             remote_url_candidates(&["fd7a:115c:a1e0::1".parse().unwrap()], None, 80, None);
 
-        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Vpn));
     }
 
     #[test]
-    fn remote_url_candidates_order_tailscale_then_default_route_then_rest() {
+    fn remote_url_candidates_order_vpn_then_default_route_then_rest() {
         let candidates = remote_url_candidates(
             &[v4(192, 168, 1, 20), v4(100, 100, 10, 5), v4(10, 0, 0, 15)],
             Some(v4(10, 0, 0, 15)),
@@ -192,11 +194,11 @@ mod tests {
                 "http://192.168.1.20:3000/remote"
             ]
         );
-        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Vpn));
     }
 
     #[test]
-    fn remote_url_candidates_order_default_route_first_without_tailscale() {
+    fn remote_url_candidates_order_default_route_first_without_vpn() {
         let candidates = remote_url_candidates(
             &[v4(192, 168, 1, 20), v4(10, 0, 0, 15), v4(172, 16, 0, 7)],
             Some(v4(10, 0, 0, 15)),
@@ -218,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_url_candidates_order_tailscale_ipv6_before_rest() {
+    fn remote_url_candidates_order_vpn_ipv6_before_rest() {
         let candidates = remote_url_candidates(
             &[
                 "2001:db8::5".parse().unwrap(),
@@ -239,7 +241,7 @@ mod tests {
                 "http://[2001:db8::5]:3000/remote"
             ]
         );
-        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Tailscale));
+        assert_eq!(candidates[0].label, Some(RemoteUrlLabel::Vpn));
     }
 
     #[test]

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -20,7 +20,29 @@ fn present_help_lists_no_presenter_flag() {
         .args(["present", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("--no-presenter"));
+        .stdout(predicate::str::contains("--no-presenter"))
+        .stdout(predicate::str::contains("--host [<IP>]"))
+        .stdout(predicate::str::contains("bare --host uses 0.0.0.0"));
+}
+
+#[test]
+fn present_bare_host_matches_explicit_wildcard_in_cli_path() {
+    let bare = Command::cargo_bin("peitho")
+        .unwrap()
+        .args(["present", "--no-serve", "--host"])
+        .output()
+        .unwrap();
+    let explicit = Command::cargo_bin("peitho")
+        .unwrap()
+        .args(["present", "--no-serve", "--host", "0.0.0.0"])
+        .output()
+        .unwrap();
+
+    assert!(!bare.status.success());
+    assert_eq!(bare.status.code(), explicit.status.code());
+    assert_eq!(bare.stdout, explicit.stdout);
+    assert_eq!(bare.stderr, explicit.stderr);
+    assert!(String::from_utf8_lossy(&bare.stderr).contains("--host requires the present server"));
 }
 
 #[test]

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -22,26 +22,21 @@ fn present_help_lists_no_presenter_flag() {
         .success()
         .stdout(predicate::str::contains("--no-presenter"))
         .stdout(predicate::str::contains("--host [<IP>]"))
-        .stdout(predicate::str::contains("bare --host uses 0.0.0.0"));
+        .stdout(predicate::str::contains(
+            "bare --host picks the best address automatically",
+        ))
+        .stdout(predicate::str::contains("VPN, e.g. Tailscale, preferred"));
 }
 
 #[test]
-fn present_bare_host_matches_explicit_wildcard_in_cli_path() {
+fn present_bare_host_requires_server_in_cli_path() {
     let bare = Command::cargo_bin("peitho")
         .unwrap()
         .args(["present", "--no-serve", "--host"])
         .output()
         .unwrap();
-    let explicit = Command::cargo_bin("peitho")
-        .unwrap()
-        .args(["present", "--no-serve", "--host", "0.0.0.0"])
-        .output()
-        .unwrap();
 
     assert!(!bare.status.success());
-    assert_eq!(bare.status.code(), explicit.status.code());
-    assert_eq!(bare.stdout, explicit.stdout);
-    assert_eq!(bare.stderr, explicit.stderr);
     assert!(String::from_utf8_lossy(&bare.stderr).contains("--host requires the present server"));
 }
 
@@ -744,72 +739,9 @@ fn present_no_open_server_prints_assigned_url() {
 
 #[test]
 fn present_host_prints_remote_qr_after_remote_control_lines() {
-    let dir = tempdir().unwrap();
-    let fixture = Fixture::write(dir.path());
-    let shell = dir.path().join("shell.js");
-    fs::write(
-        &shell,
-        "export function mountPresentShell() {}\nexport function installKeyboardNavigation() {}\nexport function installSyncBridge() {}\nexport function serverSyncChannelFactory() {}\n",
-    )
-    .unwrap();
-
-    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("peitho"))
-        .current_dir(dir.path())
-        .args(fixture.present_args(&shell))
-        .args(["--no-open", "--port", "0", "--host", "0.0.0.0"])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let stdout = child.stdout.take().unwrap();
-    let mut stderr = child.stderr.take().unwrap();
-    let (tx, rx) = mpsc::channel();
-    let reader = std::thread::spawn(move || {
-        let mut lines = Vec::new();
-        for line in BufReader::new(stdout).lines() {
-            let line = line.unwrap();
-            let done =
-                line.contains('█') || line.contains("no non-loopback network addresses found");
-            lines.push(line);
-            if done {
-                tx.send(lines).unwrap();
-                break;
-            }
-        }
-    });
-    let lines = match rx.recv_timeout(Duration::from_secs(5)) {
-        Ok(lines) => lines,
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            let _ = child.kill();
-            let status = child.wait().unwrap();
-            reader.join().unwrap();
-            let mut stderr_text = String::new();
-            stderr.read_to_string(&mut stderr_text).unwrap();
-            if !status.success() && stderr_text.contains("failed to bind present server") {
-                eprintln!("skipping QR assertion: present server bind blocked: {stderr_text}");
-                return;
-            }
-            panic!("present server exited before printing remote control output: {stderr_text}");
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            child.kill().unwrap();
-            child.wait().unwrap();
-            reader.join().unwrap();
-            panic!("present server did not print remote control output within 5 seconds");
-        }
-    };
-    child.kill().unwrap();
-    child.wait().unwrap();
-    reader.join().unwrap();
-
-    if lines
-        .iter()
-        .any(|line| line.contains("no non-loopback network addresses found"))
-    {
-        eprintln!("skipping QR assertion: no non-loopback network addresses found");
+    let Some(lines) = capture_present_remote_output(&["--host", "0.0.0.0"]) else {
         return;
-    }
+    };
 
     let remote_line_indexes = lines
         .iter()
@@ -823,10 +755,43 @@ fn present_host_prints_remote_qr_after_remote_control_lines() {
     let first_url = remote_control_url_from_line(&lines[remote_line_indexes[0]]);
     let blank_index = remote_line_indexes.last().unwrap() + 1;
     assert_eq!(lines[blank_index], "");
+    assert_eq!(
+        lines[blank_index + 1],
+        lines[remote_line_indexes[0]].replacen("remote control", "scan to open", 1)
+    );
 
     let expected_qr = peitho::qr::qr_unicode_lines(first_url).unwrap();
-    assert_eq!(lines[blank_index + 1], expected_qr[0]);
-    assert_eq!(lines[blank_index + 2], expected_qr[1]);
+    assert_eq!(lines[blank_index + 2], expected_qr[0]);
+    assert_eq!(lines[blank_index + 3], expected_qr[1]);
+}
+
+#[test]
+fn present_bare_host_prints_single_remote_line_caption_and_qr() {
+    let Some(lines) = capture_present_remote_output(&["--host"]) else {
+        return;
+    };
+
+    let remote_line_indexes = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| line.starts_with("remote control").then_some(index))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        remote_line_indexes.len(),
+        1,
+        "bare --host should print exactly one remote control line: {lines:?}"
+    );
+    let first_url = remote_control_url_from_line(&lines[remote_line_indexes[0]]);
+    let blank_index = remote_line_indexes[0] + 1;
+    assert_eq!(lines[blank_index], "");
+    assert_eq!(
+        lines[blank_index + 1],
+        lines[remote_line_indexes[0]].replacen("remote control", "scan to open", 1)
+    );
+
+    let expected_qr = peitho::qr::qr_unicode_lines(first_url).unwrap();
+    assert_eq!(lines[blank_index + 2], expected_qr[0]);
+    assert_eq!(lines[blank_index + 3], expected_qr[1]);
 }
 
 #[test]
@@ -1093,6 +1058,82 @@ fn response_body(response: &str) -> &str {
         .split_once("\r\n\r\n")
         .map(|(_, body)| body)
         .unwrap_or(response)
+}
+
+fn capture_present_remote_output(host_args: &[&str]) -> Option<Vec<String>> {
+    let dir = tempdir().unwrap();
+    let fixture = Fixture::write(dir.path());
+    let shell = dir.path().join("shell.js");
+    fs::write(
+        &shell,
+        "export function mountPresentShell() {}\nexport function installKeyboardNavigation() {}\nexport function installSyncBridge() {}\nexport function serverSyncChannelFactory() {}\n",
+    )
+    .unwrap();
+
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("peitho"))
+        .current_dir(dir.path())
+        .args(fixture.present_args(&shell))
+        .args(["--no-open", "--port", "0"])
+        .args(host_args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut lines = Vec::new();
+        for line in BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            let done =
+                line.contains('█') || line.contains("no non-loopback network addresses found");
+            lines.push(line);
+            if done {
+                tx.send(lines).unwrap();
+                break;
+            }
+        }
+    });
+
+    let lines = match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(lines) => lines,
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = child.kill();
+            let status = child.wait().unwrap();
+            reader.join().unwrap();
+            let mut stderr_text = String::new();
+            stderr.read_to_string(&mut stderr_text).unwrap();
+            if !status.success()
+                && (stderr_text.contains("failed to bind present server")
+                    || stderr_text.contains("no non-loopback network address found for --host"))
+            {
+                eprintln!("skipping QR assertion: {stderr_text}");
+                return None;
+            }
+            panic!("present server exited before printing remote control output: {stderr_text}");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            reader.join().unwrap();
+            panic!("present server did not print remote control output within 5 seconds");
+        }
+    };
+    child.kill().unwrap();
+    child.wait().unwrap();
+    reader.join().unwrap();
+
+    if lines
+        .iter()
+        .any(|line| line.contains("no non-loopback network addresses found"))
+    {
+        eprintln!("skipping QR assertion: no non-loopback network addresses found");
+        return None;
+    }
+
+    Some(lines)
 }
 
 fn join_present_server(handle: thread::JoinHandle<miette::Result<()>>, timeout: Duration) {

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -682,27 +682,129 @@ fn present_no_open_server_prints_assigned_url() {
         .unwrap();
 
     let stdout = child.stdout.take().unwrap();
-    let (tx, rx) = mpsc::channel();
+    let (serving_tx, serving_rx) = mpsc::channel();
+    let (lines_tx, lines_rx) = mpsc::channel();
     let reader = std::thread::spawn(move || {
-        let mut tx = Some(tx);
+        let mut lines = Vec::new();
+        let mut serving_tx = Some(serving_tx);
         for line in BufReader::new(stdout).lines() {
             let line = line.unwrap();
             if line.contains("serving presentation at") {
-                if let Some(tx) = tx.take() {
-                    tx.send(line).unwrap();
+                if let Some(tx) = serving_tx.take() {
+                    tx.send(line.clone()).unwrap();
                 }
             }
+            lines.push(line);
         }
+        lines_tx.send(lines).unwrap();
     });
-    let line = rx
+    let line = serving_rx
         .recv_timeout(Duration::from_secs(5))
         .expect("present server did not print serving URL within 5 seconds");
     child.kill().unwrap();
     child.wait().unwrap();
     reader.join().unwrap();
+    let lines = lines_rx.recv().unwrap();
 
     assert!(line.contains("http://127.0.0.1:"));
     assert!(line.contains("/present.html"));
+    let serving_index = lines
+        .iter()
+        .position(|captured| captured == &line)
+        .expect("captured serving line");
+    assert!(
+        !lines[serving_index + 1..]
+            .iter()
+            .any(|line| contains_qr_half_block(line)),
+        "plain present without --host printed QR-looking output: {lines:?}"
+    );
+}
+
+#[test]
+fn present_host_prints_remote_qr_after_remote_control_lines() {
+    let dir = tempdir().unwrap();
+    let fixture = Fixture::write(dir.path());
+    let shell = dir.path().join("shell.js");
+    fs::write(
+        &shell,
+        "export function mountPresentShell() {}\nexport function installKeyboardNavigation() {}\nexport function installSyncBridge() {}\nexport function serverSyncChannelFactory() {}\n",
+    )
+    .unwrap();
+
+    let mut child = std::process::Command::new(assert_cmd::cargo::cargo_bin("peitho"))
+        .current_dir(dir.path())
+        .args(fixture.present_args(&shell))
+        .args(["--no-open", "--port", "0", "--host", "0.0.0.0"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = child.stdout.take().unwrap();
+    let mut stderr = child.stderr.take().unwrap();
+    let (tx, rx) = mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        let mut lines = Vec::new();
+        for line in BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            let done =
+                line.contains('█') || line.contains("no non-loopback network addresses found");
+            lines.push(line);
+            if done {
+                tx.send(lines).unwrap();
+                break;
+            }
+        }
+    });
+    let lines = match rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(lines) => lines,
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            let _ = child.kill();
+            let status = child.wait().unwrap();
+            reader.join().unwrap();
+            let mut stderr_text = String::new();
+            stderr.read_to_string(&mut stderr_text).unwrap();
+            if !status.success() && stderr_text.contains("failed to bind present server") {
+                eprintln!("skipping QR assertion: present server bind blocked: {stderr_text}");
+                return;
+            }
+            panic!("present server exited before printing remote control output: {stderr_text}");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            child.kill().unwrap();
+            child.wait().unwrap();
+            reader.join().unwrap();
+            panic!("present server did not print remote control output within 5 seconds");
+        }
+    };
+    child.kill().unwrap();
+    child.wait().unwrap();
+    reader.join().unwrap();
+
+    if lines
+        .iter()
+        .any(|line| line.contains("no non-loopback network addresses found"))
+    {
+        eprintln!("skipping QR assertion: no non-loopback network addresses found");
+        return;
+    }
+
+    let remote_line_indexes = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(index, line)| line.starts_with("remote control").then_some(index))
+        .collect::<Vec<_>>();
+    assert!(
+        !remote_line_indexes.is_empty(),
+        "expected remote control lines in {lines:?}"
+    );
+    let first_url = remote_control_url_from_line(&lines[remote_line_indexes[0]]);
+    let blank_index = remote_line_indexes.last().unwrap() + 1;
+    assert_eq!(lines[blank_index], "");
+
+    let expected_qr = peitho::qr::qr_unicode_lines(first_url).unwrap();
+    assert_eq!(lines[blank_index + 1], expected_qr[0]);
+    assert_eq!(lines[blank_index + 2], expected_qr[1]);
 }
 
 #[test]
@@ -992,4 +1094,15 @@ fn serving_addr(line: &str) -> SocketAddr {
         .strip_suffix("/present.html")
         .unwrap_or_else(|| panic!("unexpected serving URL line: {line}"));
     host_port.parse().unwrap()
+}
+
+fn remote_control_url_from_line(line: &str) -> &str {
+    let start = line
+        .find("http://")
+        .unwrap_or_else(|| panic!("remote control line did not contain a URL: {line}"));
+    &line[start..]
+}
+
+fn contains_qr_half_block(line: &str) -> bool {
+    line.contains('█') || line.contains('▀') || line.contains('▄')
 }

--- a/docs/plans/2026-07-17-remote-qr.md
+++ b/docs/plans/2026-07-17-remote-qr.md
@@ -72,20 +72,44 @@ byte-identical).
 ## Amendment: bare `--host` and Tailscale-first ranking (2026-07-17)
 
 While verifying the QR live, the author's expectation surfaced: "I thought it
-would just prefer Tailscale by itself." Decisions:
+would just prefer Tailscale by itself." Decisions (the bare-form semantics
+below are the second iteration — the first cut made bare `--host` a
+`0.0.0.0` shorthand, and the author rejected wildcard binding for the bare
+form):
 
-- **`--host` accepts a bare form** (no value): it is shorthand for
-  `--host 0.0.0.0` — bind all interfaces, so the phone can connect over the
-  LAN too (binding only the Tailscale address was rejected as too rigid).
-  Explicit `--host <IP>` remains for tight, single-interface exposure.
+- **`--host` accepts a bare form** (no value): peitho picks the best single
+  address automatically — the top of the Tailscale-first ranking below — and
+  binds **only that address** (plus loopback for the local windows, the same
+  listener shape as an explicit `--host <IP>`). With Tailscale up the
+  exposure is tailnet-only; without it, it falls back to the default-route
+  (LAN) address; with no non-loopback address at all it fails with a
+  line-numbered-style error and help, rather than serving something
+  unreachable. Wildcard binding never happens implicitly — it remains
+  available explicitly via `--host 0.0.0.0` / `--host ::`.
+  In clap terms the option is `Option<Option<IpAddr>>`: absent → loopback
+  only, bare → auto-select, value → that address.
 - **Candidate ranking becomes Tailscale-first**: Tailscale-labeled addresses
   (CGNAT 100.64/10, fd7a:115c:a1e0::/48) rank above the default-route
-  address, then the rest; ordering is stable within each tier. The first
-  candidate feeds both the first printed line and the QR, so scanning always
-  lands on the tailnet-stable URL when Tailscale is up — immune to
-  client-isolated venue Wi-Fi — and degrades to the old default-route-first
-  behavior without Tailscale. This aligns with #289's recommendation of
-  Tailscale as the standard pattern.
+  address, then the rest; ordering is stable within each tier. One ranking
+  drives both decisions: the bare form binds the top candidate, and the
+  explicit-wildcard form orders its printed candidates (first line = QR
+  target) the same way. Scanning therefore always lands on the
+  tailnet-stable URL when Tailscale is up — immune to client-isolated venue
+  Wi-Fi. This aligns with #289's recommendation of Tailscale as the
+  standard pattern.
+- **QR legibility**: the QR block is preceded by a caption line naming the
+  URL it encodes (with its label), e.g.
+  `scan to open (VPN): http://100.x.y.z:PORT/remote`, so the
+  QR-to-URL mapping is self-describing even when the explicit wildcard form
+  prints multiple candidates.
+- **Label wording is generic `VPN`, not `Tailscale`** (author decision
+  2026-07-17): the detection is an address-range heuristic — Tailscale's
+  CGNAT 100.64.0.0/10 and ULA fd7a:115c:a1e0::/48 — which other mesh VPNs
+  (e.g. Netbird) share, so the generic label is the honest one and the
+  false-positive concern disappears. `RemoteUrlLabel::Vpn` renders `VPN`;
+  the detection function is named for what it matches (mesh-VPN address
+  ranges) with the Tailscale ranges recorded in a comment. Docs and help
+  say "VPN (e.g. Tailscale) preferred".
 
 ## Non-goals
 

--- a/docs/plans/2026-07-17-remote-qr.md
+++ b/docs/plans/2026-07-17-remote-qr.md
@@ -1,0 +1,74 @@
+# Terminal QR code for the /remote control URL (Issue #298)
+
+Author decisions (2026-07-17): render the QR **always when `--host` is given**
+(no `--qr` flag — zero-config philosophy; `present` is long-running so the
+terminal-height cost is paid once and not scrolled past), and encode **only
+the top-ranked candidate** (the text lines remain for manual pickup of the
+others).
+
+## Design
+
+- **Dependency**: `qrcodegen` (Nayuki's pure-Rust QR encoder, zero
+  dependencies, tiny). Binary-size impact is negligible next to the embedded
+  Mermaid renderer. ECC level Low is sufficient (the QR is read off a bright
+  terminal at arm's length; smaller symbol wins), version chosen automatically
+  by the encoder.
+- **Rendering**: a new `crates/peitho/src/qr.rs` module with a pure function
+  `qr_unicode_lines(text: &str) -> Result<Vec<String>, qrcodegen::DataTooLong>`
+  (review amendment: over-capacity input must not abort the process — the
+  caller warns on stderr and keeps the text lines) using Unicode half-block
+  characters — two module rows per terminal line via `'█'` (both dark),
+  `'▀'` (top dark), `'▄'` (bottom dark), `' '` (both light) — plus a
+  **2-module quiet zone** on all four sides (half-block rendering makes that
+  one leading/trailing blank terminal line and two leading/trailing spaces
+  per line; the terminal's own margin supplies the rest — this is the
+  compromise most CLIs ship, full ISO quiet zone is 4 modules).
+  Dark modules are the **drawn blocks** (foreground): on the common
+  dark-background terminal this yields an inverted-contrast code, which
+  every mainstream phone scanner decodes; on light terminals it is a
+  standard-contrast code. No ANSI colors — colors would break on themes.
+  Odd total module height renders the final half row with `'▀'`/`' '`.
+- **Wiring seam** (shape settled during adversarial review — two type-level
+  strengthenings over the first cut):
+  - **`RemoteUrl` newtype** in `remote_url.rs` with a private field;
+    `remote_url_for_addr` is the only constructor and
+    `RemoteUrlCandidate.url` carries it. Correct IPv6 bracketing is thereby
+    a type guarantee, not a convention a future caller must remember — a
+    plain `String` URL cannot reach the printer or the QR encoder.
+  - **Single-traversal output**: `remote_control_output(&RemoteControlTarget)
+    -> (Vec<String>, Option<&RemoteUrl>)` produces the text lines and the
+    QR target in one pass, so "the QR encodes the URL on the first printed
+    line" is enforced by construction rather than by Vec-ordering
+    convention. `Specific` → its URL; `Candidates` → the first (already
+    ranked: default route first, Tailscale labeled); empty → `None`.
+  `present` prints the text lines, then a blank line, then the QR when a
+  target exists. No QR without `--host`; no QR when there are no candidates
+  (the no-`--host` case is pinned by a negative integration test; the
+  no-candidates case by a unit test on `remote_control_output`).
+
+## Tasks (TDD)
+
+1. `qr.rs`: `qr_unicode_lines` — tests: encodes a known URL and decodes
+   structurally (dimensions match qrcodegen's `size()` + quiet zone; first
+   content line starts with the finder-pattern run; every line has equal
+   `char` width; odd-size bottom row uses half blocks; deterministic output
+   for a fixed input, asserted against a golden snapshot of a short string).
+2. `main.rs`: `remote_control_output` unit tests for the three target shapes;
+   integration: the present flow with `--host` prints the QR block after the
+   `remote control:` lines (extend the existing test at ~main.rs:4903 and the
+   `crates/peitho/tests/present.rs` `--host` coverage if any asserts on
+   output), and no QR block without `--host`.
+3. Docs: README `--host` section and `site/content/guide/` present page
+   mention the QR (one sentence each) if they document `--host` today —
+   check first; do not add new sections.
+
+## Gates
+
+All CLAUDE.md gates (cargo test ×3, clippy `-D warnings`, fmt, bindings
+drift, npm build/test/typecheck, dist drift — TS untouched so dist must be
+byte-identical).
+
+## Non-goals
+
+- `--qr` flag, QR for non-top candidates, web-page QR rendering, ANSI-color
+  rendering.

--- a/docs/plans/2026-07-17-remote-qr.md
+++ b/docs/plans/2026-07-17-remote-qr.md
@@ -40,7 +40,8 @@ others).
     QR target in one pass, so "the QR encodes the URL on the first printed
     line" is enforced by construction rather than by Vec-ordering
     convention. `Specific` → its URL; `Candidates` → the first (already
-    ranked: default route first, Tailscale labeled); empty → `None`.
+    ranked; ordering superseded by the amendment below: Tailscale first,
+    then default route, then the rest); empty → `None`.
   `present` prints the text lines, then a blank line, then the QR when a
   target exists. No QR without `--host`; no QR when there are no candidates
   (the no-`--host` case is pinned by a negative integration test; the
@@ -67,6 +68,24 @@ others).
 All CLAUDE.md gates (cargo test ×3, clippy `-D warnings`, fmt, bindings
 drift, npm build/test/typecheck, dist drift — TS untouched so dist must be
 byte-identical).
+
+## Amendment: bare `--host` and Tailscale-first ranking (2026-07-17)
+
+While verifying the QR live, the author's expectation surfaced: "I thought it
+would just prefer Tailscale by itself." Decisions:
+
+- **`--host` accepts a bare form** (no value): it is shorthand for
+  `--host 0.0.0.0` — bind all interfaces, so the phone can connect over the
+  LAN too (binding only the Tailscale address was rejected as too rigid).
+  Explicit `--host <IP>` remains for tight, single-interface exposure.
+- **Candidate ranking becomes Tailscale-first**: Tailscale-labeled addresses
+  (CGNAT 100.64/10, fd7a:115c:a1e0::/48) rank above the default-route
+  address, then the rest; ordering is stable within each tier. The first
+  candidate feeds both the first printed line and the QR, so scanning always
+  lands on the tailnet-stable URL when Tailscale is up — immune to
+  client-isolated venue Wi-Fi — and degrades to the old default-route-first
+  behavior without Tailscale. This aligns with #289's recommendation of
+  Tailscale as the standard pattern.
 
 ## Non-goals
 

--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -76,13 +76,14 @@ peitho present --host 100.64.0.5
 
 The local slides and presenter windows still use loopback. A specific
 `--host <IP>` adds a listener for that address and prints exactly one
-`/remote` URL; bare `--host` is shorthand for `--host 0.0.0.0`, binding all
-IPv4 interfaces, while `--host ::` binds the IPv6 dual-stack wildcard where
-the OS supports it. With the bare form, a token immediately after `--host` is
-read as the IP value, so use `peitho present deck.md --host` rather than
+`/remote` URL; bare `--host` picks the best non-loopback address
+automatically with VPN (e.g. Tailscale) preferred, then binds only that
+address plus loopback. Wildcard binding is explicit via `--host 0.0.0.0` or
+`--host ::`; with the bare form, a token immediately after `--host` is read
+as the IP value, so use `peitho present deck.md --host` rather than
 `peitho present --host deck.md`. Peitho renders a terminal QR code for the
-top-ranked remote URL, and the top line plus QR prefer Tailscale when
-available.
+top-ranked remote URL, and the top line plus QR prefer VPN (e.g. Tailscale)
+when available.
 
 ## `peitho export`
 

--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -75,11 +75,14 @@ peitho present --host 100.64.0.5
 ```
 
 The local slides and presenter windows still use loopback. A specific
-`--host` adds a listener for that address and prints exactly one `/remote`
-URL. A wildcard host (`0.0.0.0`/`::`) becomes the single listener, still
-covering loopback, and prints non-loopback `/remote` URL candidates for the
-phone. Peitho also renders a terminal QR code for the top-ranked remote URL.
-A Tailscale address is the recommended host when available.
+`--host <IP>` adds a listener for that address and prints exactly one
+`/remote` URL; bare `--host` is shorthand for `--host 0.0.0.0`, binding all
+IPv4 interfaces, while `--host ::` binds the IPv6 dual-stack wildcard where
+the OS supports it. With the bare form, a token immediately after `--host` is
+read as the IP value, so use `peitho present deck.md --host` rather than
+`peitho present --host deck.md`. Peitho renders a terminal QR code for the
+top-ranked remote URL, and the top line plus QR prefer Tailscale when
+available.
 
 ## `peitho export`
 

--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -78,7 +78,8 @@ The local slides and presenter windows still use loopback. A specific
 `--host` adds a listener for that address and prints exactly one `/remote`
 URL. A wildcard host (`0.0.0.0`/`::`) becomes the single listener, still
 covering loopback, and prints non-loopback `/remote` URL candidates for the
-phone. A Tailscale address is the recommended host when available.
+phone. Peitho also renders a terminal QR code for the top-ranked remote URL.
+A Tailscale address is the recommended host when available.
 
 ## `peitho export`
 


### PR DESCRIPTION
Closes #298

## What

`peitho present --host <IP>` renders a Unicode half-block QR code for the top-ranked `/remote` URL below the existing `remote control:` text lines. Author decisions: always on with `--host` (no flag), top candidate only; the ranked text lines stay.

## How

- **Encoding**: `qrcodegen` 1.8 (pure Rust, zero dependencies), ECC Low, 2-module quiet zone, no ANSI colors (dark modules are the drawn foreground blocks — decodes fine inverted on dark terminals; verified). Over-capacity input returns a `Result` and degrades to a stderr warning — the text lines always print.
- **Type-level guarantees** (three-lenses review): a `RemoteUrl` newtype with a private field and `remote_url_for_addr` as the sole constructor makes correct IPv6 bracketing unforgeable for both the printed lines and the QR; `remote_control_output` derives the text lines and the QR target in one traversal, so "the QR encodes the URL on the first printed line" holds by construction, not by Vec-ordering convention.
- Design record: `docs/plans/2026-07-17-remote-qr.md`.

## Verification

- All gates: `cargo test --workspace` ×3, clippy `-D warnings`, fmt, bindings drift, npm build/test/typecheck (TS untouched; dist byte-identical)
- Adversarial multi-agent review (9 confirmed/plausible findings, all fixed at the root — including replacing an initially vendored hand-written QR encoder with the real crates.io crate) + 5 fresh review rounds (last two clean)
- Live E2E: ran `present --host` on the Tailscale IP and decoded the terminal QR with CoreImage's `CIDetector` (scanner-equivalent) — the payload matches the printed URL exactly; negative test pins that plain `peitho present` prints no QR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC
