### PR TITLE
Landscape layout for /remote and stacked navigation buttons

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -773,8 +773,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
   <style>
     :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --peitho-canvas-width: __PEITHO_CANVAS_WIDTH__px; --peitho-canvas-height: __PEITHO_CANVAS_HEIGHT__px; --peitho-canvas-aspect: __PEITHO_CANVAS_ASPECT__; }
     html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }
-    body { height: 100vh; height: 100svh; overflow: hidden; }
-    #peitho-remote-root { height: 100vh; height: 100svh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px; padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
+    body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }
+    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px; padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
     .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
     .peitho-remote { width: 100%; max-width: 32rem; margin: 0 auto; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 12px; }
     .peitho-remote-dim-on-end { transition: opacity 120ms ease; }
@@ -831,7 +831,7 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-action-arrow { font-size: 20px; font-weight: 400; line-height: 1; opacity: 0.85; }
     @media (orientation: landscape) and (max-height: 520px) {
       #peitho-remote-root { padding: 12px 14px; padding-left: calc(14px + env(safe-area-inset-left, 0px)); padding-right: calc(14px + env(safe-area-inset-right, 0px)); padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)); }
-      .peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }
+      .peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px; grid-template-columns: min(calc((100dvh - 151px - env(safe-area-inset-bottom, 0px)) * __PEITHO_CANVAS_ASPECT__), 52%) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }
       .peitho-remote-preview { grid-area: 1 / 1 / 2 / 2; max-height: 100%; min-height: 0; }
       .peitho-remote-titlebar { grid-area: 2 / 1 / 3 / 2; }
       .peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }
@@ -1775,8 +1775,9 @@ Paragraph after heading.
         assert!(html.contains(
             "html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }"
         ));
-        assert!(html.contains("body { height: 100vh; height: 100svh; overflow: hidden; }"));
-        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px;"));
+        assert!(html
+            .contains("body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }"));
+        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px;"));
         assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
         assert!(html.contains(".peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-status { flex: none; }"));
         assert!(html.contains(
@@ -1823,7 +1824,8 @@ Paragraph after heading.
         assert!(html.contains(".peitho-remote-actions [data-peitho-direction=\"next\"] { min-height: 60px; border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; font-size: 17px;"));
         assert!(html.contains("@media (orientation: landscape) and (max-height: 520px)"));
         assert!(html.contains("#peitho-remote-root { padding: 12px 14px; padding-left: calc(14px + env(safe-area-inset-left, 0px)); padding-right: calc(14px + env(safe-area-inset-right, 0px)); padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)); }"));
-        assert!(html.contains(".peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }"));
+        assert!(html.contains(".peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px;"));
+        assert!(html.contains("grid-template-columns: min(calc((100dvh - 151px - env(safe-area-inset-bottom, 0px)) * 4 / 3), 52%) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }"));
         assert!(html.contains(
             ".peitho-remote-preview { grid-area: 1 / 1 / 2 / 2; max-height: 100%; min-height: 0; }"
         ));

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -821,14 +821,31 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto; min-height: 0; }
     .peitho-remote-notes-body[data-peitho-empty="true"] { color: #5a6473; font-size: 14px; font-style: italic; }
     .peitho-remote-status { min-height: 1.4em; text-align: center; color: #aab3c2; font-size: 13px; line-height: 1.4; }
-    .peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; flex: none; }
-    .peitho-remote-actions button { min-height: 60px; border-radius: 999px; font: 600 17px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; touch-action: manipulation; }
-    .peitho-remote-actions [data-peitho-direction="prev"] { border: 1px solid #2f3644; background: transparent; color: #dde3ec; }
-    .peitho-remote-actions [data-peitho-direction="next"] { border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; }
+    .peitho-remote-actions { display: flex; flex-direction: column; gap: 10px; flex: none; }
+    .peitho-remote-actions button { border-radius: 999px; font: 600 17px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; touch-action: manipulation; display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
+    .peitho-remote-actions [data-peitho-direction="prev"] { min-height: 48px; border: 1px solid #2f3644; background: transparent; color: #dde3ec; font-size: 15px; }
+    .peitho-remote-actions [data-peitho-direction="next"] { min-height: 60px; border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; font-size: 17px; }
     .peitho-remote-actions button:disabled,
     .peitho-remote-timer-button:disabled,
     .peitho-remote-reset-button:disabled { opacity: 0.32; }
     .peitho-remote-action-arrow { font-size: 20px; font-weight: 400; line-height: 1; opacity: 0.85; }
+    @media (orientation: landscape) and (max-height: 520px) {
+      #peitho-remote-root { padding: 12px 14px; padding-left: calc(14px + env(safe-area-inset-left, 0px)); padding-right: calc(14px + env(safe-area-inset-right, 0px)); padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)); }
+      .peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }
+      .peitho-remote-preview { grid-area: 1 / 1 / 2 / 2; max-height: 100%; min-height: 0; }
+      .peitho-remote-titlebar { grid-area: 2 / 1 / 3 / 2; }
+      .peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }
+      .peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }
+      .peitho-remote-notes { grid-area: 1 / 2 / 3 / 3; }
+      .peitho-remote-status { grid-area: 3 / 2 / 4 / 3; }
+      .peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }
+      .peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }
+      .peitho-remote-actions button { flex-direction: column; border-radius: 20px; }
+      .peitho-remote-actions [data-peitho-direction="prev"] { flex: 1; min-height: 0; }
+      .peitho-remote-actions [data-peitho-direction="next"] { flex: 1.35; min-height: 0; }
+      .peitho-remote-action-arrow { order: -1; font-size: 26px; }
+      .peitho-remote-action-label { font-size: 13px; font-weight: 600; }
+    }
   </style>
 </head>
 <body>
