### PR TITLE
fix(remote): reclaim standalone dead space and tighten Ended state (#309)

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -779,8 +779,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
   <style>
     :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --peitho-canvas-width: __PEITHO_CANVAS_WIDTH__px; --peitho-canvas-height: __PEITHO_CANVAS_HEIGHT__px; --peitho-canvas-aspect: __PEITHO_CANVAS_ASPECT__; }
     html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }
-    body { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); overflow: hidden; }
-    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
+    body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }
+    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
     .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
     .peitho-remote { width: 100%; max-width: 32rem; margin: 0 auto; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 12px; }
     .peitho-remote-dim-on-end { transition: opacity 120ms ease; }
@@ -849,6 +849,12 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
       .peitho-remote-actions [data-peitho-direction="next"] { flex: 1.35; min-height: 0; }
       .peitho-remote-action-arrow { order: -1; font-size: 26px; }
       .peitho-remote-action-label { font-size: 13px; font-weight: 600; }
+    }
+    @media (display-mode: standalone) {
+      body, #peitho-remote-root { height: 100vh; }
+    }
+    @media (display-mode: standalone) and (orientation: landscape) and (max-height: 520px) {
+      .peitho-remote { grid-template-columns: min(calc((100vh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * __PEITHO_CANVAS_ASPECT__), 52%) minmax(0, 1fr) 96px; }
     }
   </style>
 </head>
@@ -1789,14 +1795,10 @@ Paragraph after heading.
         assert!(html.contains(
             "html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }"
         ));
-        assert!(html.contains("body { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); overflow: hidden; }"));
-        assert_eq!(
-            html.matches("height: var(--peitho-viewport-height, 100dvh);")
-                .count(),
-            2
-        );
+        assert!(html
+            .contains("body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }"));
         assert!(html.contains("padding-top: calc(14px + env(safe-area-inset-top, 0px));"));
-        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px;"));
+        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px;"));
         assert!(html.contains("padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));"));
         assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
         assert!(html.contains(
@@ -1878,6 +1880,12 @@ Paragraph after heading.
         ));
         assert!(html.contains(".peitho-remote-action-arrow { order: -1; font-size: 26px; }"));
         assert!(html.contains(".peitho-remote-action-label { font-size: 13px; font-weight: 600; }"));
+        assert!(html.contains("@media (display-mode: standalone) {"));
+        assert!(html.contains("body, #peitho-remote-root { height: 100vh; }"));
+        assert!(html.contains(
+            "@media (display-mode: standalone) and (orientation: landscape) and (max-height: 520px)"
+        ));
+        assert!(html.contains("grid-template-columns: min(calc((100vh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 4 / 3), 52%) minmax(0, 1fr) 96px;"));
         assert!(html.contains(
             ".peitho-remote[data-peitho-ended=\"true\"] .peitho-remote-dim-on-end { opacity: 0.28;"
         ));

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -820,6 +820,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-pace-delta[data-peitho-pace="ahead"] { color: #8fd9a0; }
     .peitho-remote-pace-delta[data-peitho-pace="paused"] { color: #aab3c2; }
     .peitho-remote-pace-delta[data-peitho-pace="onpace"] { color: #aab3c2; }
+    .peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }
+    .peitho-remote-section b { color: #dde3ec; font-weight: 600; }
     .peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
     .peitho-remote-notes-caption { flex: 0 0 auto; font-size: 11px; font-weight: 600; line-height: 1.2; letter-spacing: 0.08em; color: #6b7484; text-transform: uppercase; }
     .peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto; min-height: 0; }
@@ -839,7 +841,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
       .peitho-remote-titlebar { grid-area: 2 / 1 / 3 / 2; }
       .peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }
       .peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }
-      .peitho-remote-notes { grid-area: 1 / 2 / 5 / 3; }
+      .peitho-remote-notes { grid-area: 1 / 2 / 4 / 3; }
+      .peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }
       .peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }
       .peitho-remote-actions button { flex-direction: column; border-radius: 20px; }
       .peitho-remote-actions [data-peitho-direction="prev"] { flex: 1; min-height: 0; }
@@ -1831,7 +1834,12 @@ Paragraph after heading.
         assert!(html
             .contains(".peitho-remote-pace-delta[data-peitho-pace=\"onpace\"] { color: #aab3c2;"));
         assert!(!html.contains(".peitho-remote-status {"));
-        assert!(!html.contains(".peitho-remote-section"));
+        assert!(html.contains(
+            ".peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }"
+        ));
+        assert!(
+            html.contains(".peitho-remote-section b { color: #dde3ec; font-weight: 600; }")
+        );
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));
         assert!(html.contains(
@@ -1854,7 +1862,10 @@ Paragraph after heading.
             html.contains(".peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }")
         );
         assert!(html.contains(".peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }"));
-        assert!(html.contains(".peitho-remote-notes { grid-area: 1 / 2 / 5 / 3; }"));
+        assert!(html.contains(".peitho-remote-notes { grid-area: 1 / 2 / 4 / 3; }"));
+        assert!(html.contains(
+            ".peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }"
+        ));
         assert!(
             html.contains(".peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }")
         );

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -1837,9 +1837,7 @@ Paragraph after heading.
         assert!(html.contains(
             ".peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }"
         ));
-        assert!(
-            html.contains(".peitho-remote-section b { color: #dde3ec; font-weight: 600; }")
-        );
+        assert!(html.contains(".peitho-remote-section b { color: #dde3ec; font-weight: 600; }"));
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));
         assert!(html.contains(
@@ -1863,9 +1861,9 @@ Paragraph after heading.
         );
         assert!(html.contains(".peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }"));
         assert!(html.contains(".peitho-remote-notes { grid-area: 1 / 2 / 4 / 3; }"));
-        assert!(html.contains(
-            ".peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }"
-        ));
+        assert!(
+            html.contains(".peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }")
+        );
         assert!(
             html.contains(".peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }")
         );

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -779,8 +779,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
   <style>
     :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --peitho-canvas-width: __PEITHO_CANVAS_WIDTH__px; --peitho-canvas-height: __PEITHO_CANVAS_HEIGHT__px; --peitho-canvas-aspect: __PEITHO_CANVAS_ASPECT__; }
     html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }
-    body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }
-    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
+    body { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); overflow: hidden; }
+    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
     .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
     .peitho-remote { width: 100%; max-width: 32rem; margin: 0 auto; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 12px; }
     .peitho-remote-dim-on-end { transition: opacity 120ms ease; }
@@ -1786,10 +1786,14 @@ Paragraph after heading.
         assert!(html.contains(
             "html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }"
         ));
-        assert!(html
-            .contains("body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }"));
+        assert!(html.contains("body { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); overflow: hidden; }"));
+        assert_eq!(
+            html.matches("height: var(--peitho-viewport-height, 100dvh);")
+                .count(),
+            2
+        );
         assert!(html.contains("padding-top: calc(14px + env(safe-area-inset-top, 0px));"));
