### PR TITLE
docs: reword pillar 2 as "version-controllable"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ All written artifacts in this project must be in English. This includes: documen
 ## The three pillars (invariants that must not be broken)
 
 1. **Separation of content and design**: Content is Markdown, design is layout HTML+CSS. Do not mix them
-2. **Git-manageable HTML/CSS layouts**: The layout itself is the schema (`<slot name accepts arity>`). Do not split the contract into a separate file
+2. **Version-controllable HTML/CSS layouts**: The layout itself is the schema (`<slot name accepts arity>`). Do not split the contract into a separate file
 3. **Type-checked slot contracts and keyed overrides**: Slot excess/deficiency, type mismatches, broken references, and unassigned content are all build errors with line numbers + help. **Silent dropping is absolutely forbidden** (never let the parser swallow unknown structures with `_ => {}`)
 
 Other invariants:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Content that doesn't fit the contract — missing or extra slots, type mismatche
 The three pillars, in short:
 
 - **Separation of content and design** — content is Markdown, design is layout HTML and CSS. While writing, you never think about design; the design carries over to your next deck
-- **Git-manageable layouts** — design artifacts are plain HTML/CSS. They diff and review cleanly
+- **Version-controllable layouts** — design artifacts are plain HTML/CSS. They diff and review cleanly
 - **Type-checked slot contracts** — the layout is the schema. Violations are build errors with line numbers and hints, never silent drops
 
 ## Quick start

--- a/docs/PEITHO_KICKOFF.md
+++ b/docs/PEITHO_KICKOFF.md
@@ -20,8 +20,8 @@
 
 1. **Separation of content and design** (derived from k1LoW/deck)
    Content is Markdown, design is templates and CSS. The two are never mixed.
-2. **HTML-native, git-manageable templates**
-   Design artifacts are HTML/CSS. They can be managed with git, diffed, and reviewed. Whereas deck locks design into Google Slides' proprietary world, Peitho differentiates itself here.
+2. **HTML-native, version-controllable templates**
+   Design artifacts are HTML/CSS. They can be version-controlled, diffed, and reviewed. Whereas deck locks design into Google Slides' proprietary world, Peitho differentiates itself here.
 3. **Type-checked slot contracts and keyed overrides** (derived from Carina)
    Slot shortages/excesses, type mismatches, and broken references are detected at build time. The polar opposite of deck's "silently drops content when placeholders are insufficient."
 
