### PR TITLE
Release v1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.12.0"
+version = "1.13.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
## Summary

Bump version to 1.13.0 for the next release.

Since v1.12.0, one PR merged:

- #324 Support footnotes in slide bodies (Issue #323) — Markdown footnote references and definitions; hybrid slot dispatch places the block into a dedicated `footnotes` slot when the layout declares one, otherwise at the end of `body`; plain superscript markers; example deck bundled

## Test plan

- [x] cargo test --workspace ×3
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo fmt --all --check
- [x] git diff --exit-code bindings/
- [x] npm run build && npm test && npm run typecheck
- [x] git diff --exit-code packages/peitho-present/dist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)