@@ -1797,9 +1814,43 @@ Paragraph after heading.
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));
         assert!(html.contains(
-            ".peitho-remote-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; flex: none;"
+            ".peitho-remote-actions { display: flex; flex-direction: column; gap: 10px; flex: none;"
         ));
-        assert!(html.contains(".peitho-remote-actions button { min-height: 60px; border-radius: 999px; font: 600 17px"));
+        assert!(
+            html.contains(".peitho-remote-actions button { border-radius: 999px; font: 600 17px")
+        );
+        assert!(html.contains(".peitho-remote-actions [data-peitho-direction=\"prev\"] { min-height: 48px; border: 1px solid #2f3644; background: transparent; color: #dde3ec; font-size: 15px;"));
+        assert!(html.contains(".peitho-remote-actions [data-peitho-direction=\"next\"] { min-height: 60px; border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; font-size: 17px;"));
+        assert!(html.contains("@media (orientation: landscape) and (max-height: 520px)"));
+        assert!(html.contains("#peitho-remote-root { padding: 12px 14px; padding-left: calc(14px + env(safe-area-inset-left, 0px)); padding-right: calc(14px + env(safe-area-inset-right, 0px)); padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)); }"));
+        assert!(html.contains(".peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }"));
+        assert!(html.contains(
+            ".peitho-remote-preview { grid-area: 1 / 1 / 2 / 2; max-height: 100%; min-height: 0; }"
+        ));
+        assert!(html.contains(".peitho-remote-titlebar { grid-area: 2 / 1 / 3 / 2; }"));
+        assert!(
+            html.contains(".peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }")
+        );
+        assert!(html.contains(".peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }"));
+        assert!(html.contains(".peitho-remote-notes { grid-area: 1 / 2 / 3 / 3; }"));
+        assert!(html.contains(".peitho-remote-status { grid-area: 3 / 2 / 4 / 3; }"));
+        assert!(
+            html.contains(".peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }")
+        );
+        assert!(
+            html.contains(".peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }")
+        );
+        assert!(html.contains(
+            ".peitho-remote-actions button { flex-direction: column; border-radius: 20px; }"
+        ));
+        assert!(html.contains(
+            ".peitho-remote-actions [data-peitho-direction=\"prev\"] { flex: 1; min-height: 0; }"
+        ));
+        assert!(html.contains(
+            ".peitho-remote-actions [data-peitho-direction=\"next\"] { flex: 1.35; min-height: 0; }"
+        ));
+        assert!(html.contains(".peitho-remote-action-arrow { order: -1; font-size: 26px; }"));
+        assert!(html.contains(".peitho-remote-action-label { font-size: 13px; font-weight: 600; }"));
         assert!(html.contains(
             ".peitho-remote[data-peitho-ended=\"true\"] .peitho-remote-dim-on-end { opacity: 0.35;"
         ));

