### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.8.0"
+version = "1.9.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Release v1.9.0: the phone remote-control feature set.

- #297 Phone remote control via a /remote route on the present server
- #300 feat(remote): richer /remote page with preview, pace, notes, and timer control
- #302 feat(present): terminal QR code for the /remote control URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC