### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "html-escape",
  "lol_html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.9.0"
+version = "1.10.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Release v1.10.0.

## Changes since v1.9.0

### New Features
- #305 Landscape layout for /remote and stacked navigation buttons
- #308 Standalone home-screen mode for /remote and a stable --host port

### Bug Fixes
- #310 fix(remote): clear ended and stale session state on re-handshake
- #311 fix(remote): reclaim standalone dead space and tighten Ended state (#309)