--- a/docs/plans/2026-07-17-remote-landscape.md
+++ b/docs/plans/2026-07-17-remote-landscape.md
@@ -154,6 +154,31 @@ from CLAUDE.md.
   667×375, ~7px at the 844×390 design target) — accepted; nothing clips or
   overlaps.
 
+## Real-device amendments (2026-07-17, iPhone Safari screenshots from the author)
+
+- **`100dvh` cascade** (`height: 100vh; height: 100svh; height: 100dvh;` on
+  `body` and `#peitho-remote-root`): iOS Safari in landscape with the tab bar
+  visible reports `svh` ~45px smaller than the actual visible area (measured
+  on the author's phone — portrait reports correctly), which left a dead band
+  below the grid. `dvh` tracks the current chrome state, and also expands the
+  layout when the user hides Safari's toolbar. `svh` stays in the cascade as
+  the no-`dvh` fallback.
+- **Landscape column 1 tracks the preview's real width**: on short
+  real-device viewports the aspect-fit preview used only ~154px of its fixed
+  `1.55fr` (~290px) column, wasting ~130px that belongs to the notes column.
+  The column is now
+  `min(calc((100dvh - 151px - env(safe-area-inset-bottom, 0px)) * <aspect>), 52%)`
+  (progressive second declaration; the `1.55fr` line remains as the no-`dvh`
+  fallback). 151px = the column's fixed vertical overhead (padding-top 12 +
+  titlebar ~19 + chase 34 + pace 44 + three 10px row gaps + padding-bottom
+  base 12); `<aspect>` is the canvas token, so the calc reads
+  `* 16 / 9` etc. The 52% cap equals the old 1.55fr share at the 844×390
+  design size, so the approved-mock rendering is unchanged there.
+- **Portrait stays untouched** (author decision): the portrait cramped-notes
+  feedback is chrome tax (~130px) + preview + buttons; revisit together with
+  the standalone/add-to-home-screen follow-up (Issue #306) rather than
+  shrinking the preview now.
+
 ## Non-goals
 
 - Tablet-specific layouts.

--- a/docs/plans/2026-07-17-remote-landscape.md
+++ b/docs/plans/2026-07-17-remote-landscape.md
@@ -1,0 +1,161 @@
+# Landscape layout for /remote + stacked navigation buttons (Issue #303)
+
+Design finalized in Claude Design ("Remote landscape", frames 9b + 9c,
+author-approved 2026-07-17 after three chat iterations). The author picked the
+**edge-rail** landscape split (9b) over the issue-sketch bottom-pills variant
+(9a), and — replacing an intermediate left-hand-mode proposal — settled on
+**stacked navigation buttons everywhere**: Next is always the bottom-most
+control, full width, accent; Previous sits above it as a slimmer ghost pill.
+Bottom-center/bottom-corner placement is equally reachable by either thumb, so
+the design is handedness-neutral by construction and needs **no left-hand
+toggle, no per-device setting** (a `data-peitho-hand` mirror was explicitly
+rejected: "Next on the left is not intuitive").
+
+This deliberately amends one Issue #303 non-goal: the portrait button row
+changes from a `1fr 1fr` side-by-side grid to the stacked pair, for everyone
+(author decision, 2026-07-17). Everything above the buttons in portrait is
+untouched; the notes panel gives up ~50px of height.
+
+## Final visual spec (from the approved mock)
+
+### Both orientations
+
+- **Actions**: vertical stack, `gap: 10px`. Previous: ghost pill
+  (`border: 1px solid #2f3644`, transparent, `#dde3ec`), slimmer
+  (`min-height: 48px` portrait / `44px` landscape-column contexts is NOT
+  needed — see rail below; portrait uses 48px), `font-size: 15px`.
+  Next: accent pill (`rgba(56,189,248,0.14)` / `#38bdf8`), `min-height: 60px`,
+  `font-size: 17px`. DOM order (prev, next) already matches the stack.
+- Button labels move from bare text nodes into
+  `<span class="peitho-remote-action-label">` so the rail can restyle/stack
+  them. Text stays "Previous" / "Next" in both orientations ("Previous" at
+  13px ≈ 60px fits the 96px rail; no dual short/long label spans).
+
+### Landscape (`@media (orientation: landscape) and (max-height: 520px)`)
+
+Breakpoint rationale: `orientation: landscape` alone would also catch tall
+desktop windows; the `max-height` guard targets phones. Short-but-narrow
+(portrait) viewports keep today's compression fallback unchanged — that
+behavior is load-bearing (7d10b2a: pace row and buttons always visible).
+
+Three-column grid on `.peitho-remote` (the DOM stays flat; children are
+placed with `grid-area`, so the dynamically inserted section line and the
+optional elements need no wrapper divs):
+
+```
+grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px;
+grid-template-rows: minmax(0, 1fr) auto auto auto;
+gap: 10px 14px;  max-width: none;
+```
+
+| area     | grid placement      | notes                                        |
+|----------|---------------------|----------------------------------------------|
+| preview  | row 1, col 1        | `max-height: 100%; min-height: 0` — grid stretch supplies the width; keeps `aspect-ratio`; on very short viewports the shell letterboxes inside |
+| titlebar | row 2, col 1        |                                              |
+| chase    | row 3, col 1        |                                              |
+| pace     | row 4, col 1        | timer + reset stay here (author-approved); `flex-wrap: wrap` so a long pace delta wraps inside the column instead of overflowing into the notes column on narrow landscape viewports |
+| notes    | rows 1–2, col 2     | the flexible area                            |
+| status   | row 3, col 2        | usually empty; shows `Ended`                 |
+| section  | row 4, col 2        | bottom-aligned beside the pace row; absent ⇒ empty auto row, no hole |
+| actions  | rows 1–4, col 3     | becomes the rail                             |
+
+Rail styling: `.peitho-remote-actions` switches to a column flex; buttons get
+`border-radius: 20px`, `flex: 1` (Previous) / `flex: 1.35` (Next),
+`min-height: 0`, column content (arrow above label via `order: -1` on the
+arrow), arrow `26px`, label `13px/600`. Next occupies the bottom-right
+corner — the strongest blind-tap thumb zone in a two-handed landscape grip
+(this was the deciding argument for 9b).
+
+Root padding in landscape: `12px 14px` plus `env(safe-area-inset-left/right)`
+(the page already sets `viewport-fit=cover`, so notch-side content would be
+clipped without it) **and** `padding-bottom: calc(12px +
+env(safe-area-inset-bottom, 0px))` — the `padding: 12px 14px` shorthand resets
+the portrait bottom-inset longhand inside the media query, and the home
+indicator still occupies the bottom edge in landscape, so the bottom inset
+must be re-added or the rail's Next button overlaps the swipe-gesture zone.
+
+Known risk, deliberately deferred to E2E: a palm resting on the right screen
+edge could ghost-tap the rail. If real-device use shows accidental taps, the
+fallbacks are (in order) a few px of dead margin on the rail, then the 9a
+bottom-pills variant.
+
+## Implementation tasks (TDD, in order)
+
+Each task: failing test first, then implementation, then the full gate list
+from CLAUDE.md.
+
+### 1. remote.ts: action label spans
+
+- `remoteButton()` wraps the label in `span.peitho-remote-action-label`
+  (arrow span stays). jsdom tests: both buttons carry the label span with the
+  right text; arrow/label order per direction unchanged in DOM (prev: arrow
+  then label; next: label then arrow); click dispatch and disabled logic
+  untouched (existing tests keep passing).
+
+### 2. render.rs: portrait stacked actions + landscape grid
+
+- `.peitho-remote-actions` portrait: `display: flex; flex-direction: column;
+  gap: 10px;`; per-direction min-heights/fonts per spec above.
+- New landscape media query block per the table above, all
+  `peitho-remote-*` selectors.
+- Extend `remote_index_mounts_remote_bundle_with_feature_detection_and_canvas_tokens`
+  (string-containment style, as the file already does): stacked actions rules,
+  the exact media-query prelude
+  `@media (orientation: landscape) and (max-height: 520px)`, the
+  grid-template lines, one `grid-area` per placed element, rail flex rules,
+  safe-area padding line.
+
+### 3. Embedded bundle + gates
+
+- `npm run build` → commit `dist/remote.js` (+ others only if they drift);
+  full gate list including 3× `cargo test --workspace`.
+
+### 4. E2E (manual, before PR)
+
+- `peitho present --host --port <fixed>` on an example deck with sections +
+  notes; Chrome windows at 844×390 (landscape) and 390×844 (portrait), plus
+  667×375 (SE-class) for the shrink path. Verify: rail renders with Next in
+  the corner, notes/section/status placement, preview aspect fit
+  (letterboxing acceptable, no overflow), portrait stacked buttons, ended
+  state dims and disables in both orientations. Screenshot evidence.
+
+## Review-driven amendments (2026-07-17, applied before PR)
+
+- **Safe-area bottom inset re-added in landscape** (see the root-padding
+  paragraph above) — caught in the first review pass.
+- **Dead CSS removed**: the landscape preview rule dropped
+  `width: 100%; margin-inline: auto` (grid stretch already fills the track,
+  which made the auto margins dead); the rail button rules were consolidated
+  so `border-radius: 20px` and `flex-direction: column` live once on
+  `.peitho-remote-actions button` and the per-direction rules carry only
+  `flex` and `min-height: 0`.
+- **`flex-wrap: wrap` on the landscape pace row**: column 1 is ~313px on an
+  SE-class 667×375 viewport; with the timer running, the nowrap pace delta
+  could otherwise overflow the `minmax(0, 1.55fr)` track into the notes
+  column. Wrapping the delta onto a second line inside the column is the
+  intended degradation.
+- **`aria-hidden="true"` on the arrow spans**: the old DOM used whitespace
+  text nodes between arrow and label; spacing is now CSS gap, so without the
+  attribute assistive technology would announce the fused run ("‹Previous").
+  Hiding the decorative glyphs makes the accessible names plain
+  "Previous"/"Next" — better than the old baseline.
+- **`align-self: end` on the landscape section line and chase**: default grid
+  stretch top-aligned the 12.5px section text in the ~44px pace row band
+  (the mock bottom-aligns it), and for decks without `time` the 6px
+  slide-mode chase floated mid-row because the status min-height sets row 3's
+  height. Pinning both to the row bottom matches the mock; for timed decks
+  the chase rule is a no-op (34px chase already fills the row).
+- **Preview aspect behavior, measured (2026-07-17)**: in real Chrome the
+  landscape preview keeps its aspect ratio under default grid stretch
+  (315×175 ≈ 16:9 measured at 667×375) — `max-height: 100%` only engages on
+  wide-short viewports, where the shell letterboxes inside. On
+  smaller-than-target landscape viewports the ratio-derived pane is shorter
+  than the 1fr row, leaving slack between preview and titlebar (~55px at
+  667×375, ~7px at the 844×390 design target) — accepted; nothing clips or
+  overlaps.
+
+## Non-goals
+
+- Tablet-specific layouts.
+- Any handedness setting (rejected in design).
+- Markdown notes, agenda list on the phone (unchanged from #299).

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1305,11 +1305,15 @@ function remoteButton(doc, action, label) {
   button.dataset.peithoDirection = action;
   const arrow = doc.createElement("span");
   arrow.className = "peitho-remote-action-arrow";
+  arrow.setAttribute("aria-hidden", "true");
   arrow.textContent = action === "prev" ? "\u2039" : "\u203A";
+  const labelSpan = doc.createElement("span");
+  labelSpan.className = "peitho-remote-action-label";
+  labelSpan.textContent = label;
   if (action === "prev") {
-    button.append(arrow, doc.createTextNode(` ${label}`));
+    button.append(arrow, labelSpan);
   } else {
-    button.append(doc.createTextNode(`${label} `), arrow);
+    button.append(labelSpan, arrow);
   }
   return button;
 }

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -674,11 +674,15 @@ function remoteButton(doc: Document, action: "prev" | "next", label: string): HT
   button.dataset.peithoDirection = action;
   const arrow = doc.createElement("span");
   arrow.className = "peitho-remote-action-arrow";
+  arrow.setAttribute("aria-hidden", "true");
   arrow.textContent = action === "prev" ? "‹" : "›";
+  const labelSpan = doc.createElement("span");
+  labelSpan.className = "peitho-remote-action-label";
+  labelSpan.textContent = label;
   if (action === "prev") {
-    button.append(arrow, doc.createTextNode(` ${label}`));
+    button.append(arrow, labelSpan);
   } else {
-    button.append(doc.createTextNode(`${label} `), arrow);
+    button.append(labelSpan, arrow);
   }
   return button;
 }

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -282,6 +282,8 @@ it("remote controller treats a null replay index as the first non-skipped slide"
 });
 
 it("remote renders preview title section notes and section-aware chase chrome", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
   const previewNavigations: unknown[] = [];
   const manifest = manifestWithSlides(
     [
@@ -757,6 +759,8 @@ it("remote chase puts the last-slide rabbit at the slide goal", async () => {
 });
 
 it("remote chase pins the single-slide rabbit at the slide goal", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
   const { root, channel } = await mountRemoteForTest(
     manifestWithSlides([{ key: "only" }], { plannedDurationMs: 60_000 })
   );

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -163,6 +163,25 @@ it("remote buttons dispatch navigate request events only", () => {
   expect(requests).toEqual([{ to: "prev" }, { to: "next" }]);
 });
 
+it("remote action buttons wrap labels and keep directional child order", () => {
+  const root = document.createElement("main");
+  cleanups.push(installRemoteControls({ root, document, bus: new EventTarget() }));
+
+  const prev = button(root, "prev");
+  const next = button(root, "next");
+  const prevArrow = prev.querySelector(".peitho-remote-action-arrow");
+  const nextArrow = next.querySelector(".peitho-remote-action-arrow");
+  const prevLabel = prev.querySelector(".peitho-remote-action-label");
+  const nextLabel = next.querySelector(".peitho-remote-action-label");
+
+  expect(prevLabel?.textContent).toBe("Previous");
+  expect(nextLabel?.textContent).toBe("Next");
+  expect(prevArrow?.getAttribute("aria-hidden")).toBe("true");
+  expect(nextArrow?.getAttribute("aria-hidden")).toBe("true");
+  expect(Array.from(prev.children)).toEqual([prevArrow, prevLabel]);
+  expect(Array.from(next.children)).toEqual([nextLabel, nextArrow]);
+});
+
 it("remote controls mount disabled before the synced event arrives", () => {
   const root = document.createElement("main");
   cleanups.push(installRemoteControls({ root, document, bus: new EventTarget() }));


### PR DESCRIPTION
Closes #303

## What

- **Landscape layout** for the `/remote` phone page, active under `@media (orientation: landscape) and (max-height: 520px)`: a three-column CSS grid placed over the unchanged flat DOM — stage column (slide preview, title/counter, chase track, pace row), notes column (notes, status, section line), and a 96px right-edge button rail with **Next in the bottom-right corner** (the strongest blind-tap thumb zone in a two-handed landscape grip). Short-but-narrow viewports keep the existing compression fallback; safe-area insets are preserved on the notch sides and the home-indicator bottom edge.
- **Stacked navigation buttons in both orientations**: Next is always the bottom-most control (full width, accent); Previous sits above it as a slimmer ghost pill. Bottom placement is equally reachable by either thumb, so the design is handedness-neutral by construction — a left-hand mirror mode was prototyped and rejected ("Next on the left is not intuitive"). This deliberately amends the issue's portrait non-goal (author decision, 2026-07-17).
- `remote.ts`: button labels move into `span.peitho-remote-action-label` (spacing now via CSS gap) and arrow glyphs get `aria-hidden="true"`, so assistive technology announces plain "Previous"/"Next".

Design finalized in Claude Design ("Remote landscape" frames 9b + 9c, author-approved 2026-07-17). Design record: `docs/plans/2026-07-17-remote-landscape.md`, including review-driven amendments (safe-area bottom re-add, dead-CSS removal, `flex-wrap` on the landscape pace row, `align-self: end` on section/chase, measured preview aspect behavior).

## Verification

- All gates green: `cargo test --workspace` ×3 (0 failures each), clippy `-D warnings`, `cargo fmt --check`, `bindings/` drift clean, vitest 255/255, `tsc --noEmit`, `dist/remote.js` rebuilt and committed (no `shell.js`/`preview.js` drift).
- E2E against `peitho present` on `examples/peitho-tour` (sections + notes + time): landscape 844×390 matches the approved mock (rail, disabled Previous on slide 1); 667×375 SE-class shows no overflow; portrait shows the stacked pair with everything above unchanged; sync-driven index change updates preview/counter/section line and enables Previous; empty-notes placeholder renders.
- Known deferred risk (documented in the design record): palm resting on the right screen edge could ghost-tap the rail — to be watched on a real device; fallbacks are a dead margin on the rail, then the bottom-pills variant.
- 5 review rounds completed: round 1 (plan-doc sync), round 2 (two `align-self` alignment fixes), rounds 3–5 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2CDJTHJnfgNJrDJTamnQC