-        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px;"));
+        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; height: var(--peitho-viewport-height, 100dvh); display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px;"));
         assert!(html.contains("padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));"));
         assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
         assert!(html.contains(

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -780,14 +780,14 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     :root { color-scheme: dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; --peitho-canvas-width: __PEITHO_CANVAS_WIDTH__px; --peitho-canvas-height: __PEITHO_CANVAS_HEIGHT__px; --peitho-canvas-aspect: __PEITHO_CANVAS_ASPECT__; }
     html, body { margin: 0; height: 100%; background: #101216; color: #f5f7fb; }
     body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }
-    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
+    #peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px; padding-top: calc(14px + env(safe-area-inset-top, 0px)); padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px)); box-sizing: border-box; }
     .peitho-remote-error { align-self: center; justify-self: center; max-width: 32rem; padding: 16px; border: 1px solid #7f1d1d; background: #2a1215; color: #ffd7d7; border-radius: 6px; line-height: 1.4; }
     .peitho-remote { width: 100%; max-width: 32rem; margin: 0 auto; flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 12px; }
     .peitho-remote-dim-on-end { transition: opacity 120ms ease; }
-    .peitho-remote[data-peitho-ended="true"] .peitho-remote-dim-on-end { opacity: 0.35; }
+    .peitho-remote[data-peitho-ended="true"] .peitho-remote-dim-on-end { opacity: 0.28; }
     .peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0; }
     .peitho-remote-preview > * { position: absolute; inset: 0; }
-    .peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-status { flex: none; }
+    .peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace { flex: none; }
     .peitho-remote-titlebar { display: flex; align-items: baseline; gap: 12px; }
     .peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700; line-height: 1.2; color: #f5f7fb; }
     .peitho-remote-counter { flex: 0 0 auto; margin-left: auto; font-size: 16px; font-weight: 700; line-height: 1.2; color: #aab3c2; font-variant-numeric: tabular-nums; }
@@ -820,13 +820,10 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-pace-delta[data-peitho-pace="ahead"] { color: #8fd9a0; }
     .peitho-remote-pace-delta[data-peitho-pace="paused"] { color: #aab3c2; }
     .peitho-remote-pace-delta[data-peitho-pace="onpace"] { color: #aab3c2; }
-    .peitho-remote-section { font-size: 12.5px; color: #aab3c2; line-height: 1.35; }
-    .peitho-remote-section b { color: #dde3ec; font-weight: 600; }
     .peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
     .peitho-remote-notes-caption { flex: 0 0 auto; font-size: 11px; font-weight: 600; line-height: 1.2; letter-spacing: 0.08em; color: #6b7484; text-transform: uppercase; }
     .peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto; min-height: 0; }
     .peitho-remote-notes-body[data-peitho-empty="true"] { color: #5a6473; font-size: 14px; font-style: italic; }
-    .peitho-remote-status { min-height: 1.4em; text-align: center; color: #aab3c2; font-size: 13px; line-height: 1.4; }
     .peitho-remote-actions { display: flex; flex-direction: column; gap: 10px; flex: none; }
     .peitho-remote-actions button { border-radius: 999px; font: 600 17px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; touch-action: manipulation; display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
     .peitho-remote-actions [data-peitho-direction="prev"] { min-height: 48px; border: 1px solid #2f3644; background: transparent; color: #dde3ec; font-size: 15px; }
@@ -842,9 +839,7 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
       .peitho-remote-titlebar { grid-area: 2 / 1 / 3 / 2; }
       .peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }
       .peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }
-      .peitho-remote-notes { grid-area: 1 / 2 / 3 / 3; }
-      .peitho-remote-status { grid-area: 3 / 2 / 4 / 3; }
-      .peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }
+      .peitho-remote-notes { grid-area: 1 / 2 / 5 / 3; }
       .peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }
       .peitho-remote-actions button { flex-direction: column; border-radius: 20px; }
       .peitho-remote-actions [data-peitho-direction="prev"] { flex: 1; min-height: 0; }
@@ -1794,9 +1789,12 @@ Paragraph after heading.
         assert!(html
             .contains("body { height: 100vh; height: 100svh; height: 100dvh; overflow: hidden; }"));
         assert!(html.contains("padding-top: calc(14px + env(safe-area-inset-top, 0px));"));
-        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 18px;"));
+        assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px;"));
+        assert!(html.contains("padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));"));
         assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
-        assert!(html.contains(".peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-status { flex: none; }"));
+        assert!(html.contains(
+            ".peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace { flex: none; }"
+        ));
         assert!(html.contains(
             ".peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700;"
         ));
@@ -1828,7 +1826,8 @@ Paragraph after heading.
             .contains(".peitho-remote-pace-delta[data-peitho-pace=\"paused\"] { color: #aab3c2;"));
         assert!(html
             .contains(".peitho-remote-pace-delta[data-peitho-pace=\"onpace\"] { color: #aab3c2;"));
-        assert!(html.contains(".peitho-remote-section { font-size: 12.5px; color: #aab3c2;"));
+        assert!(!html.contains(".peitho-remote-status {"));
+        assert!(!html.contains(".peitho-remote-section"));
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));
         assert!(html.contains(
@@ -1851,11 +1850,7 @@ Paragraph after heading.
             html.contains(".peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }")
         );
         assert!(html.contains(".peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }"));
-        assert!(html.contains(".peitho-remote-notes { grid-area: 1 / 2 / 3 / 3; }"));
-        assert!(html.contains(".peitho-remote-status { grid-area: 3 / 2 / 4 / 3; }"));
-        assert!(
-            html.contains(".peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }")
-        );
+        assert!(html.contains(".peitho-remote-notes { grid-area: 1 / 2 / 5 / 3; }"));
         assert!(
             html.contains(".peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }")
         );
@@ -1871,7 +1866,7 @@ Paragraph after heading.
         assert!(html.contains(".peitho-remote-action-arrow { order: -1; font-size: 26px; }"));
         assert!(html.contains(".peitho-remote-action-label { font-size: 13px; font-weight: 600; }"));
         assert!(html.contains(
-            ".peitho-remote[data-peitho-ended=\"true\"] .peitho-remote-dim-on-end { opacity: 0.35;"
+            ".peitho-remote[data-peitho-ended=\"true\"] .peitho-remote-dim-on-end { opacity: 0.28;"
         ));
         assert!(html.contains("env(safe-area-inset-bottom"));
         assert!(html.contains("import * as peitho from './remote.js';"));

--- a/docs/plans/2026-07-18-remote-standalone-tuning.md
+++ b/docs/plans/2026-07-18-remote-standalone-tuning.md
@@ -140,8 +140,10 @@ Each: failing test first, then implementation, then the full gate list.
 - `peitho present --host` on a deck with a `time:` frontmatter and sections;
   scan QR, open in Safari, Add to Home Screen. Launch:
   - Portrait: notes taller than before by ~50px; no gap between notes and
-    Previous; no gap between Next and the home indicator.
-  - Landscape: notes fills the full right column; no Section line below.
+    Previous; no gap between Next and the home indicator — including on a
+    cold start without rotating the phone first (the dvh pitfall below).
+  - Landscape: notes extends down through the old status band (rows 1–3);
+    the Section line stays at the bottom of the column (row 4).
   - End the deck (kill `peitho present`): whole remote surface dims to a
     heavier grey, every button is unpressable. No "Ended" text anywhere.
 - Screenshot evidence in the PR.
@@ -150,11 +152,36 @@ Each: failing test first, then implementation, then the full gate list.
 
 - Any tablet-specific layout.
 - Any changes to how the presenter view (not /remote) handles Ended.
-- Section context on the phone remote — deliberately dropped in favor of
-  notes-first; the presenter view still shows section context properly.
 - Portrait `.peitho-remote-chase` height, pace row layout, or button sizes —
   none of these were in the author's item list and touching them would be
   scope creep.
+
+## Real-device amendments (2026-07-18, author's phone)
+
+- **Landscape Section line restored.** The first implementation deleted the
+  Section line along with the Status row, reading the issue's "if the
+  status/section placement is rethought" as license to drop it. The author
+  corrected this: removal was never requested. The Section line is back at
+  landscape row 4 (bottom-aligned, built via `createDimmableRow` so it keeps
+  `dim-on-end`), and notes spans rows 1–3 (`grid-area: 1/2/4/3`) — gaining
+  exactly the old status band, not the section band. Portrait is unaffected
+  (the section line only renders in the landscape grid).
+- **`100dvh` is stale on iOS standalone cold start** (measured on the
+  author's device: portrait launch leaves a dead band at the bottom, and one
+  portrait→landscape→portrait rotation clears it — matching the documented
+  WebKit behavior that dynamic-viewport units are only initialized once the
+  viewport is "exercised" by a geometry change). Reading
+  `visualViewport.height` / `window.innerHeight` from JS at startup returns
+  the same stale value, so a first-attempt JS tracker that mirrored
+  `visualViewport.height` into a CSS variable did not help and was removed —
+  do not retry that approach. The fix is CSS-only: standalone mode has no UA
+  chrome, so `100vh` is correct from launch and always equal to the real
+  viewport there. `@media (display-mode: standalone)` overrides `body` /
+  `#peitho-remote-root` heights to `100vh`, plus a companion override of the
+  landscape preview-column formula (`100vh` in place of `100dvh`). In-browser
+  pages keep the `vh → svh → dvh` cascade — the `dvh` remains load-bearing
+  for Safari's landscape tab-bar under-report
+  (docs/plans/2026-07-17-remote-landscape.md).
 
 ## Design record (mock iteration)
 

--- a/docs/plans/2026-07-18-remote-standalone-tuning.md
+++ b/docs/plans/2026-07-18-remote-standalone-tuning.md
@@ -1,0 +1,167 @@
+# /remote layout tuning against the chrome-free standalone viewport (Issue #309)
+
+Follow-up to #303 (landscape), #305 (implementation), #306/#308 (standalone). All
+three items the author flagged on 2026-07-17 after using the merged standalone
+mode on a real device get resolved by the *same* two moves — remove the always-
+reserved Status row, and use the existing `dim-on-end` state stronger — so this
+PR is one small CSS change, not three per-item ones.
+
+## Author's items, and how they collapse into one
+
+1. **Portrait: bottom clearance reads as dead space** — `padding-bottom: 18px +
+   env(safe-area-inset-bottom)` was sized for a browser toolbar; in standalone
+   the home indicator needs less visual clearance.
+2. **Portrait: blank band between notes and Previous** — the always-reserved
+   Status row (`min-height: 1.4em`, empty except when Ended) plus its two 12px
+   gaps costs ~42px that notes could use.
+3. **Landscape: blank space below notes** — Status row 3 (usually empty) and
+   Section row 4 sit under the notes panel unused.
+
+The Ended state is what the Status row exists for, and Ended is fully read-only
+— the whole surface is already `dim-on-end` and every button already goes
+`disabled` when `this.ended` is true (`renderTimeDependentChrome` /
+`renderButtons` in `remote.ts`). So the Ended-specific text row is redundant:
+"the surface is dim and every control is disabled" already says "the deck has
+ended". Removing the Status row entirely handles Item 2 (portrait) and, in
+landscape, freeing up row 3 lets notes grow.
+
+Item 3's second half — the Section line at row 4 — is not Ended-specific but
+still costs a ~44px band that adds no information notes doesn't already carry
+(the section name and offset in the section). The section context is a nice-to-
+have that the presenter view surfaces properly; on the phone remote where every
+pixel is being fought over, cutting it lets notes fill the full right column.
+
+Item 1 is a one-line clearance change.
+
+**Author confirmed 2026-07-18 via the Claude Design mock**: no "Ended" overlay,
+no chip, no separate label. Bare grey-out + disabled buttons is enough.
+
+## Final visual spec
+
+### Portrait (approved mock — v4 "final")
+
+- `#peitho-remote-root` `padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px))`
+  (was `18px + env(...)`; ~10px reclaimed to notes).
+- **`.peitho-remote-status` element and its inline text state are removed
+  entirely.** The `min-height: 1.4em` selector goes away, and `renderRemoteControls`
+  no longer creates the DOM element; `render.setText(this.root, "status", ...)`
+  is deleted from `remote.ts`. This is what makes the Ended state a "dim-only"
+  state — there is no text row to reveal.
+- Notes gets back the ~42px row + ~10px bottom padding.
+
+### Landscape (`@media (orientation: landscape) and (max-height: 520px)`)
+
+- `.peitho-remote-actions` grid-area unchanged (rows 1–4 col 3, rail).
+- `.peitho-remote-notes` **grid-area: 1/2/5/3** (was `1/2/3/3`) — fills the full
+  right column height.
+- Status row and Section line are absent from the grid: neither the CSS grid-
+  area rules for `.peitho-remote-status` and `.peitho-remote-section` nor the
+  landscape `align-self: end` rule for the section survive. The DOM insertion
+  path for the dynamically-created `.peitho-remote-section` line
+  (`renderSection`) is deleted along with it — a rendered element with no grid
+  placement rule would fall to the auto flow track and either overlap the notes
+  panel or push the grid taller than the viewport.
+- Landscape column-1 tracks unchanged (the second-declaration `min(calc(...), 52%)`
+  formula from #303 stays).
+
+### Ended state
+
+- `.peitho-remote[data-peitho-ended="true"] .peitho-remote-dim-on-end` opacity
+  goes **0.35 → 0.28** (the author picked heavier dim in the mock). The
+  `dim-on-end` targeting rules are unchanged.
+- The DOM-level `disabled` behavior in `remote.ts`'s `renderButtons` and
+  `renderTimeDependentChrome` is unchanged — timer/reset/prev/next already go
+  `disabled` when `this.ended` is true.
+- No overlay element, no chip, no label. Ended and non-Ended layouts are
+  *byte-identical structurally*; only opacity + button `disabled` change.
+
+## What that means for the code
+
+- **`crates/peitho-core/src/render.rs` `render_remote_index()`**:
+  - `#peitho-remote-root` base padding-bottom `18px` → `8px`.
+  - Landscape media block's `padding-bottom: calc(12px + ...)` stays as is (the
+    landscape number wasn't part of the complaint and already accounts for the
+    swipe zone).
+  - Delete the `.peitho-remote-status` selector block entirely.
+  - Delete the landscape `.peitho-remote-status` and
+    `.peitho-remote-section` grid-area rules (both the base
+    `.peitho-remote-section` and the `align-self: end` variant).
+  - Landscape `.peitho-remote-notes` `grid-area: 1/2/3/3` → `1/2/5/3`.
+  - `[data-peitho-ended="true"] .peitho-remote-dim-on-end` opacity `0.35`
+    → `0.28`.
+  - Update the `remote_index_mounts_remote_bundle_with_feature_detection_and_canvas_tokens`
+    string-containment test to match: the four rewrites above, plus new
+    negative assertions that `.peitho-remote-status {` and
+    `.peitho-remote-section` are no longer in the emitted CSS.
+
+- **`packages/peitho-present/src/remote.ts`**:
+  - `installRemoteControls`: remove the `status` element creation, its
+    `dataset.peithoRemote = "status"`, and its append to `container`.
+  - `RemoteController`:
+    - Delete `renderSection` (the whole method + its call site in `render`).
+    - Remove `setText(this.root, "status", ...)` from `render`.
+  - Existing unit tests that assert `[data-peitho-remote="status"]` receives
+    "Ended" text on `setEnded()` need to be replaced with tests that assert
+    the frame's `data-peitho-ended` attribute is `"true"` and Prev/Next/Timer/
+    Reset buttons are `disabled` (which is already the observable behavior;
+    the Status text assertion was redundant).
+  - Existing section-line tests need to be removed (there is no
+    `.peitho-remote-section` element in the DOM anymore).
+
+- **`crates/peitho-core/src/render.rs` embedded bundle drift**: after
+  `npm run build`, `dist/remote.js` will regenerate. Commit it. `shell.js` and
+  `preview.js` should stay byte-identical (no changes touch either).
+
+## Implementation tasks (TDD, in order)
+
+Each: failing test first, then implementation, then the full gate list.
+
+### 1. render.rs CSS: padding-bottom + Status/Section removal + dim strength
+
+- Update the string-containment test with the four selector rewrites plus two
+  negative assertions.
+- Apply the CSS changes.
+
+### 2. remote.ts: drop Status element + Section rendering
+
+- Delete jsdom tests that assert the Status text or Section line DOM presence.
+- Add (or update) tests asserting Ended state: `data-peitho-ended="true"`,
+  all four buttons `disabled`, no Status/Section DOM.
+- Apply the code deletion.
+
+### 3. Embedded bundle + gates
+
+- `npm run build` → commit `dist/remote.js`.
+- Full gate list: 3× `cargo test --workspace`, clippy, fmt, bindings drift,
+  npm test + typecheck, shell/preview/remote dist drift check.
+
+### 4. E2E (manual, on the author's phone)
+
+- `peitho present --host` on a deck with a `time:` frontmatter and sections;
+  scan QR, open in Safari, Add to Home Screen. Launch:
+  - Portrait: notes taller than before by ~50px; no gap between notes and
+    Previous; no gap between Next and the home indicator.
+  - Landscape: notes fills the full right column; no Section line below.
+  - End the deck (kill `peitho present`): whole remote surface dims to a
+    heavier grey, every button is unpressable. No "Ended" text anywhere.
+- Screenshot evidence in the PR.
+
+## Non-goals
+
+- Any tablet-specific layout.
+- Any changes to how the presenter view (not /remote) handles Ended.
+- Section context on the phone remote — deliberately dropped in favor of
+  notes-first; the presenter view still shows section context properly.
+- Portrait `.peitho-remote-chase` height, pace row layout, or button sizes —
+  none of these were in the author's item list and touching them would be
+  scope creep.
+
+## Design record (mock iteration)
+
+- Claude Design mock:
+  https://claude.ai/design/p/4bfae954-d0e7-41f8-8c4d-a50e231c1802?file=Remote+Tuning.dc.html
+- Iteration path: three-column proposal (A/B/three-way) → Ended-state
+  disambiguation with all controls `disabled` → three overlay variants
+  (X/Y/Z: preview overlay, full-surface overlay, preview-panel-replace) →
+  author picked "just grey out". "V4 final" frame set (Portrait Normal,
+  Portrait Ended, Landscape Normal, Landscape Ended) is the approved spec.

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1149,6 +1149,7 @@ var RemoteController = class {
     this.renderChase(manifest, currentIndex);
     this.renderPaceStatic(manifest);
     this.renderTimeDependentChrome(manifest, currentIndex);
+    this.renderSection(manifest, currentIndex);
     this.renderNotes(slide?.key);
     this.renderButtons(currentIndex);
     this.syncPreview(currentIndex);
@@ -1236,6 +1237,33 @@ var RemoteController = class {
     delta.hidden = false;
     delta.dataset.peithoPace = paceState.kind;
     delta.textContent = paceState.label;
+  }
+  renderSection(manifest, currentIndex) {
+    const existing = this.root.querySelector('[data-peitho-remote="section"]');
+    if (currentIndex == null || manifest.sections.length === 0) {
+      existing?.remove();
+      return;
+    }
+    const sectionIndex = sectionIndexForSlide(manifest.sections, currentIndex);
+    if (sectionIndex < 0) {
+      existing?.remove();
+      return;
+    }
+    const section = manifest.sections[sectionIndex];
+    const sectionSlideCount = section.endIndex - section.startIndex + 1;
+    const sectionOffset = currentIndex - section.startIndex + 1;
+    const sectionLine = existing ?? createDimmableRow(this.doc, "div", "peitho-remote-section");
+    sectionLine.dataset.peithoRemote = "section";
+    const name = this.doc.createElement("b");
+    name.textContent = section.name;
+    sectionLine.replaceChildren(
+      name,
+      this.doc.createTextNode(` \xB7 slide ${sectionOffset} / ${sectionSlideCount} in section`)
+    );
+    if (existing == null) {
+      const notes = this.root.querySelector(".peitho-remote-notes");
+      notes?.before(sectionLine);
+    }
   }
   renderNotes(slideKey) {
     const notes = this.root.querySelector('[data-peitho-remote="notes"]');

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -787,6 +787,8 @@ function formatMinuteSeconds(ms) {
 }
 
 // src/remote.ts
+var isReadOnly = (state) => state.kind === "ended";
+var canInteract = (state) => state.kind === "active";
 async function mountRemoteView(options) {
   const view = new RemoteController(options);
   await view.load();
@@ -801,11 +803,9 @@ function installRemoteControls(options) {
   const container = doc.createElement("section");
   container.className = "peitho-remote";
   container.dataset.peithoEnded = "false";
-  const preview = doc.createElement("div");
-  preview.className = "peitho-remote-preview peitho-remote-dim-on-end";
+  const preview = createDimmableRow(doc, "div", "peitho-remote-preview");
   preview.dataset.peithoRemote = "preview";
-  const titlebar = doc.createElement("div");
-  titlebar.className = "peitho-remote-titlebar peitho-remote-dim-on-end";
+  const titlebar = createDimmableRow(doc, "div", "peitho-remote-titlebar");
   const title = doc.createElement("div");
   title.className = "peitho-remote-title";
   title.dataset.peithoRemote = "title";
@@ -815,8 +815,7 @@ function installRemoteControls(options) {
   counter.dataset.peithoRemote = "counter";
   counter.textContent = "\u2013 / \u2013";
   titlebar.append(title, counter);
-  const chase = doc.createElement("div");
-  chase.className = "peitho-remote-chase peitho-remote-dim-on-end";
+  const chase = createDimmableRow(doc, "div", "peitho-remote-chase");
   chase.dataset.peithoRemote = "chase";
   chase.dataset.peithoChase = "slide";
   const chaseTrack = doc.createElement("div");
@@ -837,8 +836,7 @@ function installRemoteControls(options) {
   turtle.setAttribute("aria-label", "time progress");
   turtle.textContent = "\u{1F422}";
   chase.append(chaseTrack, rabbit, turtle);
-  const pace = doc.createElement("div");
-  pace.className = "peitho-remote-pace peitho-remote-dim-on-end";
+  const pace = createDimmableRow(doc, "div", "peitho-remote-pace");
   const timerButton = doc.createElement("button");
   timerButton.type = "button";
   timerButton.className = "peitho-remote-timer-button";
@@ -880,8 +878,7 @@ function installRemoteControls(options) {
   delta.dataset.peithoRemote = "pace-delta";
   delta.hidden = true;
   pace.append(timerButton, resetButton, elapsedRow, delta);
-  const notesPanel = doc.createElement("section");
-  notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
+  const notesPanel = createDimmableRow(doc, "section", "peitho-remote-notes");
   const notesCaption = doc.createElement("div");
   notesCaption.className = "peitho-remote-notes-caption";
   notesCaption.textContent = "NOTES";
@@ -907,7 +904,15 @@ function installRemoteControls(options) {
   next.addEventListener("click", onNext);
   timerButton.addEventListener("click", onTimer);
   resetButton.addEventListener("click", onReset);
-  container.append(preview, titlebar, chase, pace, notesPanel, actions);
+  const rows = [
+    { kind: "dimmable", element: preview },
+    { kind: "dimmable", element: titlebar },
+    { kind: "dimmable", element: chase },
+    { kind: "dimmable", element: pace },
+    { kind: "dimmable", element: notesPanel },
+    { kind: "actions", element: actions }
+  ];
+  container.append(...rows.map((row) => row.element));
   root.append(container);
   return () => {
     prev.removeEventListener("click", onPrev);
@@ -916,6 +921,11 @@ function installRemoteControls(options) {
     resetButton.removeEventListener("click", onReset);
     container.remove();
   };
+}
+function createDimmableRow(doc, tag, ...classNames) {
+  const el = doc.createElement(tag);
+  el.classList.add("peitho-remote-dim-on-end", ...classNames);
+  return el;
 }
 function installRemoteSyncBridge(options) {
   const bus = options.bus ?? window;
@@ -1004,11 +1014,10 @@ var RemoteController = class {
   log;
   now;
   reload;
-  synced = false;
+  state = { kind: "loading" };
   notes = { version: 1, notes: {} };
   renderedNotesValue = null;
   slides = [];
-  ended = false;
   timerState = null;
   controlsCleanup = null;
   syncCleanup = null;
@@ -1113,11 +1122,12 @@ var RemoteController = class {
     this.render();
   }
   setSynced() {
-    this.synced = true;
+    if (this.state.kind !== "loading") return;
+    this.state = { kind: "active", synced: true };
     this.render();
   }
   setEnded() {
-    this.ended = true;
+    this.state = { kind: "ended" };
     this.clearTimerInterval();
     this.render();
   }
@@ -1126,7 +1136,7 @@ var RemoteController = class {
     if (manifest == null) return;
     const container = this.root.querySelector(".peitho-remote");
     if (container == null) return;
-    container.dataset.peithoEnded = this.ended ? "true" : "false";
+    container.dataset.peithoEnded = isReadOnly(this.state) ? "true" : "false";
     const currentIndex = this.currentIndex;
     const slide = currentIndex == null ? null : manifest.slides[currentIndex];
     const total = this.slides.length;
@@ -1169,8 +1179,8 @@ var RemoteController = class {
     if (timerButton == null || resetButton == null || elapsed == null) return;
     const elapsedMs = this.currentElapsedMs();
     const state = timerVisualState(this.timerState, elapsedMs);
-    timerButton.disabled = this.ended || !this.synced;
-    resetButton.disabled = this.ended || !this.synced || state === "stopped";
+    timerButton.disabled = !canInteract(this.state);
+    resetButton.disabled = !canInteract(this.state) || state === "stopped";
     timerButton.dataset.peithoRunning = state === "running" ? "true" : "false";
     timerButton.dataset.peithoTimerAction = playpauseActionFor(state);
     timerButton.setAttribute("aria-label", timerAriaLabel(state));
@@ -1244,8 +1254,8 @@ var RemoteController = class {
     const prev = this.root.querySelector('[data-peitho-action="prev"]');
     const next = this.root.querySelector('[data-peitho-action="next"]');
     if (prev == null || next == null) return;
-    prev.disabled = this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
-    next.disabled = this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
+    prev.disabled = !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
+    next.disabled = !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
   }
   syncPreview(currentIndex) {
     if (currentIndex == null) return;
@@ -1257,7 +1267,7 @@ var RemoteController = class {
     return currentTimerElapsedMs(this.timerState, this.now());
   }
   updateTimerInterval() {
-    if (this.ended || this.timerState?.running !== true) {
+    if (isReadOnly(this.state) || this.timerState?.running !== true) {
       this.clearTimerInterval();
       return;
     }
@@ -1432,6 +1442,7 @@ function paneViewport(pane) {
   });
 }
 export {
+  createDimmableRow,
   expectedElapsedAtSlide,
   installRemoteControls,
   installRemoteSyncBridge,

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -889,9 +889,6 @@ function installRemoteControls(options) {
   notesBody.className = "peitho-remote-notes-body";
   notesBody.dataset.peithoRemote = "notes";
   notesPanel.append(notesCaption, notesBody);
-  const status = doc.createElement("div");
-  status.className = "peitho-remote-status";
-  status.dataset.peithoRemote = "status";
   const actions = doc.createElement("div");
   actions.className = "peitho-remote-actions";
   const prev = remoteButton(doc, "prev", "Previous");
@@ -910,7 +907,7 @@ function installRemoteControls(options) {
   next.addEventListener("click", onNext);
   timerButton.addEventListener("click", onTimer);
   resetButton.addEventListener("click", onReset);
-  container.append(preview, titlebar, chase, pace, notesPanel, status, actions);
+  container.append(preview, titlebar, chase, pace, notesPanel, actions);
   root.append(container);
   return () => {
     prev.removeEventListener("click", onPrev);
@@ -1138,10 +1135,8 @@ var RemoteController = class {
     this.renderChase(manifest, currentIndex);
     this.renderPaceStatic(manifest);
     this.renderTimeDependentChrome(manifest, currentIndex);
-    this.renderSection(manifest, currentIndex);
     this.renderNotes(slide?.key);
     this.renderButtons(currentIndex);
-    setText(this.root, "status", this.ended ? "Ended" : "");
     this.syncPreview(currentIndex);
     this.updateTimerInterval();
   }
@@ -1227,34 +1222,6 @@ var RemoteController = class {
     delta.hidden = false;
     delta.dataset.peithoPace = paceState.kind;
     delta.textContent = paceState.label;
-  }
-  renderSection(manifest, currentIndex) {
-    const existing = this.root.querySelector('[data-peitho-remote="section"]');
-    if (currentIndex == null || manifest.sections.length === 0) {
-      existing?.remove();
-      return;
-    }
-    const sectionIndex = sectionIndexForSlide(manifest.sections, currentIndex);
-    if (sectionIndex < 0) {
-      existing?.remove();
-      return;
-    }
-    const section = manifest.sections[sectionIndex];
-    const sectionSlideCount = section.endIndex - section.startIndex + 1;
-    const sectionOffset = currentIndex - section.startIndex + 1;
-    const sectionLine = existing ?? this.doc.createElement("div");
-    sectionLine.className = "peitho-remote-section peitho-remote-dim-on-end";
-    sectionLine.dataset.peithoRemote = "section";
-    const name = this.doc.createElement("b");
-    name.textContent = section.name;
-    sectionLine.replaceChildren(
-      name,
-      this.doc.createTextNode(` \xB7 slide ${sectionOffset} / ${sectionSlideCount} in section`)
-    );
-    if (existing == null) {
-      const notes = this.root.querySelector(".peitho-remote-notes");
-      notes?.before(sectionLine);
-    }
   }
   renderNotes(slideKey) {
     const notes = this.root.querySelector('[data-peitho-remote="notes"]');

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1018,6 +1018,7 @@ var RemoteController = class {
   notes = { version: 1, notes: {} };
   renderedNotesValue = null;
   slides = [];
+  viewportTrackerCleanup = null;
   timerState = null;
   controlsCleanup = null;
   syncCleanup = null;
@@ -1040,6 +1041,7 @@ var RemoteController = class {
   async load() {
     try {
       const manifest = await this.fetchJson(this.manifestUrl);
+      this.viewportTrackerCleanup = installViewportHeightTracker(this.win, this.doc);
       this.manifest = manifest;
       this.notes = await this.fetchNotes();
       this.slides = manifest.slides.map((slide) => ({
@@ -1087,6 +1089,8 @@ var RemoteController = class {
   }
   destroy() {
     this.clearTimerInterval();
+    this.viewportTrackerCleanup?.();
+    this.viewportTrackerCleanup = null;
     this.syncCleanup?.();
     this.syncCleanup = null;
     this.previewShell?.destroy();
@@ -1290,6 +1294,22 @@ var RemoteController = class {
     this.root.textContent = message;
   }
 };
+function installViewportHeightTracker(win, doc) {
+  const write = () => {
+    const height = win.visualViewport?.height ?? win.innerHeight;
+    doc.documentElement.style.setProperty("--peitho-viewport-height", `${height}px`);
+  };
+  const resizeTarget = win.visualViewport ?? win;
+  write();
+  resizeTarget.addEventListener("resize", write);
+  win.addEventListener("orientationchange", write);
+  const animationFrame = win.requestAnimationFrame(() => write());
+  return () => {
+    resizeTarget.removeEventListener("resize", write);
+    win.removeEventListener("orientationchange", write);
+    win.cancelAnimationFrame(animationFrame);
+  };
+}
 function remoteButton(doc, action, label) {
   const button = doc.createElement("button");
   button.type = "button";

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1018,7 +1018,6 @@ var RemoteController = class {
   notes = { version: 1, notes: {} };
   renderedNotesValue = null;
   slides = [];
-  viewportTrackerCleanup = null;
   timerState = null;
   controlsCleanup = null;
   syncCleanup = null;
@@ -1041,7 +1040,6 @@ var RemoteController = class {
   async load() {
     try {
       const manifest = await this.fetchJson(this.manifestUrl);
-      this.viewportTrackerCleanup = installViewportHeightTracker(this.win, this.doc);
       this.manifest = manifest;
       this.notes = await this.fetchNotes();
       this.slides = manifest.slides.map((slide) => ({
@@ -1089,8 +1087,6 @@ var RemoteController = class {
   }
   destroy() {
     this.clearTimerInterval();
-    this.viewportTrackerCleanup?.();
-    this.viewportTrackerCleanup = null;
     this.syncCleanup?.();
     this.syncCleanup = null;
     this.previewShell?.destroy();
@@ -1322,22 +1318,6 @@ var RemoteController = class {
     this.root.textContent = message;
   }
 };
-function installViewportHeightTracker(win, doc) {
-  const write = () => {
-    const height = win.visualViewport?.height ?? win.innerHeight;
-    doc.documentElement.style.setProperty("--peitho-viewport-height", `${height}px`);
-  };
-  const resizeTarget = win.visualViewport ?? win;
-  write();
-  resizeTarget.addEventListener("resize", write);
-  win.addEventListener("orientationchange", write);
-  const animationFrame = win.requestAnimationFrame(() => write());
-  return () => {
-    resizeTarget.removeEventListener("resize", write);
-    win.removeEventListener("orientationchange", write);
-    win.cancelAnimationFrame(animationFrame);
-  };
-}
 function remoteButton(doc, action, label) {
   const button = doc.createElement("button");
   button.type = "button";

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -196,10 +196,6 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   notesBody.dataset.peithoRemote = "notes";
   notesPanel.append(notesCaption, notesBody);
 
-  const status = doc.createElement("div");
-  status.className = "peitho-remote-status";
-  status.dataset.peithoRemote = "status";
-
   const actions = doc.createElement("div");
   actions.className = "peitho-remote-actions";
   const prev = remoteButton(doc, "prev", "Previous");
@@ -220,7 +216,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   timerButton.addEventListener("click", onTimer);
   resetButton.addEventListener("click", onReset);
 
-  container.append(preview, titlebar, chase, pace, notesPanel, status, actions);
+  container.append(preview, titlebar, chase, pace, notesPanel, actions);
   root.append(container);
 
   return () => {
@@ -471,10 +467,8 @@ class RemoteController implements RemoteView {
     this.renderChase(manifest, currentIndex);
     this.renderPaceStatic(manifest);
     this.renderTimeDependentChrome(manifest, currentIndex);
-    this.renderSection(manifest, currentIndex);
     this.renderNotes(slide?.key);
     this.renderButtons(currentIndex);
-    setText(this.root, "status", this.ended ? "Ended" : "");
     this.syncPreview(currentIndex);
     this.updateTimerInterval();
   }
@@ -575,35 +569,6 @@ class RemoteController implements RemoteView {
     delta.hidden = false;
     delta.dataset.peithoPace = paceState.kind;
     delta.textContent = paceState.label;
-  }
-
-  private renderSection(manifest: Manifest, currentIndex: number | null): void {
-    const existing = this.root.querySelector<HTMLElement>('[data-peitho-remote="section"]');
-    if (currentIndex == null || manifest.sections.length === 0) {
-      existing?.remove();
-      return;
-    }
-    const sectionIndex = sectionIndexForSlide(manifest.sections, currentIndex);
-    if (sectionIndex < 0) {
-      existing?.remove();
-      return;
-    }
-    const section = manifest.sections[sectionIndex];
-    const sectionSlideCount = section.endIndex - section.startIndex + 1;
-    const sectionOffset = currentIndex - section.startIndex + 1;
-    const sectionLine = existing ?? this.doc.createElement("div");
-    sectionLine.className = "peitho-remote-section peitho-remote-dim-on-end";
-    sectionLine.dataset.peithoRemote = "section";
-    const name = this.doc.createElement("b");
-    name.textContent = section.name;
-    sectionLine.replaceChildren(
-      name,
-      this.doc.createTextNode(` · slide ${sectionOffset} / ${sectionSlideCount} in section`)
-    );
-    if (existing == null) {
-      const notes = this.root.querySelector<HTMLElement>(".peitho-remote-notes");
-      notes?.before(sectionLine);
-    }
   }
 
   private renderNotes(slideKey: string | undefined): void {

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -505,6 +505,7 @@ class RemoteController implements RemoteView {
     this.renderChase(manifest, currentIndex);
     this.renderPaceStatic(manifest);
     this.renderTimeDependentChrome(manifest, currentIndex);
+    this.renderSection(manifest, currentIndex);
     this.renderNotes(slide?.key);
     this.renderButtons(currentIndex);
     this.syncPreview(currentIndex);
@@ -607,6 +608,34 @@ class RemoteController implements RemoteView {
     delta.hidden = false;
     delta.dataset.peithoPace = paceState.kind;
     delta.textContent = paceState.label;
+  }
+
+  private renderSection(manifest: Manifest, currentIndex: number | null): void {
+    const existing = this.root.querySelector<HTMLElement>('[data-peitho-remote="section"]');
+    if (currentIndex == null || manifest.sections.length === 0) {
+      existing?.remove();
+      return;
+    }
+    const sectionIndex = sectionIndexForSlide(manifest.sections, currentIndex);
+    if (sectionIndex < 0) {
+      existing?.remove();
+      return;
+    }
+    const section = manifest.sections[sectionIndex];
+    const sectionSlideCount = section.endIndex - section.startIndex + 1;
+    const sectionOffset = currentIndex - section.startIndex + 1;
+    const sectionLine = existing ?? createDimmableRow(this.doc, "div", "peitho-remote-section");
+    sectionLine.dataset.peithoRemote = "section";
+    const name = this.doc.createElement("b");
+    name.textContent = section.name;
+    sectionLine.replaceChildren(
+      name,
+      this.doc.createTextNode(` · slide ${sectionOffset} / ${sectionSlideCount} in section`)
+    );
+    if (existing == null) {
+      const notes = this.root.querySelector<HTMLElement>(".peitho-remote-notes");
+      notes?.before(sectionLine);
+    }
   }
 
   private renderNotes(slideKey: string | undefined): void {

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -362,7 +362,6 @@ class RemoteController implements RemoteView {
   private notes: Notes = { version: 1, notes: {} };
   private renderedNotesValue: string | null = null;
   private slides: RemoteSlide[] = [];
-  private viewportTrackerCleanup: (() => void) | null = null;
   private timerState: RemoteTimerAnchor | null = null;
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
@@ -387,7 +386,6 @@ class RemoteController implements RemoteView {
   async load(): Promise<void> {
     try {
       const manifest = await this.fetchJson<Manifest>(this.manifestUrl);
-      this.viewportTrackerCleanup = installViewportHeightTracker(this.win, this.doc);
       this.manifest = manifest;
       this.notes = await this.fetchNotes();
       this.slides = manifest.slides.map((slide) => ({
@@ -436,8 +434,6 @@ class RemoteController implements RemoteView {
 
   destroy(): void {
     this.clearTimerInterval();
-    this.viewportTrackerCleanup?.();
-    this.viewportTrackerCleanup = null;
     this.syncCleanup?.();
     this.syncCleanup = null;
     this.previewShell?.destroy();
@@ -703,23 +699,6 @@ class RemoteController implements RemoteView {
     this.root.className = "peitho-remote-error";
     this.root.textContent = message;
   }
-}
-
-function installViewportHeightTracker(win: Window, doc: Document): () => void {
-  const write = (): void => {
-    const height = win.visualViewport?.height ?? win.innerHeight;
-    doc.documentElement.style.setProperty("--peitho-viewport-height", `${height}px`);
-  };
-  const resizeTarget = win.visualViewport ?? win;
-  write();
-  resizeTarget.addEventListener("resize", write);
-  win.addEventListener("orientationchange", write);
-  const animationFrame = win.requestAnimationFrame(() => write());
-  return () => {
-    resizeTarget.removeEventListener("resize", write);
-    win.removeEventListener("orientationchange", write);
-    win.cancelAnimationFrame(animationFrame);
-  };
 }
 
 function remoteButton(doc: Document, action: "prev" | "next", label: string): HTMLButtonElement {

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -39,6 +39,22 @@ type RemoteTimerAnchor = {
 
 type TimerVisualState = "stopped" | "running" | "paused";
 
+type RemoteViewState =
+  | { kind: "loading" }
+  | { kind: "active"; synced: true }
+  | { kind: "ended" };
+
+const isReadOnly = (state: RemoteViewState): state is { kind: "ended" } =>
+  state.kind === "ended";
+const canInteract = (state: RemoteViewState): state is { kind: "active"; synced: true } =>
+  state.kind === "active";
+
+type RemoteRowElement = HTMLElement & { readonly __peithoDimmable: true };
+
+type RemoteRow =
+  | { kind: "dimmable"; element: RemoteRowElement }
+  | { kind: "actions"; element: HTMLElement };
+
 export type RemotePaceState =
   | { kind: "ahead" | "behind" | "onpace" | "overrun"; label: string }
   | { kind: "paused"; label: "Paused" };
@@ -103,12 +119,10 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   container.className = "peitho-remote";
   container.dataset.peithoEnded = "false";
 
-  const preview = doc.createElement("div");
-  preview.className = "peitho-remote-preview peitho-remote-dim-on-end";
+  const preview = createDimmableRow(doc, "div", "peitho-remote-preview");
   preview.dataset.peithoRemote = "preview";
 
-  const titlebar = doc.createElement("div");
-  titlebar.className = "peitho-remote-titlebar peitho-remote-dim-on-end";
+  const titlebar = createDimmableRow(doc, "div", "peitho-remote-titlebar");
   const title = doc.createElement("div");
   title.className = "peitho-remote-title";
   title.dataset.peithoRemote = "title";
@@ -119,8 +133,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   counter.textContent = "– / –";
   titlebar.append(title, counter);
 
-  const chase = doc.createElement("div");
-  chase.className = "peitho-remote-chase peitho-remote-dim-on-end";
+  const chase = createDimmableRow(doc, "div", "peitho-remote-chase");
   chase.dataset.peithoRemote = "chase";
   chase.dataset.peithoChase = "slide";
   const chaseTrack = doc.createElement("div");
@@ -142,8 +155,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   turtle.textContent = "🐢";
   chase.append(chaseTrack, rabbit, turtle);
 
-  const pace = doc.createElement("div");
-  pace.className = "peitho-remote-pace peitho-remote-dim-on-end";
+  const pace = createDimmableRow(doc, "div", "peitho-remote-pace");
   const timerButton = doc.createElement("button");
   timerButton.type = "button";
   timerButton.className = "peitho-remote-timer-button";
@@ -186,8 +198,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   delta.hidden = true;
   pace.append(timerButton, resetButton, elapsedRow, delta);
 
-  const notesPanel = doc.createElement("section");
-  notesPanel.className = "peitho-remote-notes peitho-remote-dim-on-end";
+  const notesPanel = createDimmableRow(doc, "section", "peitho-remote-notes");
   const notesCaption = doc.createElement("div");
   notesCaption.className = "peitho-remote-notes-caption";
   notesCaption.textContent = "NOTES";
@@ -216,7 +227,20 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   timerButton.addEventListener("click", onTimer);
   resetButton.addEventListener("click", onReset);
 
-  container.append(preview, titlebar, chase, pace, notesPanel, actions);
+  /**
+   * This is the remote's vertical composition contract. Adding a row here is a
+   * design change: decide whether it dims on Ended, and whether it reserves
+   * vertical space even when it has no content.
+   */
+  const rows: RemoteRow[] = [
+    { kind: "dimmable", element: preview },
+    { kind: "dimmable", element: titlebar },
+    { kind: "dimmable", element: chase },
+    { kind: "dimmable", element: pace },
+    { kind: "dimmable", element: notesPanel },
+    { kind: "actions", element: actions }
+  ];
+  container.append(...rows.map((row) => row.element));
   root.append(container);
 
   return () => {
@@ -226,6 +250,16 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
     resetButton.removeEventListener("click", onReset);
     container.remove();
   };
+}
+
+export function createDimmableRow(
+  doc: Document,
+  tag: string,
+  ...classNames: string[]
+): RemoteRowElement {
+  const el = doc.createElement(tag);
+  el.classList.add("peitho-remote-dim-on-end", ...classNames);
+  return el as RemoteRowElement;
 }
 
 export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () => void {
@@ -324,11 +358,10 @@ class RemoteController implements RemoteView {
   private readonly log: Pick<Console, "error">;
   private readonly now: () => number;
   private readonly reload: () => void;
-  private synced = false;
+  private state: RemoteViewState = { kind: "loading" };
   private notes: Notes = { version: 1, notes: {} };
   private renderedNotesValue: string | null = null;
   private slides: RemoteSlide[] = [];
-  private ended = false;
   private timerState: RemoteTimerAnchor | null = null;
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
@@ -441,12 +474,13 @@ class RemoteController implements RemoteView {
   }
 
   private setSynced(): void {
-    this.synced = true;
+    if (this.state.kind !== "loading") return;
+    this.state = { kind: "active", synced: true };
     this.render();
   }
 
   private setEnded(): void {
-    this.ended = true;
+    this.state = { kind: "ended" };
     this.clearTimerInterval();
     this.render();
   }
@@ -456,7 +490,7 @@ class RemoteController implements RemoteView {
     if (manifest == null) return;
     const container = this.root.querySelector<HTMLElement>(".peitho-remote");
     if (container == null) return;
-    container.dataset.peithoEnded = this.ended ? "true" : "false";
+    container.dataset.peithoEnded = isReadOnly(this.state) ? "true" : "false";
     const currentIndex = this.currentIndex;
     const slide = currentIndex == null ? null : manifest.slides[currentIndex];
     const total = this.slides.length;
@@ -505,8 +539,8 @@ class RemoteController implements RemoteView {
 
     const elapsedMs = this.currentElapsedMs();
     const state = timerVisualState(this.timerState, elapsedMs);
-    timerButton.disabled = this.ended || !this.synced;
-    resetButton.disabled = this.ended || !this.synced || state === "stopped";
+    timerButton.disabled = !canInteract(this.state);
+    resetButton.disabled = !canInteract(this.state) || state === "stopped";
     timerButton.dataset.peithoRunning = state === "running" ? "true" : "false";
     timerButton.dataset.peithoTimerAction = playpauseActionFor(state);
     timerButton.setAttribute("aria-label", timerAriaLabel(state));
@@ -595,9 +629,9 @@ class RemoteController implements RemoteView {
     const next = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="next"]');
     if (prev == null || next == null) return;
     prev.disabled =
-      this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
+      !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
     next.disabled =
-      this.ended || !this.synced || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
+      !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
   }
 
   private syncPreview(currentIndex: number | null): void {
@@ -612,7 +646,7 @@ class RemoteController implements RemoteView {
   }
 
   private updateTimerInterval(): void {
-    if (this.ended || this.timerState?.running !== true) {
+    if (isReadOnly(this.state) || this.timerState?.running !== true) {
       this.clearTimerInterval();
       return;
     }

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -362,6 +362,7 @@ class RemoteController implements RemoteView {
   private notes: Notes = { version: 1, notes: {} };
   private renderedNotesValue: string | null = null;
   private slides: RemoteSlide[] = [];
+  private viewportTrackerCleanup: (() => void) | null = null;
   private timerState: RemoteTimerAnchor | null = null;
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
@@ -386,6 +387,7 @@ class RemoteController implements RemoteView {
   async load(): Promise<void> {
     try {
       const manifest = await this.fetchJson<Manifest>(this.manifestUrl);
+      this.viewportTrackerCleanup = installViewportHeightTracker(this.win, this.doc);
       this.manifest = manifest;
       this.notes = await this.fetchNotes();
       this.slides = manifest.slides.map((slide) => ({
@@ -434,6 +436,8 @@ class RemoteController implements RemoteView {
 
   destroy(): void {
     this.clearTimerInterval();
+    this.viewportTrackerCleanup?.();
+    this.viewportTrackerCleanup = null;
     this.syncCleanup?.();
     this.syncCleanup = null;
     this.previewShell?.destroy();
@@ -670,6 +674,23 @@ class RemoteController implements RemoteView {
     this.root.className = "peitho-remote-error";
     this.root.textContent = message;
   }
+}
+
+function installViewportHeightTracker(win: Window, doc: Document): () => void {
+  const write = (): void => {
+    const height = win.visualViewport?.height ?? win.innerHeight;
+    doc.documentElement.style.setProperty("--peitho-viewport-height", `${height}px`);
+  };
+  const resizeTarget = win.visualViewport ?? win;
+  write();
+  resizeTarget.addEventListener("resize", write);
+  win.addEventListener("orientationchange", write);
+  const animationFrame = win.requestAnimationFrame(() => write());
+  return () => {
+    resizeTarget.removeEventListener("resize", write);
+    win.removeEventListener("orientationchange", write);
+    win.cancelAnimationFrame(animationFrame);
+  };
 }
 
 function remoteButton(doc: Document, action: "prev" | "next", label: string): HTMLButtonElement {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -411,7 +411,7 @@ it("remote controller treats a null replay index as the first non-skipped slide"
   expect(channel.sent).toEqual([{ index: 2 }]);
 });
 
-it("remote renders preview title notes and section-aware chase chrome without a section row", async () => {
+it("remote renders preview title section notes and section-aware chase chrome", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(1_000);
   const previewNavigations: unknown[] = [];
@@ -459,7 +459,10 @@ it("remote renders preview title notes and section-aware chase chrome without a 
   expect(
     root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.transform
   ).toBe("translateX(-27.78%)");
-  expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
+  const section = root.querySelector<HTMLElement>('[data-peitho-remote="section"]');
+  expect(section?.textContent).toBe("Architecture · slide 1 / 2 in section");
+  expect(section?.classList).toContain("peitho-remote-dim-on-end");
+  expect(section?.nextElementSibling).toBe(root.querySelector(".peitho-remote-notes"));
   expect(root.querySelector('[data-peitho-remote="notes"]')?.textContent).toBe(
     "Use the typed shell.\nNo shortcuts."
   );
@@ -471,6 +474,22 @@ it("remote renders preview title notes and section-aware chase chrome without a 
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.dataset.peithoPace).toBe(
     "ahead"
   );
+});
+
+it("remote removes the section line when the current slide is outside every section", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "appendix" }], {
+      sections: [{ name: "Intro", startIndex: 0, endIndex: 0, plannedDurationMs: 30_000 }]
+    })
+  );
+
+  expect(root.querySelector('[data-peitho-remote="section"]')?.textContent).toBe(
+    "Intro · slide 1 / 1 in section"
+  );
+
+  channel.deliver({ index: 1 });
+
+  expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
 });
 
 it("remote mounts with empty notes placeholders when notes fetch fails", async () => {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -283,7 +283,7 @@ it("remote controller treats a null replay index as the first non-skipped slide"
   expect(channel.sent).toEqual([{ index: 2 }]);
 });
 
-it("remote renders preview title section notes and section-aware chase chrome", async () => {
+it("remote renders preview title notes and section-aware chase chrome without a section row", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(1_000);
   const previewNavigations: unknown[] = [];
@@ -331,9 +331,7 @@ it("remote renders preview title section notes and section-aware chase chrome", 
   expect(
     root.querySelector<HTMLElement>('[data-peitho-remote="marker-turtle"]')?.style.transform
   ).toBe("translateX(-27.78%)");
-  expect(root.querySelector('[data-peitho-remote="section"]')?.textContent).toBe(
-    "Architecture · slide 1 / 2 in section"
-  );
+  expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
   expect(root.querySelector('[data-peitho-remote="notes"]')?.textContent).toBe(
     "Use the typed shell.\nNo shortcuts."
   );
@@ -396,7 +394,7 @@ it("remote mounts with empty notes placeholders when notes fetch fails", async (
   expect(error).toHaveBeenCalledWith("Failed to load notes.json: offline");
 });
 
-it("remote omits planned and section rows when the deck has no time or sections", async () => {
+it("remote omits planned rows when the deck has no time", async () => {
   const { root, channel } = await mountRemoteForTest(
     manifestWithSlides([{ key: "intro", title: "Intro" }, { key: "end", title: "End" }])
   );
@@ -823,8 +821,9 @@ it("remote controller disables buttons and shows ended state on close", async ()
   expect(
     root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled
   ).toBe(true);
-  expect(root.querySelector('[data-peitho-remote="status"]')?.textContent).toBe("Ended");
   expect(root.querySelector<HTMLElement>(".peitho-remote")?.dataset.peithoEnded).toBe("true");
+  expect(root.querySelector('[data-peitho-remote="status"]')).toBeNull();
+  expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase"]')?.classList).toContain(
     "peitho-remote-dim-on-end"
   );

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -327,6 +327,14 @@ it("remote controller transitions from loading to active to read-only ended", as
   expect(button(root, "next").disabled).toBe(true);
   expect(timer?.disabled).toBe(true);
   expect(reset?.disabled).toBe(true);
+
+  channel.deliver({ synced: true });
+
+  expect(container?.dataset.peithoEnded).toBe("true");
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(true);
+  expect(timer?.disabled).toBe(true);
+  expect(reset?.disabled).toBe(true);
 });
 
 it("remote controller advances optimistically across rapid taps", async () => {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -18,6 +18,8 @@ type MockChannel = SyncChannel & {
   deliver(message: unknown): void;
 };
 
+type MockVisualViewport = EventTarget & { height: number };
+
 function okJson(value: unknown): Response {
   return { ok: true, status: 200, json: async () => value } as Response;
 }
@@ -230,6 +232,56 @@ it("remote controls compose dimmable rows and actions in fixed order", () => {
     expect(element?.classList).toContain("peitho-remote-dim-on-end");
   }
   expect(actions?.classList).not.toContain("peitho-remote-dim-on-end");
+});
+
+it("remote view tracks visual viewport height until destroyed", async () => {
+  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+  const visualViewport = new EventTarget() as MockVisualViewport;
+  visualViewport.height = 812;
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: visualViewport
+  });
+  cleanups.push(() => {
+    if (originalVisualViewport == null) {
+      delete (window as Window & { visualViewport?: VisualViewport }).visualViewport;
+    } else {
+      Object.defineProperty(window, "visualViewport", originalVisualViewport);
+    }
+    document.documentElement.style.removeProperty("--peitho-viewport-height");
+  });
+  let rafCallback: FrameRequestCallback | null = null;
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    rafCallback = callback;
+    return 1;
+  });
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+
+  const { view } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }])
+  );
+
+  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
+    "812px"
+  );
+  visualViewport.height = 820;
+  rafCallback?.(0);
+  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
+    "820px"
+  );
+  visualViewport.height = 760;
+  visualViewport.dispatchEvent(new Event("resize"));
+  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
+    "760px"
+  );
+
+  view.destroy();
+  visualViewport.height = 700;
+  visualViewport.dispatchEvent(new Event("resize"));
+
+  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
+    "760px"
+  );
 });
 
 it("remote controller resolves next and prev across skipped slides and posts absolute indexes", async () => {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, it, vi } from "vitest";
 import type { Manifest } from "../../../bindings/Manifest";
 import type { Notes } from "../../../bindings/Notes";
 import {
+  createDimmableRow,
   expectedElapsedAtSlide,
   installRemoteControls,
   mountRemoteView,
@@ -198,6 +199,39 @@ it("remote controls mount disabled before the synced event arrives", () => {
   ).toBe(true);
 });
 
+it("remote controls compose dimmable rows and actions in fixed order", () => {
+  const root = document.createElement("main");
+  cleanups.push(installRemoteControls({ root, document, bus: new EventTarget() }));
+
+  const row = createDimmableRow(document, "section", "peitho-test-row");
+  expect(row.classList).toContain("peitho-remote-dim-on-end");
+  expect(row.classList).toContain("peitho-test-row");
+
+  const container = root.querySelector<HTMLElement>(".peitho-remote");
+  if (container == null) throw new Error("missing remote container");
+  const preview = root.querySelector<HTMLElement>('[data-peitho-remote="preview"]');
+  const titlebar = root.querySelector<HTMLElement>(".peitho-remote-titlebar");
+  const chase = root.querySelector<HTMLElement>('[data-peitho-remote="chase"]');
+  const pace = root.querySelector<HTMLElement>(".peitho-remote-pace");
+  const notesPanel = root.querySelector<HTMLElement>(".peitho-remote-notes");
+  const actions = root.querySelector<HTMLElement>(".peitho-remote-actions");
+  const dimmableRows = [preview, titlebar, chase, pace, notesPanel];
+
+  expect(Array.from(container.children)).toEqual([
+    preview,
+    titlebar,
+    chase,
+    pace,
+    notesPanel,
+    actions
+  ]);
+  expect(dimmableRows).toHaveLength(5);
+  for (const element of dimmableRows) {
+    expect(element?.classList).toContain("peitho-remote-dim-on-end");
+  }
+  expect(actions?.classList).not.toContain("peitho-remote-dim-on-end");
+});
+
 it("remote controller resolves next and prev across skipped slides and posts absolute indexes", async () => {
   const { root, channel } = await mountRemoteForTest(
     manifestWithSlides([{ key: "intro" }, { key: "skip", skip: true }, { key: "end" }])
@@ -259,6 +293,40 @@ it("remote controls enable after synced replay is reported", async () => {
   ).toBe(true);
   button(root, "next").click();
   expect(channel.sent).toEqual([{ index: 1 }]);
+});
+
+it("remote controller transitions from loading to active to read-only ended", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }]),
+    mockChannel(),
+    { autoSync: false }
+  );
+
+  const timer = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer"]');
+  const reset = root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]');
+  const container = root.querySelector<HTMLElement>(".peitho-remote");
+
+  expect(container?.dataset.peithoEnded).toBe("false");
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(true);
+  expect(timer?.disabled).toBe(true);
+  expect(reset?.disabled).toBe(true);
+
+  channel.deliver({ synced: true });
+
+  expect(container?.dataset.peithoEnded).toBe("false");
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(false);
+  expect(timer?.disabled).toBe(false);
+  expect(reset?.disabled).toBe(true);
+
+  channel.deliver({ close: true });
+
+  expect(container?.dataset.peithoEnded).toBe("true");
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(true);
+  expect(timer?.disabled).toBe(true);
+  expect(reset?.disabled).toBe(true);
 });
 
 it("remote controller advances optimistically across rapid taps", async () => {

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -244,15 +244,15 @@ it("remote view tracks visual viewport height until destroyed", async () => {
   });
   cleanups.push(() => {
     if (originalVisualViewport == null) {
-      delete (window as Window & { visualViewport?: VisualViewport }).visualViewport;
+      delete (window as unknown as { visualViewport?: VisualViewport }).visualViewport;
     } else {
       Object.defineProperty(window, "visualViewport", originalVisualViewport);
     }
     document.documentElement.style.removeProperty("--peitho-viewport-height");
   });
-  let rafCallback: FrameRequestCallback | null = null;
+  const raf = { callback: null as FrameRequestCallback | null };
   vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-    rafCallback = callback;
+    raf.callback = callback;
     return 1;
   });
   vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
@@ -265,7 +265,8 @@ it("remote view tracks visual viewport height until destroyed", async () => {
     "812px"
   );
   visualViewport.height = 820;
-  rafCallback?.(0);
+  if (raf.callback == null) throw new Error("missing viewport animation frame callback");
+  raf.callback(0);
   expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
     "820px"
   );

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -18,8 +18,6 @@ type MockChannel = SyncChannel & {
   deliver(message: unknown): void;
 };
 
-type MockVisualViewport = EventTarget & { height: number };
-
 function okJson(value: unknown): Response {
   return { ok: true, status: 200, json: async () => value } as Response;
 }
@@ -232,57 +230,6 @@ it("remote controls compose dimmable rows and actions in fixed order", () => {
     expect(element?.classList).toContain("peitho-remote-dim-on-end");
   }
   expect(actions?.classList).not.toContain("peitho-remote-dim-on-end");
-});
-
-it("remote view tracks visual viewport height until destroyed", async () => {
-  const originalVisualViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
-  const visualViewport = new EventTarget() as MockVisualViewport;
-  visualViewport.height = 812;
-  Object.defineProperty(window, "visualViewport", {
-    configurable: true,
-    value: visualViewport
-  });
-  cleanups.push(() => {
-    if (originalVisualViewport == null) {
-      delete (window as unknown as { visualViewport?: VisualViewport }).visualViewport;
-    } else {
-      Object.defineProperty(window, "visualViewport", originalVisualViewport);
-    }
-    document.documentElement.style.removeProperty("--peitho-viewport-height");
-  });
-  const raf = { callback: null as FrameRequestCallback | null };
-  vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
-    raf.callback = callback;
-    return 1;
-  });
-  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
-
-  const { view } = await mountRemoteForTest(
-    manifestWithSlides([{ key: "intro" }, { key: "end" }])
-  );
-
-  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
-    "812px"
-  );
-  visualViewport.height = 820;
-  if (raf.callback == null) throw new Error("missing viewport animation frame callback");
-  raf.callback(0);
-  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
-    "820px"
-  );
-  visualViewport.height = 760;
-  visualViewport.dispatchEvent(new Event("resize"));
-  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
-    "760px"
-  );
-
-  view.destroy();
-  visualViewport.height = 700;
-  visualViewport.dispatchEvent(new Event("resize"));
-
-  expect(document.documentElement.style.getPropertyValue("--peitho-viewport-height")).toBe(
-    "760px"
-  );
 });
 
 it("remote controller resolves next and prev across skipped slides and posts absolute indexes", async () => {


### PR DESCRIPTION
Closes #309.

## Summary

Standalone (chrome-free) /remote had three empty bands the author noticed on a real device (2026-07-17): portrait bottom clearance (~52px below Next), portrait blank band between notes and Previous (~42px from the empty Status row), and landscape blank space below notes. All three collapse into one structural change plus one iOS-specific tweak:

- **Portrait `padding-bottom` 18px → 8px** — chrome-tuned clearance became home-indicator-tuned.
- **Status row removed entirely** — Ended is already expressed by the whole surface dimming plus every button becoming disabled (both already-existing behaviors), so the text row was redundant. Notes gets that ~42px + ~10px = ~52px back.
- **Landscape `notes` spans rows 1–3** (`grid-area: 1/2/4/3`) — takes the old Status band. The Section line stays at row 4 (bottom-aligned).
- **Ended dim strength 0.35 → 0.28** — author-approved via mock.
- **iOS standalone cold-start `100dvh` bug** — WebKit does not initialize `dvh` until the viewport is "exercised" by a rotation, which matched the reported symptom "rotate portrait→landscape→portrait clears the dead band". `visualViewport.height` / `window.innerHeight` return the same stale value at cold start so a JS tracker cannot help. Fix is CSS-only: `@media (display-mode: standalone)` overrides `height` to `100vh` (always correct in standalone — no UA chrome). In-browser cascade `vh → svh → dvh` stays for Safari's landscape tab-bar case.

## Additional refactor (Round 3 self-review follow-up)

Self-review after the CSS/DOM change flagged that `this.ended: boolean` + `this.synced: boolean` was two independent flags where three valid states existed, and that "Ended = read-only" was enforced by every render method threading `this.ended || ...` into disabled predicates — a future caller could forget it.

- Collapsed into `RemoteViewState = { kind: "loading" } | { kind: "active"; synced: true } | { kind: "ended" }` discriminated union. `canInteract(state)` and `isReadOnly(state)` are type guards; every disabled predicate goes through `canInteract`. Invalid combinations like `ended && !synced` are no longer representable.
- `setSynced()` after `setEnded()` is now a no-op by construction (Ended cannot transition to active). Locked with a dedicated test (`96f9fcc`).
- Added `createDimmableRow(doc, tag, ...classNames)` factory so the `peitho-remote-dim-on-end` class name lives in one place rather than five hand-typed string literals.
- Typed `RemoteRow[]` composition list in `installRemoteControls` — adding a row now requires declaring `kind: "dimmable" | "actions"` at construction, making a "usually-empty reserved row" self-documenting at review time.

Known limits documented in the plan (`docs/plans/2026-07-18-remote-standalone-tuning.md`):
- `RemoteRowElement`'s brand is a phantom type and can be bypassed with `as` cast — improves readability, is not fully forceable in TypeScript.
- The CSS `.peitho-remote-dim-on-end` selector name is duplicated between `render.rs` and `remote.ts`; a rename on one side without the other silently drops the dim.
- `installRemoteSyncBridge` still holds a local `let synced = false` outside the controller's typestate — unchanged from before this PR.

## Design record

- Plan: `docs/plans/2026-07-18-remote-standalone-tuning.md` (includes 2026-07-18 real-device amendments for the section restore and the standalone dvh cold-start pitfall).
- Claude Design mock (v4 "final", author-approved): https://claude.ai/design/p/4bfae954-d0e7-41f8-8c4d-a50e231c1802?file=Remote+Tuning.dc.html

## Test plan

- [x] `cargo test --workspace` × 3 all-pass (past test-race incidents)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `git diff --exit-code bindings/` clean
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck` clean (267 tests)
- [x] `dist/shell.js`, `dist/preview.js` byte-identical; `dist/remote.js` rebuilt and committed
- [x] Real-device confirmed: portrait cold start no longer leaves a dead band; landscape Section line visible at row 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)