@@ -168,7 +168,7 @@ Peitho stays a **pure renderer** (it does not adopt deck's stateful-target appro
 ```
 
 - The content (Markdown) is never touched. Adjustments are left to the cascade.
-- Everything is git-managed, diffable, and fully reproducible. Re-rendering naturally reapplies it (achieving "the adjustment survives" even though it's a pure function, via source-side CSS).
+- Everything is version-controlled, diffable, and fully reproducible. Re-rendering naturally reapplies it (achieving "the adjustment survives" even though it's a pure function, via source-side CSS).
 - This is only possible because it's HTML/CSS-native. Since deck's Google Slides has no cascade, it had no choice but to accumulate state on the target. Peitho produces the same result without accumulating state.
 - **Override checking**: an override targeting a nonexistent slot is a compile error. A reference to a nonexistent slide key is also an error. Even the escape hatch is protected by types.
 
@@ -244,10 +244,10 @@ peitho/
 
 ## 11. Positioning (Differentiation from Existing Tools)
 
-- **deck**: borrows the content/design separation concept. However deck depends on Google Slides (proprietary, OAuth, stateful). Peitho differentiates itself by being HTML-native, git-managed, and a pure renderer.
+- **deck**: borrows the content/design separation concept. However deck depends on Google Slides (proprietary, OAuth, stateful). Peitho differentiates itself by being HTML-native, version-controllable, and a pure renderer.
 - **Slidev / Marp**: part of the same lineage of Markdown-based, developer-oriented presentation tools. Peitho's distinctiveness is its **type-checked slot contracts + keyed overrides** (no silent drops, broken references rejected at build time) — bringing Carina's type philosophy into slides.
 
-In short: **deck's content/design separation × HTML-native, git-manageable templates × Carina-derived type-checked slot contracts and keyed overrides**.
+In short: **deck's content/design separation × HTML-native, version-controllable templates × Carina-derived type-checked slot contracts and keyed overrides**.
 
 ---
 

--- a/docs/plans/2026-07-05-explicit-slot-syntax.md
+++ b/docs/plans/2026-07-05-explicit-slot-syntax.md
@@ -8,7 +8,7 @@ Break the spec-final design down to implementable steps. Everything is done in T
 ## Alignment with the three pillars / invariants
 
 - **Pillar ① (separation of content and design)**: the new notation is a Markdown-side extension (`:::` + attribute). No HTML fragment is imposed on the author. ✅
-- **Pillar ② (Git-manageable HTML/CSS layouts)**: no layout-side changes. The slot contract stays single-sourced from the layout HTML. ✅
+- **Pillar ② (Version-controllable HTML/CSS layouts)**: no layout-side changes. The slot contract stays single-sourced from the layout HTML. ✅
 - **Pillar ③ (type-checked slot contract, no silent drop)**:
   - `ExplicitSlot(SlotName)` newtype separates convention-driven and explicit routing at the type level
   - All 11 validation rules (see spec) become line-numbered build errors with help

--- a/docs/plans/2026-07-09-docs-site.md
+++ b/docs/plans/2026-07-09-docs-site.md
@@ -250,7 +250,7 @@ Page outline:
 - Pillars:
   - "Separation of content and design": Markdown owns content; HTML/CSS own
     layout and theme.
-  - "Git-manageable HTML/CSS layouts": layouts and CSS are normal files that
+  - "Version-controllable HTML/CSS layouts": layouts and CSS are normal files that
     diff and review cleanly.
   - "Type-checked slot contracts": `<slot name accepts arity>` is the schema;
     missing, extra, mistyped, and unassigned content fail the build with line
@@ -282,7 +282,7 @@ rm -rf .zola-landing
 test -f .zola-landing/index.html
 rg -n 'HTML-native presentation tool' .zola-landing/index.html
 rg -n 'Separation of content and design' .zola-landing/index.html
-rg -n 'Git-manageable HTML&#x2F;CSS layouts' .zola-landing/index.html
+rg -n 'Version-controllable HTML&#x2F;CSS layouts' .zola-landing/index.html
 rg -n 'Type-checked slot contracts' .zola-landing/index.html
 rg -n 'brew install mizzy&#x2F;tap&#x2F;peitho' .zola-landing/index.html
 rg -n '/guide/' .zola-landing/index.html

--- a/docs/specs/2026-07-09-docs-site-design.md
+++ b/docs/specs/2026-07-09-docs-site-design.md
@@ -21,7 +21,7 @@ peitho's own requirements rather than by what similar tools use:
   this spec was first approved): monochrome palette, Mincho typography, black
   section rules, and hairline rows. Zola templates are plain HTML + CSS
   (Tera), so the identity extends naturally to the whole site. This also
-  matches peitho's own pillars: HTML-native, git-manageable HTML/CSS.
+  matches peitho's own pillars: HTML-native, version-controllable HTML/CSS.
 - **Rust toolchain.** Zola is a single Rust binary; CI installs one tool. No
   new package ecosystem is introduced for the site.
 - **syntect built in.** Zola highlights code with syntect — the same
@@ -54,7 +54,7 @@ Japanese can be added later non-destructively by dropping
 ### Content structure: three pillars
 
 1. **Landing page** (`/`) — hero (one-line statement of what peitho is), the
-   three pillars (separation of content and design; git-manageable HTML/CSS
+   three pillars (separation of content and design; version-controllable HTML/CSS
    layouts; type-checked slot contracts), install one-liner, and entry points
    into the guide and examples. Uses the https://gosu.ke visual identity by
    author decision on 2026-07-09.

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -14,7 +14,7 @@ title = "Separation of content and design"
 meta = "Markdown owns the content; HTML and CSS own the layout and theme. Neither leaks into the other."
 
 [[extra.sections.rows]]
-title = "Git-manageable HTML/CSS layouts"
+title = "Version-controllable HTML/CSS layouts"
 meta = "Layouts and CSS are normal files that diff and review cleanly. The layout itself is the schema (<slot name accepts arity>)."
 
 [[extra.sections.rows]]


### PR DESCRIPTION
## Summary
- Rename pillar ② from "Git-manageable HTML/CSS layouts" to "Version-controllable HTML/CSS layouts" across the README, kickoff spec, docs-site landing copy, plan/spec records, and CLAUDE.md.
- "Git-manageable" names one specific VCS; the actual claim (plain-text layouts that diff and roll back) holds for any version control system, so the broader term matches the pillar's intent.
- Also updates the `docs/PEITHO_KICKOFF.md` §7 "everything is git-managed" line and the `docs/plans/2026-07-09-docs-site.md` verification `rg` command that referenced the old phrase.

## Test plan
- [ ] `(cd site && zola build --output-dir ../.zola-landing)` and confirm the landing page renders the new pillar title (`rg -n 'Version-controllable HTML&#x2F;CSS layouts' .zola-landing/index.html`).
- [ ] Skim the diff to confirm no code / test / template referenced the old phrase.