### PR TITLE
Remote pointer: laser-style pointer with fading trail from the phone remote

### DIFF
--- a/bindings/Manifest.ts
+++ b/bindings/Manifest.ts
@@ -4,4 +4,4 @@ import type { ManifestImage } from "./ManifestImage";
 import type { ManifestSection } from "./ManifestSection";
 import type { ManifestSlide } from "./ManifestSlide";
 
-export type Manifest = { version: number, peithoVersion: string, title: string, slideCount: number, plannedDurationMs: number | null, aspectRatio: AspectRatio, canvasWidth: number, canvasHeight: number, sections: Array<ManifestSection>, slides: Array<ManifestSlide>, images: Array<ManifestImage>, };
+export type Manifest = { version: number, peithoVersion: string, title: string, slideCount: number, plannedDurationMs: number | null, aspectRatio: AspectRatio, pointerColor?: string, canvasWidth: number, canvasHeight: number, sections: Array<ManifestSection>, slides: Array<ManifestSlide>, images: Array<ManifestImage>, };

--- a/crates/peitho-core/src/manifest.rs
+++ b/crates/peitho-core/src/manifest.rs
@@ -232,44 +232,6 @@ impl Manifest {
         sections: Vec<ManifestSection>,
         slides: Vec<ManifestSlide>,
     ) -> Self {
-        Self::with_images(
-            title,
-            planned_duration_ms,
-            aspect_ratio,
-            sections,
-            slides,
-            Vec::new(),
-        )
-    }
-
-    pub fn with_images(
-        title: impl Into<String>,
-        planned_duration_ms: Option<u64>,
-        aspect_ratio: AspectRatio,
-        sections: Vec<ManifestSection>,
-        slides: Vec<ManifestSlide>,
-        images: Vec<ManifestImage>,
-    ) -> Self {
-        Self::with_images_and_pointer_color(
-            title,
-            planned_duration_ms,
-            aspect_ratio,
-            None,
-            sections,
-            slides,
-            images,
-        )
-    }
-
-    pub fn with_images_and_pointer_color(
-        title: impl Into<String>,
-        planned_duration_ms: Option<u64>,
-        aspect_ratio: AspectRatio,
-        pointer_color: Option<String>,
-        sections: Vec<ManifestSection>,
-        slides: Vec<ManifestSlide>,
-        images: Vec<ManifestImage>,
-    ) -> Self {
         let slide_count = slides.len();
         Self {
             version: 1,
@@ -278,11 +240,21 @@ impl Manifest {
             slide_count,
             planned_duration_ms,
             aspect_ratio,
-            pointer_color,
+            pointer_color: None,
             sections,
             slides,
-            images,
+            images: Vec::new(),
         }
+    }
+
+    pub fn with_images(mut self, images: Vec<ManifestImage>) -> Self {
+        self.images = images;
+        self
+    }
+
+    pub fn with_pointer_color(mut self, pointer_color: Option<String>) -> Self {
+        self.pointer_color = pointer_color;
+        self
     }
 
     pub fn slide_count(&self) -> usize {
@@ -426,17 +398,19 @@ pub fn build_manifest<S>(deck: &Deck<Checked<S>>, image_assets: &[ResolvedImageA
         .map(|asset| ManifestImage::new(asset.dist_rel.as_str()))
         .collect();
 
-    Manifest::with_images_and_pointer_color(
+    Manifest::new(
         title,
         deck.settings().planned_time().map(PlannedTime::as_millis),
         deck.settings().aspect_ratio(),
+        sections,
+        slides,
+    )
+    .with_pointer_color(
         deck.settings()
             .pointer_color()
             .map(|color| color.as_str().to_owned()),
-        sections,
-        slides,
-        images,
     )
+    .with_images(images)
 }
 
 pub fn fragment_src(index: usize, key: &SlideKey) -> String {

--- a/crates/peitho-core/src/manifest.rs
+++ b/crates/peitho-core/src/manifest.rs
@@ -15,6 +15,7 @@ pub struct Manifest {
     slide_count: usize,
     planned_duration_ms: Option<u64>,
     aspect_ratio: AspectRatio,
+    pointer_color: Option<String>,
     sections: Vec<ManifestSection>,
     slides: Vec<ManifestSlide>,
     images: Vec<ManifestImage>,
@@ -32,6 +33,12 @@ struct ManifestWire {
     planned_duration_ms: Option<u64>,
     #[serde(rename = "aspectRatio", default)]
     aspect_ratio: AspectRatio,
+    #[serde(
+        rename = "pointerColor",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pointer_color: Option<String>,
     #[serde(rename = "canvasWidth", skip_deserializing)]
     canvas_width: u32,
     #[serde(rename = "canvasHeight", skip_deserializing)]
@@ -58,6 +65,8 @@ struct ManifestBinding {
     planned_duration_ms: Option<u64>,
     #[ts(rename = "aspectRatio")]
     aspect_ratio: AspectRatio,
+    #[ts(rename = "pointerColor", optional)]
+    pointer_color: Option<String>,
     #[ts(rename = "canvasWidth")]
     canvas_width: u32,
     #[ts(rename = "canvasHeight")]
@@ -241,6 +250,26 @@ impl Manifest {
         slides: Vec<ManifestSlide>,
         images: Vec<ManifestImage>,
     ) -> Self {
+        Self::with_images_and_pointer_color(
+            title,
+            planned_duration_ms,
+            aspect_ratio,
+            None,
+            sections,
+            slides,
+            images,
+        )
+    }
+
+    pub fn with_images_and_pointer_color(
+        title: impl Into<String>,
+        planned_duration_ms: Option<u64>,
+        aspect_ratio: AspectRatio,
+        pointer_color: Option<String>,
+        sections: Vec<ManifestSection>,
+        slides: Vec<ManifestSlide>,
+        images: Vec<ManifestImage>,
+    ) -> Self {
         let slide_count = slides.len();
         Self {
             version: 1,
@@ -249,6 +278,7 @@ impl Manifest {
             slide_count,
             planned_duration_ms,
             aspect_ratio,
+            pointer_color,
             sections,
             slides,
             images,
@@ -266,6 +296,10 @@ impl Manifest {
     /// The deck's canvas aspect ratio, from frontmatter `aspect_ratio:` or default 16:9.
     pub fn aspect_ratio(&self) -> AspectRatio {
         self.aspect_ratio
+    }
+
+    pub fn pointer_color(&self) -> Option<&str> {
+        self.pointer_color.as_deref()
     }
 
     /// Derived logical canvas width in pixels; equals `aspect_ratio().width()`.
@@ -300,6 +334,7 @@ impl From<&Manifest> for ManifestWire {
             slide_count: manifest.slide_count,
             planned_duration_ms: manifest.planned_duration_ms,
             aspect_ratio: manifest.aspect_ratio,
+            pointer_color: manifest.pointer_color.clone(),
             canvas_width: manifest.canvas_width(),
             canvas_height: manifest.canvas_height(),
             sections: manifest.sections.clone(),
@@ -318,6 +353,7 @@ impl From<ManifestWire> for Manifest {
             slide_count: wire.slide_count,
             planned_duration_ms: wire.planned_duration_ms,
             aspect_ratio: wire.aspect_ratio,
+            pointer_color: wire.pointer_color,
             sections: wire.sections,
             slides: wire.slides,
             images: wire.images,
@@ -390,10 +426,13 @@ pub fn build_manifest<S>(deck: &Deck<Checked<S>>, image_assets: &[ResolvedImageA
         .map(|asset| ManifestImage::new(asset.dist_rel.as_str()))
         .collect();
 
-    Manifest::with_images(
+    Manifest::with_images_and_pointer_color(
         title,
         deck.settings().planned_time().map(PlannedTime::as_millis),
         deck.settings().aspect_ratio(),
+        deck.settings()
+            .pointer_color()
+            .map(|color| color.as_str().to_owned()),
         sections,
         slides,
         images,
@@ -616,6 +655,20 @@ mod tests {
         assert!(json.contains(r#""aspectRatio": "4:3""#));
         assert!(json.contains(r#""canvasWidth": 960"#));
         assert!(json.contains(r#""canvasHeight": 720"#));
+    }
+
+    #[test]
+    fn build_manifest_serializes_pointer_color_from_checked_deck() {
+        let checked = checked_deck(
+            "---\npointer_color: '#ff2a2a'\n---\n# Intro",
+            title_body_layout(),
+        );
+
+        let manifest = build_manifest(&checked, &[]);
+        let json = manifest_json(&manifest).unwrap();
+
+        assert_eq!(manifest.pointer_color(), Some("#ff2a2a"));
+        assert!(json.contains("\"pointerColor\": \"#ff2a2a\""));
     }
 
     #[test]

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -18,7 +18,7 @@ use crate::{
     highlight::Highlighter,
     phase::{
         AssetPath, Deck, DeckSection, DeckSettings, KeySource, LayoutRequest, PageNumberFormat,
-        Parsed, ParsedSlide, PlannedTime,
+        Parsed, ParsedSlide, PlannedTime, PointerColor,
     },
 };
 
@@ -57,6 +57,8 @@ struct DeckFrontmatter {
     breaks: bool,
     #[serde(default, deserialize_with = "deserialize_optional_page_number_format")]
     page_numbers: Option<PageNumberFormat>,
+    #[serde(default)]
+    pointer_color: Option<String>,
     #[serde(default)]
     layouts: Option<AssetPath>,
     #[serde(default)]
@@ -805,6 +807,10 @@ fn parse_deck_frontmatter(raw: Option<&RawFrontmatter>) -> Result<DeckSettings> 
     )?;
     let resolution =
         parse_frontmatter_resolution(parsed.resolution, key_lines.get("resolution").copied())?;
+    let pointer_color = parse_frontmatter_pointer_color(
+        parsed.pointer_color,
+        key_lines.get("pointer_color").copied(),
+    )?;
     let code_images =
         parse_code_images_config(parsed.code_images, key_lines.get("code_images").copied())?;
 
@@ -814,6 +820,7 @@ fn parse_deck_frontmatter(raw: Option<&RawFrontmatter>) -> Result<DeckSettings> 
         resolution,
         parsed.breaks,
         parsed.page_numbers,
+        pointer_color,
         Vec::new(),
         parsed.layouts,
         parsed.css,
@@ -948,6 +955,7 @@ fn frontmatter_key_lines(raw: Option<&RawFrontmatter>) -> HashMap<&'static str, 
             "resolution",
             "breaks",
             "page_numbers",
+            "pointer_color",
             "layouts",
             "css",
             "syntaxes",
@@ -1019,6 +1027,24 @@ fn parse_frontmatter_resolution(
             Some(line),
             "resolution has no value",
             "set resolution to WxH pixels, like 1920x1080",
+        )),
+    }
+}
+
+fn parse_frontmatter_pointer_color(
+    value: Option<String>,
+    line: Option<usize>,
+) -> Result<Option<PointerColor>> {
+    match (value.as_deref(), line) {
+        (None, None) => Ok(None),
+        (Some(value), line) => PointerColor::parse(value).map(Some).map_err(|message| {
+            BuildError::new(ErrorKind::Parse, line, message, PointerColor::HELP)
+        }),
+        (None, Some(line)) => Err(BuildError::new(
+            ErrorKind::Parse,
+            Some(line),
+            "pointer_color has no value",
+            PointerColor::HELP,
         )),
     }
 }
@@ -1161,7 +1187,7 @@ fn frontmatter_yaml_error(raw: &RawFrontmatter, err: &serde_norway::Error) -> Bu
 
 fn frontmatter_help(message: &str) -> &'static str {
     if message.contains("unknown field") || message.contains("duplicate entry") {
-        "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, layouts, css, syntaxes, fonts, code_images"
+        "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, pointer_color, layouts, css, syntaxes, fonts, code_images"
     } else if frontmatter_message_mentions_key(message, "aspect_ratio") {
         "set aspect_ratio to 16:9 or 4:3"
     } else if frontmatter_message_mentions_key(message, "resolution") {
@@ -1172,6 +1198,8 @@ fn frontmatter_help(message: &str) -> &'static str {
         || message.contains(r#"use "current" or "current_of_total""#)
     {
         r#"use "current" or "current_of_total""#
+    } else if frontmatter_message_mentions_key(message, "pointer_color") {
+        PointerColor::HELP
     } else if frontmatter_message_mentions_key(message, "layouts") {
         "provide a path (relative to the deck file), or remove the layouts: key"
     } else if frontmatter_message_mentions_key(message, "css") {
@@ -2664,6 +2692,54 @@ mod tests {
     }
 
     #[test]
+    fn parses_pointer_color_frontmatter_values() {
+        let cases = [
+            ("'#ff2a2a'", "#ff2a2a"),
+            ("'#f00'", "#f00"),
+            ("'#ff2a2aff'", "#ff2a2aff"),
+            ("red", "red"),
+            ("cyan", "cyan"),
+        ];
+
+        for (yaml_value, expected) in cases {
+            let markdown = format!("---\npointer_color: {yaml_value}\n---\n# Intro");
+            let deck =
+                parse_markdown(&markdown, &crate::highlight::Highlighter::defaults()).unwrap();
+
+            assert_eq!(deck.settings().pointer_color().unwrap().as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn omitted_pointer_color_frontmatter_defaults_to_none() {
+        let deck = parse_markdown("# Intro", &crate::highlight::Highlighter::defaults()).unwrap();
+
+        assert_eq!(deck.settings().pointer_color(), None);
+    }
+
+    #[test]
+    fn rejects_invalid_pointer_color_frontmatter_with_line_and_help() {
+        for frontmatter_line in [
+            "pointer_color: not-a-color",
+            "pointer_color: rgb(255,0,0)",
+            "pointer_color: \"\"",
+        ] {
+            let markdown = format!("---\ntime: 15m\n{frontmatter_line}\n---\n# Intro");
+            let err =
+                parse_markdown(&markdown, &crate::highlight::Highlighter::defaults()).unwrap_err();
+
+            assert_eq!(err.kind, ErrorKind::Parse, "case: {frontmatter_line}");
+            assert_eq!(err.line, Some(3), "case: {frontmatter_line}");
+            assert!(
+                err.message.contains("pointer_color"),
+                "case: {frontmatter_line}: {}",
+                err.message
+            );
+            assert_eq!(err.help, PointerColor::HELP, "case: {frontmatter_line}");
+        }
+    }
+
+    #[test]
     fn parsed_deck_settings_keep_planned_time_until_consumed() {
         let raw = RawFrontmatter {
             line: 1,
@@ -3286,6 +3362,14 @@ mod tests {
         let frontmatter = parse_frontmatter("---\ntime: 15m\nbreaks: true\n---\n# Intro").unwrap();
 
         assert_eq!(frontmatter.key_line("breaks"), Some(3));
+    }
+
+    #[test]
+    fn parse_frontmatter_records_key_line_for_pointer_color() {
+        let frontmatter =
+            parse_frontmatter("---\ntime: 15m\npointer_color: cyan\n---\n# Intro").unwrap();
+
+        assert_eq!(frontmatter.key_line("pointer_color"), Some(3));
     }
 
     #[test]
@@ -5198,7 +5282,7 @@ After list
         assert!(err.to_string().contains("invalid deck frontmatter"));
         assert_eq!(
             err.help,
-            "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, layouts, css, syntaxes, fonts, code_images"
+            "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, pointer_color, layouts, css, syntaxes, fonts, code_images"
         );
     }
 
@@ -5313,6 +5397,10 @@ After list
                 "set breaks to true or false",
             ),
             (
+                "---\npointer_color: not-a-color\n---\n# Intro",
+                PointerColor::HELP,
+            ),
+            (
                 "---\ntime: bad-value\n---\n# Intro",
                 "set time to 15m, 90s, 1h, 1h30m, or an integer minute count",
             ),
@@ -5399,7 +5487,7 @@ After list
         assert!(err.to_string().contains("duplicate entry"));
         assert_eq!(
             err.help,
-            "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, layouts, css, syntaxes, fonts, code_images"
+            "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, pointer_color, layouts, css, syntaxes, fonts, code_images"
         );
     }
 
@@ -5456,7 +5544,7 @@ After list
         assert!(err.to_string().contains("invalid deck frontmatter"));
         assert_eq!(
             err.help,
-            "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, layouts, css, syntaxes, fonts, code_images"
+            "use only the supported deck frontmatter keys: time, aspect_ratio, resolution, breaks, page_numbers, pointer_color, layouts, css, syntaxes, fonts, code_images"
         );
     }
 

--- a/crates/peitho-core/src/phase.rs
+++ b/crates/peitho-core/src/phase.rs
@@ -28,6 +28,9 @@ pub enum PageNumberFormat {
     CurrentOfTotal,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PointerColor(String);
+
 impl PlannedTime {
     pub(crate) const GREATER_THAN_ZERO_MESSAGE: &'static str = "time must be greater than zero";
     pub(crate) const MAX_SAFE_JAVASCRIPT_INTEGER_MILLIS: u64 = 9_007_199_254_740_991;
@@ -47,6 +50,190 @@ impl PlannedTime {
         self.0
     }
 }
+
+impl PointerColor {
+    pub(crate) const HELP: &'static str = "set pointer_color to a CSS color like #38bdf8 or cyan";
+
+    pub fn parse(raw: &str) -> std::result::Result<Self, String> {
+        let value = raw.trim();
+        if value.is_empty() {
+            return Err("pointer_color has no value".to_owned());
+        }
+        if is_pointer_hex_color(value) || is_css_named_color(value) {
+            return Ok(Self(value.to_owned()));
+        }
+        Err(format!(
+            "invalid pointer_color '{value}'; use #RGB, #RRGGBB, #RGBA, #RRGGBBAA, or a CSS named color"
+        ))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn is_pointer_hex_color(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix('#') else {
+        return false;
+    };
+    matches!(hex.len(), 3 | 4 | 6 | 8) && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_css_named_color(value: &str) -> bool {
+    let normalized = value.to_ascii_lowercase();
+    CSS_NAMED_COLORS.contains(&normalized.as_str())
+}
+
+const CSS_NAMED_COLORS: &[&str] = &[
+    "aliceblue",
+    "antiquewhite",
+    "aqua",
+    "aquamarine",
+    "azure",
+    "beige",
+    "bisque",
+    "black",
+    "blanchedalmond",
+    "blue",
+    "blueviolet",
+    "brown",
+    "burlywood",
+    "cadetblue",
+    "chartreuse",
+    "chocolate",
+    "coral",
+    "cornflowerblue",
+    "cornsilk",
+    "crimson",
+    "cyan",
+    "darkblue",
+    "darkcyan",
+    "darkgoldenrod",
+    "darkgray",
+    "darkgreen",
+    "darkgrey",
+    "darkkhaki",
+    "darkmagenta",
+    "darkolivegreen",
+    "darkorange",
+    "darkorchid",
+    "darkred",
+    "darksalmon",
+    "darkseagreen",
+    "darkslateblue",
+    "darkslategray",
+    "darkslategrey",
+    "darkturquoise",
+    "darkviolet",
+    "deeppink",
+    "deepskyblue",
+    "dimgray",
+    "dimgrey",
+    "dodgerblue",
+    "firebrick",
+    "floralwhite",
+    "forestgreen",
+    "fuchsia",
+    "gainsboro",
+    "ghostwhite",
+    "gold",
+    "goldenrod",
+    "gray",
+    "green",
+    "greenyellow",
+    "grey",
+    "honeydew",
+    "hotpink",
+    "indianred",
+    "indigo",
+    "ivory",
+    "khaki",
+    "lavender",
+    "lavenderblush",
+    "lawngreen",
+    "lemonchiffon",
+    "lightblue",
+    "lightcoral",
+    "lightcyan",
+    "lightgoldenrodyellow",
+    "lightgray",
+    "lightgreen",
+    "lightgrey",
+    "lightpink",
+    "lightsalmon",
+    "lightseagreen",
+    "lightskyblue",
+    "lightslategray",
+    "lightslategrey",
+    "lightsteelblue",
+    "lightyellow",
+    "lime",
+    "limegreen",
+    "linen",
+    "magenta",
+    "maroon",
+    "mediumaquamarine",
+    "mediumblue",
+    "mediumorchid",
+    "mediumpurple",
+    "mediumseagreen",
+    "mediumslateblue",
+    "mediumspringgreen",
+    "mediumturquoise",
+    "mediumvioletred",
+    "midnightblue",
+    "mintcream",
+    "mistyrose",
+    "moccasin",
+    "navajowhite",
+    "navy",
+    "oldlace",
+    "olive",
+    "olivedrab",
+    "orange",
+    "orangered",
+    "orchid",
+    "palegoldenrod",
+    "palegreen",
+    "paleturquoise",
+    "palevioletred",
+    "papayawhip",
+    "peachpuff",
+    "peru",
+    "pink",
+    "plum",
+    "powderblue",
+    "purple",
+    "rebeccapurple",
+    "red",
+    "rosybrown",
+    "royalblue",
+    "saddlebrown",
+    "salmon",
+    "sandybrown",
+    "seagreen",
+    "seashell",
+    "sienna",
+    "silver",
+    "skyblue",
+    "slateblue",
+    "slategray",
+    "slategrey",
+    "snow",
+    "springgreen",
+    "steelblue",
+    "tan",
+    "teal",
+    "thistle",
+    "tomato",
+    "turquoise",
+    "violet",
+    "wheat",
+    "white",
+    "whitesmoke",
+    "yellow",
+    "yellowgreen",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssetPath(PathBuf);
@@ -103,6 +290,7 @@ pub struct DeckSettings {
     resolution: Resolution,
     breaks: bool,
     page_numbers: Option<PageNumberFormat>,
+    pointer_color: Option<PointerColor>,
     sections: Vec<DeckSection>,
     layouts: Option<AssetPath>,
     css: Option<AssetPath>,
@@ -125,6 +313,7 @@ impl DeckSettings {
         resolution: Option<Resolution>,
         breaks: bool,
         page_numbers: Option<PageNumberFormat>,
+        pointer_color: Option<PointerColor>,
         sections: Vec<DeckSection>,
         layouts: Option<AssetPath>,
         css: Option<AssetPath>,
@@ -142,6 +331,7 @@ impl DeckSettings {
             resolution,
             breaks,
             page_numbers,
+            pointer_color,
             sections,
             layouts,
             css,
@@ -169,6 +359,10 @@ impl DeckSettings {
 
     pub fn page_numbers(&self) -> Option<PageNumberFormat> {
         self.page_numbers
+    }
+
+    pub fn pointer_color(&self) -> Option<&PointerColor> {
+        self.pointer_color.as_ref()
     }
 
     pub fn sections(&self) -> &[DeckSection] {
@@ -712,6 +906,24 @@ mod tests {
     }
 
     #[test]
+    fn pointer_color_accepts_supported_css_color_strings() {
+        for value in ["#ff2a2a", "#f00", "#ff2a2aff", "red", "cyan"] {
+            let color = PointerColor::parse(value).unwrap();
+
+            assert_eq!(color.as_str(), value);
+        }
+    }
+
+    #[test]
+    fn pointer_color_rejects_unsupported_css_color_strings() {
+        for value in ["not-a-color", "rgb(255,0,0)", ""] {
+            let err = PointerColor::parse(value).unwrap_err();
+
+            assert!(err.contains("pointer_color"), "case: {value}");
+        }
+    }
+
+    #[test]
     fn deck_settings_carry_owned_sections() {
         let setup = DeckSection::new(
             "Setup".to_owned(),
@@ -724,6 +936,7 @@ mod tests {
             AspectRatio::default(),
             Some(Resolution::from_aspect_ratio_default(AspectRatio::default())),
             false,
+            None,
             None,
             vec![setup.clone()],
             None,
@@ -755,6 +968,7 @@ mod tests {
             Some(Resolution::from_aspect_ratio_default(AspectRatio::default())),
             false,
             None,
+            None,
             vec![setup.clone()],
             None,
             None,
@@ -777,6 +991,7 @@ mod tests {
             None,
             false,
             None,
+            None,
             Vec::new(),
             None,
             None,
@@ -798,6 +1013,7 @@ mod tests {
             Some(Resolution::from_frontmatter("1024x768").unwrap()),
             false,
             None,
+            None,
             Vec::new(),
             None,
             None,
@@ -817,6 +1033,7 @@ mod tests {
             AspectRatio::Ratio16To9,
             Some(Resolution::from_frontmatter("16x9").unwrap()),
             false,
+            None,
             None,
             Vec::new(),
             None,

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -960,7 +960,8 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote[data-peitho-ended="true"] .peitho-remote-dim-on-end { opacity: 0.28; }
     .peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0; }
     .peitho-remote-preview > * { position: absolute; inset: 0; }
-    .peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace { flex: none; }
+    .peitho-remote-preview[data-peitho-pointer-mode="pointer"] { cursor: crosshair; touch-action: none; }
+    .peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-pointer-mode { flex: none; }
     .peitho-remote-titlebar { display: flex; align-items: baseline; gap: 12px; }
     .peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700; line-height: 1.2; color: #f5f7fb; }
     .peitho-remote-counter { flex: 0 0 auto; margin-left: auto; font-size: 16px; font-weight: 700; line-height: 1.2; color: #aab3c2; font-variant-numeric: tabular-nums; }
@@ -999,6 +1000,9 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-notes-caption { flex: 0 0 auto; font-size: 11px; font-weight: 600; line-height: 1.2; letter-spacing: 0.08em; color: #6b7484; text-transform: uppercase; }
     .peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto; min-height: 0; }
     .peitho-remote-notes-body[data-peitho-empty="true"] { color: #5a6473; font-size: 14px; font-style: italic; }
+    .peitho-remote-pointer-mode { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; padding: 4px; border: 1px solid #2f3644; border-radius: 999px; background: #181c23; }
+    .peitho-remote-pointer-mode button { min-height: 38px; border: 0; border-radius: 999px; background: transparent; color: #aab3c2; font: 600 13px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; touch-action: manipulation; }
+    .peitho-remote-pointer-mode button[aria-pressed="true"] { background: rgba(255,42,42,0.16); color: #ff9a9a; }
     .peitho-remote-actions { display: flex; flex-direction: column; gap: 10px; flex: none; }
     .peitho-remote-actions button { border-radius: 999px; font: 600 17px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; touch-action: manipulation; display: inline-flex; align-items: center; justify-content: center; gap: 6px; }
     .peitho-remote-actions [data-peitho-direction="prev"] { min-height: 48px; border: 1px solid #2f3644; background: transparent; color: #dde3ec; font-size: 15px; }
@@ -1009,14 +1013,16 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
     .peitho-remote-action-arrow { font-size: 20px; font-weight: 400; line-height: 1; opacity: 0.85; }
     @media (orientation: landscape) and (max-height: 520px) {
       #peitho-remote-root { padding: 12px 14px; padding-top: calc(12px + env(safe-area-inset-top, 0px)); padding-left: calc(14px + env(safe-area-inset-left, 0px)); padding-right: calc(14px + env(safe-area-inset-right, 0px)); padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)); }
-      .peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px; grid-template-columns: min(calc((100dvh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * __PEITHO_CANVAS_ASPECT__), 52%) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }
+      .peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 104px; grid-template-columns: min(calc((100dvh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * __PEITHO_CANVAS_ASPECT__), 52%) minmax(0, 1fr) 104px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }
       .peitho-remote-preview { grid-area: 1 / 1 / 2 / 2; max-height: 100%; min-height: 0; }
       .peitho-remote-titlebar { grid-area: 2 / 1 / 3 / 2; }
       .peitho-remote-chase { grid-area: 3 / 1 / 4 / 2; align-self: end; }
       .peitho-remote-pace { grid-area: 4 / 1 / 5 / 2; flex-wrap: wrap; }
       .peitho-remote-notes { grid-area: 1 / 2 / 4 / 3; }
       .peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }
-      .peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }
+      .peitho-remote-pointer-mode { grid-area: 1 / 3 / 2 / 4; align-self: start; grid-template-columns: 1fr; border-radius: 20px; z-index: 1; }
+      .peitho-remote-pointer-mode button { min-height: 30px; }
+      .peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; padding-top: 78px; }
       .peitho-remote-actions button { flex-direction: column; border-radius: 20px; }
       .peitho-remote-actions [data-peitho-direction="prev"] { flex: 1; min-height: 0; }
       .peitho-remote-actions [data-peitho-direction="next"] { flex: 1.35; min-height: 0; }
@@ -1027,7 +1033,7 @@ pub fn render_remote_index(aspect_ratio: AspectRatio) -> String {
       body, #peitho-remote-root { height: 100vh; }
     }
     @media (display-mode: standalone) and (orientation: landscape) and (max-height: 520px) {
-      .peitho-remote { grid-template-columns: min(calc((100vh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * __PEITHO_CANVAS_ASPECT__), 52%) minmax(0, 1fr) 96px; }
+      .peitho-remote { grid-template-columns: min(calc((100vh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * __PEITHO_CANVAS_ASPECT__), 52%) minmax(0, 1fr) 104px; }
     }
   </style>
 </head>
@@ -2327,8 +2333,9 @@ Paragraph after heading.
         assert!(html.contains("#peitho-remote-root { height: 100vh; height: 100svh; height: 100dvh; display: flex; flex-direction: column; gap: 12px; padding: 14px 14px 8px;"));
         assert!(html.contains("padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));"));
         assert!(html.contains(".peitho-remote-preview { position: relative; aspect-ratio: var(--peitho-canvas-aspect); border-radius: 10px; border: 1px solid #2a3240; background: #fff; overflow: hidden; flex: 0 1 auto; min-height: 0;"));
+        assert!(html.contains(".peitho-remote-preview[data-peitho-pointer-mode=\"pointer\"] { cursor: crosshair; touch-action: none; }"));
         assert!(html.contains(
-            ".peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace { flex: none; }"
+            ".peitho-remote-titlebar, .peitho-remote-chase, .peitho-remote-pace, .peitho-remote-pointer-mode { flex: none; }"
         ));
         assert!(html.contains(
             ".peitho-remote-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 16px; font-weight: 700;"
@@ -2368,6 +2375,8 @@ Paragraph after heading.
         assert!(html.contains(".peitho-remote-section b { color: #dde3ec; font-weight: 600; }"));
         assert!(html.contains(".peitho-remote-notes { flex: 1; min-height: 0; background: #181c23; border: 1px solid #2a3240; border-radius: 12px; padding: 14px 16px;"));
         assert!(html.contains(".peitho-remote-notes-body { font-size: 15px; line-height: 1.65; color: #dde3ec; white-space: pre-wrap; overflow-y: auto;"));
+        assert!(html.contains(".peitho-remote-pointer-mode { display: grid; grid-template-columns: 1fr 1fr; gap: 6px;"));
+        assert!(html.contains(".peitho-remote-pointer-mode button[aria-pressed=\"true\"] { background: rgba(255,42,42,0.16); color: #ff9a9a; }"));
         assert!(html.contains(
             ".peitho-remote-actions { display: flex; flex-direction: column; gap: 10px; flex: none;"
         ));
@@ -2378,8 +2387,8 @@ Paragraph after heading.
         assert!(html.contains(".peitho-remote-actions [data-peitho-direction=\"next\"] { min-height: 60px; border: 1px solid transparent; background: rgba(56,189,248,0.14); color: #38bdf8; font-size: 17px;"));
         assert!(html.contains("@media (orientation: landscape) and (max-height: 520px)"));
         assert!(html.contains("#peitho-remote-root { padding: 12px 14px; padding-top: calc(12px + env(safe-area-inset-top, 0px)); padding-left: calc(14px + env(safe-area-inset-left, 0px)); padding-right: calc(14px + env(safe-area-inset-right, 0px)); padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px)); }"));
-        assert!(html.contains(".peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 96px;"));
-        assert!(html.contains("grid-template-columns: min(calc((100dvh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 4 / 3), 52%) minmax(0, 1fr) 96px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }"));
+        assert!(html.contains(".peitho-remote { max-width: none; display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr) 104px;"));
+        assert!(html.contains("grid-template-columns: min(calc((100dvh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 4 / 3), 52%) minmax(0, 1fr) 104px; grid-template-rows: minmax(0, 1fr) auto auto auto; gap: 10px 14px; }"));
         assert!(html.contains(
             ".peitho-remote-preview { grid-area: 1 / 1 / 2 / 2; max-height: 100%; min-height: 0; }"
         ));
@@ -2392,8 +2401,9 @@ Paragraph after heading.
         assert!(
             html.contains(".peitho-remote-section { grid-area: 4 / 2 / 5 / 3; align-self: end; }")
         );
+        assert!(html.contains(".peitho-remote-pointer-mode { grid-area: 1 / 3 / 2 / 4; align-self: start; grid-template-columns: 1fr; border-radius: 20px; z-index: 1; }"));
         assert!(
-            html.contains(".peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; }")
+            html.contains(".peitho-remote-actions { grid-area: 1 / 3 / 5 / 4; min-height: 0; padding-top: 78px; }")
         );
         assert!(html.contains(
             ".peitho-remote-actions button { flex-direction: column; border-radius: 20px; }"
@@ -2411,7 +2421,7 @@ Paragraph after heading.
         assert!(html.contains(
             "@media (display-mode: standalone) and (orientation: landscape) and (max-height: 520px)"
         ));
-        assert!(html.contains("grid-template-columns: min(calc((100vh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 4 / 3), 52%) minmax(0, 1fr) 96px;"));
+        assert!(html.contains("grid-template-columns: min(calc((100vh - 151px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) * 4 / 3), 52%) minmax(0, 1fr) 104px;"));
         assert!(html.contains(
             ".peitho-remote[data-peitho-ended=\"true\"] .peitho-remote-dim-on-end { opacity: 0.28;"
         ));

--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -194,6 +194,96 @@ impl SyncHub {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct PointerHub {
+    state: Arc<(Mutex<PointerState>, Condvar)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PointerState {
+    seq: u64,
+    event: PointerEvent,
+    session: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum PointerEvent {
+    Move { x: f64, y: f64 },
+    Up,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PointerSnapshot {
+    seq: u64,
+    event: PointerEvent,
+    session: String,
+}
+
+impl PointerHub {
+    fn new(session: String) -> Self {
+        Self {
+            state: Arc::new((
+                Mutex::new(PointerState {
+                    seq: 0,
+                    event: PointerEvent::Up,
+                    session,
+                }),
+                Condvar::new(),
+            )),
+        }
+    }
+
+    fn reset_session(&self, session: String) -> u64 {
+        let (lock, cvar) = &*self.state;
+        let mut state = lock.lock().expect("pointer hub mutex");
+        if state.session == session {
+            return state.seq;
+        }
+        state.seq += 1;
+        state.event = PointerEvent::Up;
+        state.session = session;
+        let seq = state.seq;
+        cvar.notify_all();
+        seq
+    }
+
+    fn broadcast(&self, event: PointerEvent) -> u64 {
+        let (lock, cvar) = &*self.state;
+        let mut state = lock.lock().expect("pointer hub mutex");
+        state.seq += 1;
+        state.event = event;
+        let seq = state.seq;
+        cvar.notify_all();
+        seq
+    }
+
+    fn wait_after(&self, seq: u64, timeout: Duration) -> Option<PointerSnapshot> {
+        let (lock, cvar) = &*self.state;
+        let state = lock.lock().expect("pointer hub mutex");
+        let (state, _) = cvar
+            .wait_timeout_while(state, timeout, |state| state.seq <= seq)
+            .expect("pointer hub mutex");
+        if state.seq <= seq {
+            return None;
+        }
+        Some(PointerSnapshot {
+            seq: state.seq,
+            event: state.event,
+            session: state.session.clone(),
+        })
+    }
+
+    fn snapshot(&self) -> PointerSnapshot {
+        let (lock, _) = &*self.state;
+        let state = lock.lock().expect("pointer hub mutex");
+        PointerSnapshot {
+            seq: state.seq,
+            event: state.event,
+            session: state.session.clone(),
+        }
+    }
+}
+
 pub(crate) fn resolve_request_path(
     root: &Path,
     url: &str,
@@ -270,6 +360,7 @@ pub struct PresentServer {
     server: Arc<Server>,
     listeners: Arc<Mutex<Vec<Arc<Server>>>>,
     sync: SyncHub,
+    pointer: PointerHub,
 }
 
 #[derive(Debug)]
@@ -402,6 +493,8 @@ impl PresentServer {
         let server = Server::http(addr)
             .map_err(|err| miette::Report::new(PresentServerBindError::from_boxed(addr, err)))?;
         let server = Arc::new(server);
+        let sync = SyncHub::default();
+        let pointer = PointerHub::new(sync.snapshot().session);
         Ok(Self {
             root: Arc::new(RwLock::new(root)),
             default_document: default_document.to_owned(),
@@ -409,7 +502,8 @@ impl PresentServer {
             rehearsal_sink: None,
             server: server.clone(),
             listeners: Arc::new(Mutex::new(vec![server])),
-            sync: SyncHub::default(),
+            sync,
+            pointer,
         })
     }
 
@@ -510,6 +604,14 @@ impl PresentServer {
                 self.respond_sync_post(request, shutdown);
                 return;
             }
+            (&Method::Get, "/pointer") => {
+                self.respond_pointer_get(request);
+                return;
+            }
+            (&Method::Post, "/pointer") => {
+                self.respond_pointer_post(request);
+                return;
+            }
             (&Method::Post, "/rehearsal") => {
                 self.respond_rehearsal_post(request);
                 return;
@@ -593,6 +695,52 @@ impl PresentServer {
                 shutdown.start();
             }
         }
+    }
+
+    fn respond_pointer_get(&self, request: tiny_http::Request) {
+        let Some(pointer_get) = pointer_get(request.url()) else {
+            send_response(
+                request,
+                Response::from_string("invalid pointer seq\n").with_status_code(StatusCode(400)),
+            );
+            return;
+        };
+        self.pointer.reset_session(self.sync.snapshot().session);
+        let PointerGet::Poll(seq) = pointer_get else {
+            send_json_response(
+                request,
+                pointer_handshake_response_body(self.pointer.snapshot()),
+            );
+            return;
+        };
+        let pointer = self.pointer.clone();
+        thread::spawn(
+            move || match pointer.wait_after(seq, Duration::from_secs(5)) {
+                Some(snapshot) => send_json_response(request, pointer_poll_response_body(snapshot)),
+                None => send_response(request, Response::empty(StatusCode(204))),
+            },
+        );
+    }
+
+    fn respond_pointer_post(&self, mut request: tiny_http::Request) {
+        let mut body = String::new();
+        if request.as_reader().read_to_string(&mut body).is_err() {
+            send_response(
+                request,
+                Response::from_string("invalid pointer body\n").with_status_code(StatusCode(400)),
+            );
+            return;
+        }
+        let Some(event) = pointer_event_from_body(&body) else {
+            send_response(
+                request,
+                Response::from_string("invalid pointer body\n").with_status_code(StatusCode(400)),
+            );
+            return;
+        };
+        self.pointer.reset_session(self.sync.snapshot().session);
+        let seq = self.pointer.broadcast(event);
+        send_json_response(request, pointer_post_response_body(seq));
     }
 
     fn respond_rehearsal_post(&self, mut request: tiny_http::Request) {
@@ -719,6 +867,33 @@ struct SyncCloseMessage {
     close: bool,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PointerMessage {
+    Move(PointerMoveMessage),
+    Up(PointerUpMessage),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PointerMoveMessage {
+    #[serde(rename = "move")]
+    move_: PointerMovePayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PointerMovePayload {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PointerUpMessage {
+    up: bool,
+}
+
 impl SyncMessage {
     fn is_valid(&self) -> bool {
         match self {
@@ -728,7 +903,41 @@ impl SyncMessage {
     }
 }
 
+impl PointerMessage {
+    fn into_event(self) -> Option<PointerEvent> {
+        match self {
+            Self::Move(message) => {
+                if !is_valid_pointer_coordinate(message.move_.x)
+                    || !is_valid_pointer_coordinate(message.move_.y)
+                {
+                    return None;
+                }
+                Some(PointerEvent::Move {
+                    x: message.move_.x,
+                    y: message.move_.y,
+                })
+            }
+            Self::Up(message) => message.up.then_some(PointerEvent::Up),
+        }
+    }
+}
+
+fn is_valid_pointer_coordinate(value: f64) -> bool {
+    (0.0..=1.0).contains(&value)
+}
+
+fn pointer_event_from_body(body: &str) -> Option<PointerEvent> {
+    serde_json::from_str::<PointerMessage>(body)
+        .ok()?
+        .into_event()
+}
+
 enum SyncGet {
+    Handshake,
+    Poll(u64),
+}
+
+enum PointerGet {
     Handshake,
     Poll(u64),
 }
@@ -752,6 +961,27 @@ fn sync_get(url: &str) -> Option<SyncGet> {
         }
     }
     Some(SyncGet::Handshake)
+}
+
+fn pointer_get(url: &str) -> Option<PointerGet> {
+    let Some((_, query)) = url.split_once('?') else {
+        return Some(PointerGet::Handshake);
+    };
+    if query.is_empty() {
+        return Some(PointerGet::Handshake);
+    }
+    for pair in query.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        if key == "seq" {
+            if value.is_empty() {
+                return Some(PointerGet::Handshake);
+            }
+            return value.parse().ok().map(PointerGet::Poll);
+        }
+    }
+    Some(PointerGet::Handshake)
 }
 
 fn sync_response_body(snapshot: SyncSnapshot, message: Option<&str>) -> String {
@@ -790,6 +1020,50 @@ fn sync_post_response_body(seq: u64) -> String {
     }
 
     serde_json::to_string(&SyncPostResponseBody { seq }).expect("sync post response serializes")
+}
+
+fn pointer_handshake_response_body(snapshot: PointerSnapshot) -> String {
+    #[derive(Serialize)]
+    struct PointerHandshakeResponseBody {
+        seq: u64,
+        session: String,
+    }
+
+    serde_json::to_string(&PointerHandshakeResponseBody {
+        seq: snapshot.seq,
+        session: snapshot.session,
+    })
+    .expect("pointer handshake response serializes")
+}
+
+fn pointer_poll_response_body(snapshot: PointerSnapshot) -> String {
+    #[derive(Serialize)]
+    struct PointerPollResponseBody {
+        seq: u64,
+        event: Value,
+        session: String,
+    }
+
+    let event = match snapshot.event {
+        PointerEvent::Move { x, y } => serde_json::json!({ "move": { "x": x, "y": y } }),
+        PointerEvent::Up => serde_json::json!({ "up": true }),
+    };
+    serde_json::to_string(&PointerPollResponseBody {
+        seq: snapshot.seq,
+        event,
+        session: snapshot.session,
+    })
+    .expect("pointer poll response serializes")
+}
+
+fn pointer_post_response_body(seq: u64) -> String {
+    #[derive(Serialize)]
+    struct PointerPostResponseBody {
+        seq: u64,
+    }
+
+    serde_json::to_string(&PointerPostResponseBody { seq })
+        .expect("pointer post response serializes")
 }
 
 fn rehearsal_post_response_body(recorded: bool) -> String {
@@ -1331,6 +1605,100 @@ mod tests {
     }
 
     #[test]
+    fn pointer_hub_sequence_is_monotonic() {
+        let hub = PointerHub::new("session-a".to_owned());
+
+        assert_eq!(hub.broadcast(PointerEvent::Move { x: 0.25, y: 0.5 }), 1);
+        assert_eq!(hub.broadcast(PointerEvent::Up), 2);
+        assert_eq!(hub.broadcast(PointerEvent::Move { x: 1.0, y: 0.0 }), 3);
+        assert_eq!(hub.snapshot().seq, 3);
+    }
+
+    #[test]
+    fn pointer_hub_up_is_sticky_until_next_move() {
+        let hub = PointerHub::new("session-a".to_owned());
+
+        assert_eq!(hub.snapshot().event, PointerEvent::Up);
+        hub.broadcast(PointerEvent::Move { x: 0.2, y: 0.8 });
+        hub.broadcast(PointerEvent::Up);
+
+        assert_eq!(hub.snapshot().event, PointerEvent::Up);
+        assert_eq!(
+            hub.wait_after(1, Duration::from_secs(1)).unwrap(),
+            PointerSnapshot {
+                seq: 2,
+                event: PointerEvent::Up,
+                session: "session-a".to_owned()
+            }
+        );
+
+        hub.broadcast(PointerEvent::Move { x: 0.4, y: 0.6 });
+        assert_eq!(hub.snapshot().event, PointerEvent::Move { x: 0.4, y: 0.6 });
+    }
+
+    #[test]
+    fn pointer_hub_new_session_resets_state_to_up() {
+        let hub = PointerHub::new("session-a".to_owned());
+        hub.broadcast(PointerEvent::Move { x: 0.2, y: 0.8 });
+
+        assert_eq!(hub.reset_session("session-b".to_owned()), 2);
+
+        assert_eq!(
+            hub.snapshot(),
+            PointerSnapshot {
+                seq: 2,
+                event: PointerEvent::Up,
+                session: "session-b".to_owned()
+            }
+        );
+        assert_eq!(
+            hub.wait_after(1, Duration::from_secs(1)).unwrap().event,
+            PointerEvent::Up
+        );
+    }
+
+    #[test]
+    fn pointer_coordinate_validation_accepts_only_unit_range() {
+        assert_eq!(
+            pointer_event_from_body(r#"{"move":{"x":0,"y":1}}"#).unwrap(),
+            PointerEvent::Move { x: 0.0, y: 1.0 }
+        );
+        assert_eq!(
+            pointer_event_from_body(r#"{"move":{"x":1,"y":0}}"#).unwrap(),
+            PointerEvent::Move { x: 1.0, y: 0.0 }
+        );
+        assert!(pointer_event_from_body(r#"{"move":{"x":-0.01,"y":0.5}}"#).is_none());
+        assert!(pointer_event_from_body(r#"{"move":{"x":0.5,"y":1.01}}"#).is_none());
+    }
+
+    #[test]
+    fn pointer_unknown_json_is_rejected() {
+        assert!(pointer_event_from_body("{}").is_none());
+        assert!(pointer_event_from_body(r#"{"draw":true}"#).is_none());
+        assert!(pointer_event_from_body(r#"{"up":false}"#).is_none());
+        assert!(pointer_event_from_body(r#"{"move":{"x":0.5,"y":0.5},"up":true}"#).is_none());
+        assert!(pointer_event_from_body(r#"{"move":{"x":0.5,"y":0.5,"z":0}}"#).is_none());
+    }
+
+    #[test]
+    fn pointer_wait_after_returns_immediately_when_sequence_advanced() {
+        let hub = PointerHub::new("session-a".to_owned());
+        hub.broadcast(PointerEvent::Move { x: 0.2, y: 0.8 });
+
+        let poll = hub.wait_after(0, Duration::from_secs(1)).unwrap();
+
+        assert_eq!(poll.seq, 1);
+        assert_eq!(poll.event, PointerEvent::Move { x: 0.2, y: 0.8 });
+    }
+
+    #[test]
+    fn pointer_wait_after_times_out_when_nothing_changes() {
+        let hub = PointerHub::new("session-a".to_owned());
+
+        assert!(hub.wait_after(0, Duration::from_millis(1)).is_none());
+    }
+
+    #[test]
     fn sync_response_body_always_includes_generation() {
         let body = sync_response_body(
             SyncSnapshot {
@@ -1405,6 +1773,38 @@ mod tests {
     }
 
     #[test]
+    fn pointer_response_bodies_match_transport_contract() {
+        let handshake = pointer_handshake_response_body(PointerSnapshot {
+            seq: 4,
+            event: PointerEvent::Up,
+            session: "session-a".to_owned(),
+        });
+        let moved = pointer_poll_response_body(PointerSnapshot {
+            seq: 5,
+            event: PointerEvent::Move { x: 0.42, y: 0.71 },
+            session: "session-a".to_owned(),
+        });
+        let up = pointer_poll_response_body(PointerSnapshot {
+            seq: 6,
+            event: PointerEvent::Up,
+            session: "session-a".to_owned(),
+        });
+
+        assert_eq!(
+            serde_json::from_str::<Value>(&handshake).unwrap(),
+            serde_json::json!({"seq":4,"session":"session-a"})
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&moved).unwrap(),
+            serde_json::json!({"seq":5,"event":{"move":{"x":0.42,"y":0.71}},"session":"session-a"})
+        );
+        assert_eq!(
+            serde_json::from_str::<Value>(&up).unwrap(),
+            serde_json::json!({"seq":6,"event":{"up":true},"session":"session-a"})
+        );
+    }
+
+    #[test]
     fn reload_is_not_accepted_as_a_posted_sync_message() {
         assert!(serde_json::from_str::<SyncMessage>(r#"{"reload":true}"#).is_err());
     }
@@ -1437,6 +1837,28 @@ mod tests {
             Some(SyncGet::Poll(7))
         ));
         assert!(sync_get("/sync?seq=nope").is_none());
+    }
+
+    #[test]
+    fn parses_pointer_get_query() {
+        assert!(matches!(
+            pointer_get("/pointer"),
+            Some(PointerGet::Handshake)
+        ));
+        assert!(matches!(
+            pointer_get("/pointer?seq="),
+            Some(PointerGet::Handshake)
+        ));
+        assert!(pointer_get("/pointer?seq=now").is_none());
+        assert!(matches!(
+            pointer_get("/pointer?seq=42"),
+            Some(PointerGet::Poll(42))
+        ));
+        assert!(matches!(
+            pointer_get("/pointer?other=x&seq=7"),
+            Some(PointerGet::Poll(7))
+        ));
+        assert!(pointer_get("/pointer?seq=nope").is_none());
     }
 
     #[test]

--- a/docs/plans/2026-07-20-remote-pointer.md
+++ b/docs/plans/2026-07-20-remote-pointer.md
@@ -1,0 +1,124 @@
+# Remote pointer (minimal)
+
+Date: 2026-07-20
+Status: Draft — awaiting author approval before implementation
+
+## Goal
+
+Let the presenter, holding the phone remote (`/remote`), point at things on the slides window in real time. A tap-and-hold on the remote's slide-preview area shows a red dot on the slides display; releasing removes it. Nothing is persisted; nothing enters `dist/`.
+
+Non-goals for v1:
+- Drawing / stroke retention (deferred — clean up first, add later if desired)
+- Color / size pickers (fixed red, fixed radius)
+- Overlay on presenter window (slides only)
+- Pointer-as-navigation gesture (Next/Prev buttons stay authoritative)
+
+## Why in-scope
+
+The remote is already the physical device in the presenter's hand (Issue #306/#309), and Home Screen install / landscape polish (PR #311) means the ergonomics for touch input are already solid. Pointer is the smallest addition that turns the phone from "clicker" into "clicker + laser pointer" without touching the deck contract or the three pillars.
+
+## UX
+
+Add a single toggle at the bottom of `/remote`, next to existing controls:
+
+```
+[ Off | Pointer ]
+```
+
+- Default Off. Selection is session-only (no localStorage; a reload resets to Off).
+- With Pointer on, the remote's slide-preview area (the black 16:9 region already present in the landscape layout) becomes a touch surface:
+  - `touchstart` / `pointerdown` inside the region → normalized `{x,y}` in `[0,1]²` is broadcast; slides window paints a red dot at the corresponding position.
+  - Movement while held → normalized coordinates continue to broadcast.
+  - `touchend` / `pointerup` / `pointercancel` / touch leaves the region → broadcast `pointerup`; slides fades the dot in ~150ms.
+- Next/Prev buttons remain active. Timer control area is unaffected.
+- Chord-modified taps (unlikely on iOS but possible on trackpad-connected iPads) are ignored, consistent with `hasChordModifier` guard elsewhere.
+
+Slides window:
+- One overlay `<canvas>` layered above the slide DOM at `z-index` above content, below the presenter chrome (there is no presenter chrome on the slides window, but keep the layering explicit).
+- Dot is a filled circle, radius ~1.2% of the shorter viewport dimension, color `#ff2a2a`, `mix-blend-mode: multiply` for legibility on both light and dark backgrounds. No trail.
+- `requestAnimationFrame` interpolates between received coordinates so the visual motion is smooth even if the transport batches.
+- On `peitho:navigate` (existing shell event) the overlay is cleared regardless of pointer state — pointer never survives a slide change.
+- On sync `session` change (server restart) the overlay is cleared.
+- Presenter window renders nothing pointer-related in v1.
+
+## Transport: `/pointer` endpoint (new)
+
+The existing channels don't fit:
+- `/sync` is absolute-state + long poll with coalescing — designed for one integer `index`, not a coordinate stream.
+- `/rehearsal` is one-shot POST for durable records.
+
+Add a third endpoint that reuses the long-poll shape but carries a small event stream:
+
+- `POST /pointer` — body `{"move":{"x":0.42,"y":0.71}}` or `{"up":true}`. Returns `{"seq":N}`.
+- `GET /pointer` — handshake, returns `{"seq":N,"session":"..."}` (same session id as `/sync`).
+- `GET /pointer?seq=N` — long poll (up to ~5s, shorter than `/sync`'s 30s to bound worst-case dot latency after transport hiccups; empty 204 on timeout).
+
+Server retains only the **latest** event per session, plus a monotonically increasing `seq`. Missed intermediate `move`s are acceptable — the client only needs "where is the pointer now" and "is it up". `up` is sticky until the next `move` (so a client that joins mid-idle sees "up", not a stale coordinate).
+
+Coordinate sending is throttled to ~30Hz on the remote side (`requestAnimationFrame`, coalesce to one POST per frame). Reduces battery drain and matches what the slides can visibly render. Requests use `fetch` with `keepalive: true` so a fast release still delivers the final `up`.
+
+Rationale for not using WebSocket in v1:
+- tiny_http doesn't support upgrades; adding tungstenite or a second listener is more surface than a POST endpoint.
+- iOS PWA WebSocket is workable but has more edge cases (cold connect, backgrounding) than short POSTs.
+- The `POST + long-poll` shape mirrors `/sync`, so operators reason about one transport, not two.
+
+If real-world latency measurement shows POST is inadequate, a WebSocket variant can be added later behind the same `peitho:pointer*` event contract with no UI change.
+
+## §16 event contract
+
+Remote (only emits requests):
+- `peitho:pointermodechange { mode: "off" | "pointer" }`
+- `peitho:pointermove { x: number, y: number }` (normalized)
+- `peitho:pointerup`
+
+Remote shell (bridge to transport):
+- On `pointermode: pointer`, install touch/pointer listeners on the preview region.
+- On `pointermode: off`, remove listeners and POST a final `up`.
+- Debounce/throttle to ~30Hz.
+
+Slides shell (bridge from transport to overlay):
+- Polls `/pointer` in parallel with `/sync` (independent long poll loop).
+- On `move`, updates a single `PointerState { x, y, visible: true }`.
+- On `up`, sets `visible: false` and fades out.
+- On `peitho:navigate` or `session` change, clears state.
+
+Presenter shell: no pointer subscription in v1.
+
+## Types (ts-rs)
+
+Domain in `peitho-core` remains untouched (pointer is runtime-only, no deck contract change). The pointer message type lives in the server crate and is not exported to `bindings/` — it's a transport concern, not a domain contract.
+
+## Files touched
+
+- `crates/peitho/src/server.rs` — add `/pointer` GET/POST routes, `PointerHub` (mirrors `SyncHub` but simpler: single latest event + seq).
+- `packages/peitho-present/src/remote.ts` — mode toggle, touch listeners, POST loop, region hit-testing.
+- `packages/peitho-present/src/shell.ts` — pointer overlay canvas, long-poll loop, fade animation, clear-on-navigate.
+- `packages/peitho-present/src/sync.ts` — no change (pointer is a separate transport).
+- Tests in Rust: `PointerHub` seq monotonicity, "up sticky until next move", session-scoped clear on new session.
+- Tests in vitest: mode toggle emits `peitho:pointermodechange`; slides overlay clears on `peitho:navigate`; fade timer.
+
+## Gates additions
+
+Existing gates cover this (Rust tests × 3, clippy, fmt, bindings drift not applicable since no ts-rs change, vitest, embedded shell/remote drift after `npm run build`).
+
+E2E verification before merging (real display required):
+1. `peitho present --host deck.md` on macOS, phone joins `/remote`.
+2. Toggle Pointer on, tap-drag inside the preview area, confirm red dot tracks on the slides display.
+3. Release, confirm dot fades.
+4. Advance slide via Next button, confirm any residual dot clears immediately.
+5. Toggle back to Off, confirm dot goes away and further taps do nothing.
+6. Kill server, restart, rejoin from phone, confirm no stale dot.
+
+## Deferred (explicitly not in v1)
+
+- Draw mode with per-slide stroke retention
+- Color / size selectors
+- Presenter-window pointer preview
+- Pointer analytics in rehearsal records (would violate rehearsal's terminal-only scope)
+- Multi-presenter pointer (multiple remotes at once) — server keeps only one latest event, so a second remote would race; v1 assumes one presenter
+
+## Undecided — awaiting author
+
+- Whether to ship v1 without draw at all (this plan assumes yes; if draw is wanted from day one, the transport doesn't change but the overlay/state model grows).
+- Whether Off should be the persisted default per-device (plan: no persistence in v1).
+- Dot color/size (plan: fixed `#ff2a2a`, 1.2% of min viewport dimension).

--- a/docs/plans/2026-07-20-remote-pointer.md
+++ b/docs/plans/2026-07-20-remote-pointer.md
@@ -5,11 +5,11 @@ Status: Draft — awaiting author approval before implementation
 
 ## Goal
 
-Let the presenter, holding the phone remote (`/remote`), point at things on the slides window in real time. A tap-and-hold on the remote's slide-preview area shows a red dot on the slides display; releasing removes it. Nothing is persisted; nothing enters `dist/`.
+Let the presenter, holding the phone remote (`/remote`), point at things on the slides window in real time. A tap-and-hold on the remote's slide-preview area shows a laser-style pointer on the slides display; releasing fades it out. Nothing is persisted.
 
 Non-goals for v1:
 - Drawing / stroke retention (deferred — clean up first, add later if desired)
-- Color / size pickers (fixed red, fixed radius)
+- Color / size UI pickers (frontmatter can set `pointer_color`; radius stays fixed)
 - Overlay on presenter window (slides only)
 - Pointer-as-navigation gesture (Next/Prev buttons stay authoritative)
 
@@ -27,15 +27,17 @@ Add a single toggle at the bottom of `/remote`, next to existing controls:
 
 - Default Off. Selection is session-only (no localStorage; a reload resets to Off).
 - With Pointer on, the remote's slide-preview area (the black 16:9 region already present in the landscape layout) becomes a touch surface:
-  - `touchstart` / `pointerdown` inside the region → normalized `{x,y}` in `[0,1]²` is broadcast; slides window paints a red dot at the corresponding position.
+  - `touchstart` / `pointerdown` inside the region → normalized `{x,y}` in `[0,1]²` is broadcast; slides window paints the pointer at the corresponding position.
   - Movement while held → normalized coordinates continue to broadcast.
-  - `touchend` / `pointerup` / `pointercancel` / touch leaves the region → broadcast `pointerup`; slides fades the dot in ~150ms.
+  - `touchend` / `pointerup` / `pointercancel` / touch leaves the region → broadcast `pointerup`; slides lets the recent trail fade over 500ms.
 - Next/Prev buttons remain active. Timer control area is unaffected.
 - Chord-modified taps (unlikely on iOS but possible on trackpad-connected iPads) are ignored, consistent with `hasChordModifier` guard elsewhere.
 
 Slides window:
 - One overlay `<canvas>` layered above the slide DOM at `z-index` above content, below the presenter chrome (there is no presenter chrome on the slides window, but keep the layering explicit).
-- Dot is a filled circle, radius ~1.2% of the shorter viewport dimension, color `#ff2a2a`, `mix-blend-mode: multiply` for legibility on both light and dark backgrounds. No trail.
+- Pointer is a single radial gradient, radius ~1.2% of the shorter viewport dimension: `#e0f2fe` core, `#38bdf8` at 25%, transparent edge. No blend mode.
+- `pointer_color` frontmatter can override the base color; the overlay derives the hot core by mixing that color toward white.
+- Recent move points are kept in a bounded trail buffer and fade out over 500ms; navigation and session changes clear the buffer immediately.
 - `requestAnimationFrame` interpolates between received coordinates so the visual motion is smooth even if the transport batches.
 - On `peitho:navigate` (existing shell event) the overlay is cleared regardless of pointer state — pointer never survives a slide change.
 - On sync `session` change (server restart) the overlay is cleared.
@@ -78,33 +80,34 @@ Remote shell (bridge to transport):
 
 Slides shell (bridge from transport to overlay):
 - Polls `/pointer` in parallel with `/sync` (independent long poll loop).
-- On `move`, updates a single `PointerState { x, y, visible: true }`.
-- On `up`, sets `visible: false` and fades out.
+- On `move`, updates `PointerState { x, y, visible: true }` and appends a timestamped trail point.
+- On `up`, sets `visible: false` and lets the existing trail fade out.
 - On `peitho:navigate` or `session` change, clears state.
 
 Presenter shell: no pointer subscription in v1.
 
 ## Types (ts-rs)
 
-Domain in `peitho-core` remains untouched (pointer is runtime-only, no deck contract change). The pointer message type lives in the server crate and is not exported to `bindings/` — it's a transport concern, not a domain contract.
+Pointer transport messages remain runtime-only and live in the server crate. Deck frontmatter now adds `pointer_color`, which surfaces as optional manifest `pointerColor` in `bindings/Manifest.ts`; no pointer transport type is exported to `bindings/`.
 
 ## Files touched
 
 - `crates/peitho/src/server.rs` — add `/pointer` GET/POST routes, `PointerHub` (mirrors `SyncHub` but simpler: single latest event + seq).
 - `packages/peitho-present/src/remote.ts` — mode toggle, touch listeners, POST loop, region hit-testing.
-- `packages/peitho-present/src/shell.ts` — pointer overlay canvas, long-poll loop, fade animation, clear-on-navigate.
+- `crates/peitho-core/src/parser.rs` / `phase.rs` / `manifest.rs` — `pointer_color` frontmatter validation and optional manifest `pointerColor`.
+- `packages/peitho-present/src/shell.ts` — pointer overlay canvas, long-poll loop, gradient/trail rendering, clear-on-navigate.
 - `packages/peitho-present/src/sync.ts` — no change (pointer is a separate transport).
 - Tests in Rust: `PointerHub` seq monotonicity, "up sticky until next move", session-scoped clear on new session.
 - Tests in vitest: mode toggle emits `peitho:pointermodechange`; slides overlay clears on `peitho:navigate`; fade timer.
 
 ## Gates additions
 
-Existing gates cover this (Rust tests × 3, clippy, fmt, bindings drift not applicable since no ts-rs change, vitest, embedded shell/remote drift after `npm run build`).
+Existing gates cover this (Rust tests × 3, clippy, fmt, bindings drift, vitest, embedded shell/remote drift after `npm run build`).
 
 E2E verification before merging (real display required):
 1. `peitho present --host deck.md` on macOS, phone joins `/remote`.
-2. Toggle Pointer on, tap-drag inside the preview area, confirm red dot tracks on the slides display.
-3. Release, confirm dot fades.
+2. Toggle Pointer on, tap-drag inside the preview area, confirm the cyan gradient pointer and trail track on the slides display.
+3. Release, confirm the trail fades.
 4. Advance slide via Next button, confirm any residual dot clears immediately.
 5. Toggle back to Off, confirm dot goes away and further taps do nothing.
 6. Kill server, restart, rejoin from phone, confirm no stale dot.
@@ -121,4 +124,4 @@ E2E verification before merging (real display required):
 
 - Whether to ship v1 without draw at all (this plan assumes yes; if draw is wanted from day one, the transport doesn't change but the overlay/state model grows).
 - Whether Off should be the persisted default per-device (plan: no persistence in v1).
-- Dot color/size (plan: fixed `#ff2a2a`, 1.2% of min viewport dimension).
+- ~~Dot color/size (plan: fixed `#ff2a2a`, 1.2% of min viewport dimension).~~ Resolved 2026-07-20: default is design E (`#38bdf8` radial gradient with `#e0f2fe` core), `pointer_color` frontmatter overrides the base color, radius remains 1.2%, and the overlay keeps a 500ms fading trail.

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1,3 +1,17 @@
+// src/keyboard.ts
+var navigationKeyMap = /* @__PURE__ */ new Map([
+  ["ArrowRight", "next"],
+  ["PageDown", "next"],
+  ["ArrowLeft", "prev"],
+  ["PageUp", "prev"],
+  ["Home", "first"],
+  ["End", "last"]
+]);
+var keyMap = new Map([...navigationKeyMap, [" ", "next"]]);
+function hasChordModifier(event) {
+  return event.metaKey || event.ctrlKey || event.altKey;
+}
+
 // src/timeTracker.ts
 var clamp01 = (ratio) => Math.min(Math.max(ratio, 0), 1);
 function isOverrun(elapsedMs, plannedDurationMs) {
@@ -243,6 +257,198 @@ async function mountPresentShell(options) {
   await shell.load();
   return shell;
 }
+function installPointerOverlay(options) {
+  const win = options.window ?? window;
+  const bus = options.bus ?? win;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const now = options.now ?? Date.now;
+  const log = options.console ?? console;
+  const canvas = options.canvas;
+  const ctx = canvas2dContext(canvas);
+  const state = { x: 0, y: 0, visible: false, lastUpAt: -Infinity };
+  let closed = false;
+  let seq = 0;
+  let session = null;
+  let frame = null;
+  let retryTimer = null;
+  const requestFrame = (callback) => {
+    if (typeof win.requestAnimationFrame === "function") {
+      return win.requestAnimationFrame(callback);
+    }
+    return win.setTimeout(() => callback(now()), 16);
+  };
+  const cancelFrame = (handle) => {
+    if (typeof win.cancelAnimationFrame === "function") {
+      win.cancelAnimationFrame(handle);
+      return;
+    }
+    win.clearTimeout(handle);
+  };
+  const resizeCanvas = () => {
+    const rect = canvas.getBoundingClientRect();
+    const fallbackWidth = win.innerWidth || 1;
+    const fallbackHeight = win.innerHeight || 1;
+    const cssWidth = rect.width > 0 ? rect.width : fallbackWidth;
+    const cssHeight = rect.height > 0 ? rect.height : fallbackHeight;
+    const scale = win.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.round(cssWidth * scale));
+    canvas.height = Math.max(1, Math.round(cssHeight * scale));
+    draw();
+  };
+  const clearCanvas = () => {
+    if (ctx == null) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+  const requestDraw = () => {
+    if (frame !== null) return;
+    frame = requestFrame(() => {
+      frame = null;
+      draw();
+      if (!closed && fadeOpacity(state, now()) > 0) {
+        requestDraw();
+      }
+    });
+  };
+  const resetState = () => {
+    state.visible = false;
+    state.lastUpAt = -Infinity;
+    clearCanvas();
+  };
+  const setSession = (nextSession) => {
+    if (session !== null && session !== nextSession) {
+      resetState();
+      session = nextSession;
+      return true;
+    }
+    session = nextSession;
+    return false;
+  };
+  const applyEvent = (event, options2 = {}) => {
+    if (event.kind === "move") {
+      state.x = event.x;
+      state.y = event.y;
+      state.visible = true;
+      state.lastUpAt = -Infinity;
+      requestDraw();
+      return;
+    }
+    if (options2.fadeUp === false) {
+      resetState();
+      return;
+    }
+    state.visible = false;
+    state.lastUpAt = now();
+    requestDraw();
+  };
+  const delay = () => new Promise((resolve) => {
+    retryTimer = win.setTimeout(() => {
+      retryTimer = null;
+      resolve();
+    }, 1e3);
+  });
+  const handshake = async () => {
+    try {
+      const response = await fetcher("/pointer");
+      if (closed) return false;
+      if (!response.ok) {
+        log.error(`Failed to start pointer polling: ${response.status}`);
+        await delay();
+        return false;
+      }
+      const body = await response.json();
+      if (!isPointerHandshakeResponse(body)) {
+        log.error("Invalid peitho pointer handshake");
+        await delay();
+        return false;
+      }
+      seq = body.seq;
+      setSession(body.session);
+      return true;
+    } catch (error) {
+      if (!closed) {
+        log.error(`Failed to start pointer polling: ${String(error)}`);
+        await delay();
+      }
+      return false;
+    }
+  };
+  const poll = async () => {
+    let needsHandshake = true;
+    while (!closed) {
+      while (!closed && needsHandshake && !await handshake()) {
+        continue;
+      }
+      if (closed) return;
+      needsHandshake = false;
+      try {
+        const response = await fetcher(`/pointer?seq=${seq}`);
+        if (closed) return;
+        if (response.status === 204) continue;
+        if (!response.ok) {
+          log.error(`Failed to poll pointer message: ${response.status}`);
+          await delay();
+          continue;
+        }
+        const body = pointerPollResponse(await response.json());
+        if (body == null) {
+          log.error("Invalid peitho pointer message");
+          await delay();
+          continue;
+        }
+        seq = body.seq;
+        const sessionChanged = setSession(body.session);
+        applyEvent(body.event, { fadeUp: !(sessionChanged && body.event.kind === "up") });
+      } catch (error) {
+        if (!closed) {
+          log.error(`Failed to poll pointer message: ${String(error)}`);
+          needsHandshake = true;
+          await delay();
+        }
+      }
+    }
+  };
+  const onNavigate = () => resetState();
+  if (ctx != null) {
+    resizeCanvas();
+    win.addEventListener("resize", resizeCanvas);
+    bus.addEventListener("peitho:navigate", onNavigate);
+    void poll();
+  }
+  return () => {
+    closed = true;
+    bus.removeEventListener("peitho:navigate", onNavigate);
+    win.removeEventListener("resize", resizeCanvas);
+    if (frame !== null) {
+      cancelFrame(frame);
+      frame = null;
+    }
+    if (retryTimer !== null) {
+      win.clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    clearCanvas();
+  };
+  function draw() {
+    if (ctx == null) return;
+    clearCanvas();
+    const opacity = fadeOpacity(state, now());
+    if (opacity <= 0) return;
+    ctx.save();
+    ctx.globalAlpha = opacity;
+    ctx.globalCompositeOperation = "multiply";
+    ctx.fillStyle = "#ff2a2a";
+    ctx.beginPath();
+    ctx.arc(
+      state.x * canvas.width,
+      state.y * canvas.height,
+      0.012 * Math.min(canvas.width, canvas.height),
+      0,
+      Math.PI * 2
+    );
+    ctx.fill();
+    ctx.restore();
+  }
+}
 var PresentShellController = class {
   manifest = null;
   currentIndex = -1;
@@ -258,6 +464,7 @@ var PresentShellController = class {
   viewport;
   canvasCleanups = [];
   fontScopeCleanup = null;
+  pointerCleanup = null;
   startedAtValue = null;
   pausedAtValue = null;
   pausedTotalMs = 0;
@@ -323,6 +530,7 @@ var PresentShellController = class {
         this.slides.push(view);
       }
       this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+      this.mountPointerOverlay();
     } catch (error) {
       this.clearCanvasRootProperties();
       this.root.replaceChildren();
@@ -366,6 +574,8 @@ var PresentShellController = class {
   }
   destroy() {
     this.endPresentation();
+    this.pointerCleanup?.();
+    this.pointerCleanup = null;
     this.fontScopeCleanup?.();
     this.fontScopeCleanup = null;
     while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
@@ -423,6 +633,27 @@ var PresentShellController = class {
     template.innerHTML = html;
     shadow.appendChild(template.content.cloneNode(true));
     return host;
+  }
+  mountPointerOverlay() {
+    if (this.viewport != null) return;
+    const canvas = this.doc.createElement("canvas");
+    canvas.dataset.peithoPointerOverlay = "true";
+    canvas.style.position = "absolute";
+    canvas.style.inset = "0";
+    canvas.style.zIndex = "4";
+    canvas.style.pointerEvents = "none";
+    canvas.style.mixBlendMode = "multiply";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    this.root.appendChild(canvas);
+    this.pointerCleanup = installPointerOverlay({
+      canvas,
+      fetcher: this.fetcher,
+      bus: this.bus,
+      window: this.win,
+      now: this.now,
+      console: this.log
+    });
   }
   resolveTarget(to) {
     if (to === "first") return 0;
@@ -533,17 +764,58 @@ var PresentShellController = class {
     );
   }
 };
-
-// src/keyboard.ts
-var navigationKeyMap = /* @__PURE__ */ new Map([
-  ["ArrowRight", "next"],
-  ["PageDown", "next"],
-  ["ArrowLeft", "prev"],
-  ["PageUp", "prev"],
-  ["Home", "first"],
-  ["End", "last"]
-]);
-var keyMap = new Map([...navigationKeyMap, [" ", "next"]]);
+function fadeOpacity(state, nowMs) {
+  if (state.visible) return 1;
+  if (!Number.isFinite(state.lastUpAt)) return 0;
+  return Math.max(0, Math.min(1, 1 - (nowMs - state.lastUpAt) / 150));
+}
+function canvas2dContext(canvas) {
+  try {
+    return canvas.getContext("2d");
+  } catch (_error) {
+    return null;
+  }
+}
+function isPointerHandshakeResponse(value) {
+  return hasExactKeys(value, ["seq", "session"]) && typeof value.seq === "number" && Number.isFinite(value.seq) && typeof value.session === "string";
+}
+function pointerPollResponse(value) {
+  if (!hasExactKeys(value, ["seq", "event", "session"]) || typeof value.seq !== "number" || !Number.isFinite(value.seq) || typeof value.session !== "string") {
+    return null;
+  }
+  const event = pointerOverlayEvent(value.event);
+  if (event == null) return null;
+  return { seq: value.seq, event, session: value.session };
+}
+function pointerOverlayEvent(value) {
+  if (!isRecord(value)) return null;
+  if (hasExactKeys(value, ["up"])) {
+    return value.up === true ? { kind: "up" } : null;
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || !Object.hasOwn(value, "move")) {
+    return null;
+  }
+  const move = value.move;
+  if (!hasExactKeys(move, ["x", "y"])) {
+    return null;
+  }
+  if (!isUnitCoordinate(move.x) || !isUnitCoordinate(move.y)) {
+    return null;
+  }
+  return { kind: "move", x: move.x, y: move.y };
+}
+function hasExactKeys(value, keys) {
+  if (!isRecord(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function isUnitCoordinate(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
 
 // src/swap.ts
 var SWAP_ROUTES = Object.freeze({
@@ -556,35 +828,35 @@ var SWAP_ROUTES = Object.freeze({
 });
 
 // src/sync.ts
-function isRecord(value) {
+function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 function isCloseSyncMessage(value) {
-  return isRecord(value) && value.close === true;
+  return isRecord2(value) && value.close === true;
 }
 function isIndexSyncMessage(value) {
-  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
+  return isRecord2(value) && typeof value.index === "number" && Number.isFinite(value.index);
 }
 function isSwappedSyncMessage(value) {
-  return isRecord(value) && typeof value.swapped === "boolean";
+  return isRecord2(value) && typeof value.swapped === "boolean";
 }
 function isSyncedSyncMessage(value) {
-  return isRecord(value) && value.synced === true;
+  return isRecord2(value) && value.synced === true;
 }
 function isSessionChangedSyncMessage(value) {
-  return isRecord(value) && value.sessionChanged === true;
+  return isRecord2(value) && value.sessionChanged === true;
 }
 function isNonNegativeFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 function isTimerSyncMessage(value) {
-  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
+  return isRecord2(value) && isRecord2(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
 }
 function isTimerReplaySyncMessage(value) {
-  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
+  return isRecord2(value) && isRecord2(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
 }
 function isGenerationSyncMessage(value) {
-  return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
+  return isRecord2(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
 function serverSyncChannelFactory(options = {}) {
   const url = options.url ?? "/sync";
@@ -886,13 +1158,30 @@ function installRemoteControls(options) {
   notesBody.className = "peitho-remote-notes-body";
   notesBody.dataset.peithoRemote = "notes";
   notesPanel.append(notesCaption, notesBody);
+  const pointerMode = createDimmableRow(doc, "div", "peitho-remote-pointer-mode");
+  pointerMode.dataset.peithoRemote = "pointer-mode";
+  pointerMode.setAttribute("role", "group");
+  pointerMode.setAttribute("aria-label", "Pointer mode");
+  const pointerOff = remotePointerModeButton(doc, "off", "Off");
+  const pointerOn = remotePointerModeButton(doc, "pointer", "Pointer");
+  pointerMode.append(pointerOff, pointerOn);
   const actions = doc.createElement("div");
   actions.className = "peitho-remote-actions";
   const prev = remoteButton(doc, "prev", "Previous");
   const next = remoteButton(doc, "next", "Next");
   actions.append(prev, next);
+  let currentPointerMode = "off";
+  const setPointerMode = (mode) => {
+    if (mode === currentPointerMode) return;
+    currentPointerMode = mode;
+    pointerOff.setAttribute("aria-pressed", mode === "off" ? "true" : "false");
+    pointerOn.setAttribute("aria-pressed", mode === "pointer" ? "true" : "false");
+    dispatchPointerModeChange(bus, mode);
+  };
   const onPrev = () => dispatchNavigate(bus, "prev");
   const onNext = () => dispatchNavigate(bus, "next");
+  const onPointerOff = () => setPointerMode("off");
+  const onPointerOn = () => setPointerMode("pointer");
   const onTimer = () => {
     const action = timerButton.dataset.peithoTimerAction;
     if (action === "start" || action === "pause" || action === "resume") {
@@ -902,6 +1191,8 @@ function installRemoteControls(options) {
   const onReset = () => dispatchTimerControl(bus, "reset");
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
+  pointerOff.addEventListener("click", onPointerOff);
+  pointerOn.addEventListener("click", onPointerOn);
   timerButton.addEventListener("click", onTimer);
   resetButton.addEventListener("click", onReset);
   const rows = [
@@ -910,6 +1201,7 @@ function installRemoteControls(options) {
     { kind: "dimmable", element: chase },
     { kind: "dimmable", element: pace },
     { kind: "dimmable", element: notesPanel },
+    { kind: "dimmable", element: pointerMode },
     { kind: "actions", element: actions }
   ];
   container.append(...rows.map((row) => row.element));
@@ -917,6 +1209,8 @@ function installRemoteControls(options) {
   return () => {
     prev.removeEventListener("click", onPrev);
     next.removeEventListener("click", onNext);
+    pointerOff.removeEventListener("click", onPointerOff);
+    pointerOn.removeEventListener("click", onPointerOn);
     timerButton.removeEventListener("click", onTimer);
     resetButton.removeEventListener("click", onReset);
     container.remove();
@@ -926,6 +1220,180 @@ function createDimmableRow(doc, tag, ...classNames) {
   const el = doc.createElement(tag);
   el.classList.add("peitho-remote-dim-on-end", ...classNames);
   return el;
+}
+function remotePointerModeButton(doc, mode, label) {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.dataset.peithoPointerMode = mode;
+  button.setAttribute("aria-pressed", mode === "off" ? "true" : "false");
+  button.textContent = label;
+  return button;
+}
+function installRemotePointerBridge(options) {
+  const win = options.window ?? window;
+  const bus = options.bus ?? win;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const log = options.console ?? console;
+  const now = options.now ?? Date.now;
+  const previewRoot = options.previewRoot;
+  let mode = "off";
+  let activePointerId = null;
+  let listenersInstalled = false;
+  let pendingMove = null;
+  let frame = null;
+  let previousTouchAction = null;
+  const requestFrame = (callback) => {
+    if (typeof win.requestAnimationFrame === "function") {
+      return win.requestAnimationFrame(callback);
+    }
+    return win.setTimeout(() => callback(now()), 16);
+  };
+  const cancelFrame = (handle) => {
+    if (typeof win.cancelAnimationFrame === "function") {
+      win.cancelAnimationFrame(handle);
+      return;
+    }
+    win.clearTimeout(handle);
+  };
+  const postPointer = (message) => {
+    let request;
+    try {
+      request = fetcher("/pointer", {
+        method: "POST",
+        body: JSON.stringify(message),
+        keepalive: true,
+        headers: { "Content-Type": "application/json" }
+      });
+    } catch (error) {
+      log.error(`Failed to post pointer message: ${String(error)}`);
+      return;
+    }
+    void request.then((response) => {
+      if (!response.ok) {
+        log.error(`Failed to post pointer message: ${response.status}`);
+      }
+    }).catch((error) => {
+      log.error(`Failed to post pointer message: ${String(error)}`);
+    });
+  };
+  const cancelPendingMove = () => {
+    pendingMove = null;
+    if (frame === null) return;
+    cancelFrame(frame);
+    frame = null;
+  };
+  const flushMove = () => {
+    frame = null;
+    const move = pendingMove;
+    pendingMove = null;
+    if (mode !== "pointer" || move == null) return;
+    postPointer({ move });
+  };
+  const queueMove = (move) => {
+    pendingMove = move;
+    if (frame !== null) return;
+    frame = requestFrame(flushMove);
+  };
+  const pointForEvent = (event) => {
+    const rect = previewRoot.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    return {
+      x: clamp01((event.clientX - rect.left) / rect.width),
+      y: clamp01((event.clientY - rect.top) / rect.height)
+    };
+  };
+  const onPointerDown = (event) => {
+    if (mode !== "pointer" || hasChordModifier(event) || event.button !== 0) return;
+    const point = pointForEvent(event);
+    if (point == null) return;
+    activePointerId = event.pointerId;
+    event.preventDefault();
+    dispatchPointerMove(bus, point);
+  };
+  const onPointerMove = (event) => {
+    if (mode !== "pointer" || activePointerId !== event.pointerId || hasChordModifier(event)) {
+      return;
+    }
+    const point = pointForEvent(event);
+    if (point == null) return;
+    event.preventDefault();
+    dispatchPointerMove(bus, point);
+  };
+  const onPointerEnd = (event) => {
+    if (mode !== "pointer" || activePointerId !== event.pointerId) return;
+    activePointerId = null;
+    event.preventDefault();
+    dispatchPointerUp(bus);
+  };
+  const installPointerListeners = () => {
+    if (listenersInstalled) return;
+    listenersInstalled = true;
+    previousTouchAction = previewRoot.style.touchAction;
+    previewRoot.style.touchAction = "none";
+    previewRoot.dataset.peithoPointerMode = "pointer";
+    previewRoot.addEventListener("pointerdown", onPointerDown);
+    previewRoot.addEventListener("pointermove", onPointerMove);
+    previewRoot.addEventListener("pointerup", onPointerEnd);
+    previewRoot.addEventListener("pointercancel", onPointerEnd);
+    previewRoot.addEventListener("pointerleave", onPointerEnd);
+  };
+  const removePointerListeners = (sendFinalUp) => {
+    if (listenersInstalled) {
+      previewRoot.removeEventListener("pointerdown", onPointerDown);
+      previewRoot.removeEventListener("pointermove", onPointerMove);
+      previewRoot.removeEventListener("pointerup", onPointerEnd);
+      previewRoot.removeEventListener("pointercancel", onPointerEnd);
+      previewRoot.removeEventListener("pointerleave", onPointerEnd);
+      listenersInstalled = false;
+    }
+    activePointerId = null;
+    cancelPendingMove();
+    if (previousTouchAction !== null) {
+      previewRoot.style.touchAction = previousTouchAction;
+      previousTouchAction = null;
+    }
+    delete previewRoot.dataset.peithoPointerMode;
+    if (sendFinalUp) postPointer({ up: true });
+  };
+  const onModeChange = (event) => {
+    const next = event.detail?.mode;
+    if (next !== "off" && next !== "pointer") {
+      log.error("Invalid peitho:pointermodechange event");
+      return;
+    }
+    if (next === mode) return;
+    mode = next;
+    if (mode === "pointer") {
+      installPointerListeners();
+    } else {
+      removePointerListeners(true);
+    }
+  };
+  const onPointerMoveRequest = (event) => {
+    if (mode !== "pointer") return;
+    const detail = event.detail;
+    if (!isPointerMoveDetail(detail)) {
+      log.error("Invalid peitho:pointermove event");
+      return;
+    }
+    queueMove(detail);
+  };
+  const onPointerUpRequest = () => {
+    if (mode !== "pointer") return;
+    activePointerId = null;
+    cancelPendingMove();
+    postPointer({ up: true });
+  };
+  bus.addEventListener("peitho:pointermodechange", onModeChange);
+  bus.addEventListener("peitho:pointermove", onPointerMoveRequest);
+  bus.addEventListener("peitho:pointerup", onPointerUpRequest);
+  return () => {
+    bus.removeEventListener("peitho:pointermodechange", onModeChange);
+    bus.removeEventListener("peitho:pointermove", onPointerMoveRequest);
+    bus.removeEventListener("peitho:pointerup", onPointerUpRequest);
+    removePointerListeners(mode === "pointer");
+    mode = "off";
+  };
 }
 function installRemoteSyncBridge(options) {
   const bus = options.bus ?? window;
@@ -1021,6 +1489,7 @@ var RemoteController = class {
   timerState = null;
   controlsCleanup = null;
   syncCleanup = null;
+  pointerCleanup = null;
   previewShell = null;
   timerInterval = null;
   constructor(options) {
@@ -1065,6 +1534,14 @@ var RemoteController = class {
           now: this.now,
           viewport: paneViewport(previewRoot)
         });
+        this.pointerCleanup = installRemotePointerBridge({
+          bus: this.bus,
+          previewRoot,
+          fetcher: this.fetcher,
+          window: this.win,
+          now: this.now,
+          console: this.log
+        });
       }
       this.render();
       this.syncCleanup = installRemoteSyncBridge({
@@ -1087,6 +1564,8 @@ var RemoteController = class {
   }
   destroy() {
     this.clearTimerInterval();
+    this.pointerCleanup?.();
+    this.pointerCleanup = null;
     this.syncCleanup?.();
     this.syncCleanup = null;
     this.previewShell?.destroy();
@@ -1344,6 +1823,25 @@ function dispatchNavigate(bus, to) {
 function dispatchTimerControl(bus, action) {
   bus.dispatchEvent(new CustomEvent("peitho:timercontrol", { detail: { action } }));
 }
+function dispatchPointerModeChange(bus, mode) {
+  bus.dispatchEvent(
+    new CustomEvent("peitho:pointermodechange", { detail: { mode } })
+  );
+}
+function dispatchPointerMove(bus, detail) {
+  bus.dispatchEvent(new CustomEvent("peitho:pointermove", { detail }));
+}
+function dispatchPointerUp(bus) {
+  bus.dispatchEvent(new CustomEvent("peitho:pointerup"));
+}
+function isPointerMoveDetail(value) {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value;
+  return isUnitCoordinate2(candidate.x) && isUnitCoordinate2(candidate.y);
+}
+function isUnitCoordinate2(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
 function resolveRemoteTarget(slides, currentIndex, to) {
   const base = currentIndex ?? initialSlideIndex(slides);
   if (base === null) return null;
@@ -1473,6 +1971,7 @@ export {
   createDimmableRow,
   expectedElapsedAtSlide,
   installRemoteControls,
+  installRemotePointerBridge,
   installRemoteSyncBridge,
   mountPresentShell,
   mountRemoteView,

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -252,6 +252,161 @@ function initialSlideIndex(slides) {
 }
 
 // src/shell.ts
+var DEFAULT_POINTER_BASE_COLOR = "#38bdf8";
+var DEFAULT_POINTER_CORE_COLOR = "#e0f2fe";
+var POINTER_TRAIL_DURATION_MS = 500;
+var POINTER_TRAIL_CAP = 64;
+var POINTER_CORE_MIX_TO_WHITE = 0.65;
+var CSS_NAMED_COLORS = {
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
+  black: "#000000",
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  blueviolet: "#8a2be2",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkgrey: "#a9a9a9",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkslategrey: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#adff2f",
+  grey: "#808080",
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightgrey: "#d3d3d3",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
+  red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: "#ffffff",
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32"
+};
 async function mountPresentShell(options) {
   const shell = new PresentShellController(options);
   await shell.load();
@@ -265,7 +420,9 @@ function installPointerOverlay(options) {
   const log = options.console ?? console;
   const canvas = options.canvas;
   const ctx = canvas2dContext(canvas);
-  const state = { x: 0, y: 0, visible: false, lastUpAt: -Infinity };
+  const palette = pointerPalette(options.pointerColor);
+  const state = { x: 0, y: 0, visible: false };
+  const trail = [];
   let closed = false;
   let seq = 0;
   let session = null;
@@ -304,14 +461,14 @@ function installPointerOverlay(options) {
     frame = requestFrame(() => {
       frame = null;
       draw();
-      if (!closed && fadeOpacity(state, now()) > 0) {
+      if (!closed && (state.visible || trail.length > 0)) {
         requestDraw();
       }
     });
   };
   const resetState = () => {
     state.visible = false;
-    state.lastUpAt = -Infinity;
+    trail.length = 0;
     clearCanvas();
   };
   const setSession = (nextSession) => {
@@ -328,7 +485,7 @@ function installPointerOverlay(options) {
       state.x = event.x;
       state.y = event.y;
       state.visible = true;
-      state.lastUpAt = -Infinity;
+      pushTrailPoint({ x: event.x, y: event.y, timestamp: now() });
       requestDraw();
       return;
     }
@@ -337,7 +494,6 @@ function installPointerOverlay(options) {
       return;
     }
     state.visible = false;
-    state.lastUpAt = now();
     requestDraw();
   };
   const delay = () => new Promise((resolve) => {
@@ -430,24 +586,48 @@ function installPointerOverlay(options) {
   };
   function draw() {
     if (ctx == null) return;
+    const context = ctx;
     clearCanvas();
-    const opacity = fadeOpacity(state, now());
-    if (opacity <= 0) return;
-    const x = state.x * canvas.width;
-    const y = state.y * canvas.height;
+    const nowMs = now();
     const radius = 0.012 * Math.min(canvas.width, canvas.height);
-    const ringRadius = radius + 2;
-    ctx.save();
-    ctx.globalAlpha = opacity;
-    ctx.fillStyle = "#ffffff";
-    ctx.beginPath();
-    ctx.arc(x, y, ringRadius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = "#ff2a2a";
-    ctx.beginPath();
-    ctx.arc(x, y, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.restore();
+    pruneTrail(nowMs);
+    const headIndex = state.visible ? trail.length - 1 : -1;
+    for (let index = trail.length - 1; index >= 0; index -= 1) {
+      if (index === headIndex) continue;
+      const point = trail[index];
+      const alpha = trailOpacity(point, nowMs);
+      if (alpha <= 0) continue;
+      drawPointerPoint(context, point, alpha, radius * (0.6 + 0.4 * alpha));
+    }
+    if (state.visible) {
+      drawPointerPoint(context, { x: state.x, y: state.y, timestamp: nowMs }, 1, radius);
+    }
+  }
+  function pushTrailPoint(point) {
+    trail.push(point);
+    if (trail.length > POINTER_TRAIL_CAP) {
+      trail.splice(0, trail.length - POINTER_TRAIL_CAP);
+    }
+  }
+  function pruneTrail(nowMs) {
+    while (trail.length > 0 && trailOpacity(trail[0], nowMs) <= 0) {
+      trail.shift();
+    }
+  }
+  function drawPointerPoint(context, point, alpha, radius) {
+    const x = point.x * canvas.width;
+    const y = point.y * canvas.height;
+    const gradient = context.createRadialGradient(x, y, 0, x, y, radius);
+    gradient.addColorStop(0, palette.coreColor);
+    gradient.addColorStop(0.25, palette.baseColor);
+    gradient.addColorStop(1, palette.transparentBase);
+    context.save();
+    context.globalAlpha = alpha;
+    context.fillStyle = gradient;
+    context.beginPath();
+    context.arc(x, y, radius, 0, Math.PI * 2);
+    context.fill();
+    context.restore();
   }
 }
 var PresentShellController = class {
@@ -652,7 +832,8 @@ var PresentShellController = class {
       bus: this.bus,
       window: this.win,
       now: this.now,
-      console: this.log
+      console: this.log,
+      pointerColor: this.manifest?.pointerColor ?? null
     });
   }
   resolveTarget(to) {
@@ -764,10 +945,61 @@ var PresentShellController = class {
     );
   }
 };
-function fadeOpacity(state, nowMs) {
-  if (state.visible) return 1;
-  if (!Number.isFinite(state.lastUpAt)) return 0;
-  return Math.max(0, Math.min(1, 1 - (nowMs - state.lastUpAt) / 150));
+function trailOpacity(point, nowMs) {
+  return Math.max(0, Math.min(1, 1 - (nowMs - point.timestamp) / POINTER_TRAIL_DURATION_MS));
+}
+function pointerPalette(pointerColor) {
+  const requestedColor = pointerColor?.trim() || DEFAULT_POINTER_BASE_COLOR;
+  const parsed = parsePointerColor(requestedColor);
+  const baseColor = parsed == null ? DEFAULT_POINTER_BASE_COLOR : requestedColor;
+  const rgb = parsed ?? parsePointerColor(DEFAULT_POINTER_BASE_COLOR);
+  const coreColor = baseColor.toLowerCase() === DEFAULT_POINTER_BASE_COLOR ? DEFAULT_POINTER_CORE_COLOR : mixToWhite(baseColor, POINTER_CORE_MIX_TO_WHITE);
+  return {
+    baseColor,
+    coreColor,
+    transparentBase: transparentRgb(rgb)
+  };
+}
+function mixToWhite(color, amount) {
+  const rgb = parsePointerColor(color);
+  if (rgb == null) {
+    throw new Error(`Unsupported pointer color: ${color}`);
+  }
+  const mix = Math.max(0, Math.min(1, amount));
+  return rgbToHex({
+    r: Math.round(rgb.r * (1 - mix) + 255 * mix),
+    g: Math.round(rgb.g * (1 - mix) + 255 * mix),
+    b: Math.round(rgb.b * (1 - mix) + 255 * mix)
+  });
+}
+function transparentRgb(color) {
+  return `rgba(${color.r}, ${color.g}, ${color.b}, 0)`;
+}
+function rgbToHex(color) {
+  const channel = (value) => value.toString(16).padStart(2, "0");
+  return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
+}
+function parsePointerColor(color) {
+  const value = color.trim().toLowerCase();
+  const hex = value.startsWith("#") ? value : CSS_NAMED_COLORS[value];
+  if (hex == null) return null;
+  return parseHexPointerColor(hex);
+}
+function parseHexPointerColor(color) {
+  const hex = color.slice(1);
+  if (![3, 4, 6, 8].includes(hex.length) || !/^[0-9a-f]+$/i.test(hex)) return null;
+  if (hex.length === 3 || hex.length === 4) {
+    return {
+      r: Number.parseInt(`${hex[0]}${hex[0]}`, 16),
+      g: Number.parseInt(`${hex[1]}${hex[1]}`, 16),
+      b: Number.parseInt(`${hex[2]}${hex[2]}`, 16)
+    };
+  }
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16)
+  };
 }
 function canvas2dContext(canvas) {
   try {

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -433,18 +433,19 @@ function installPointerOverlay(options) {
     clearCanvas();
     const opacity = fadeOpacity(state, now());
     if (opacity <= 0) return;
+    const x = state.x * canvas.width;
+    const y = state.y * canvas.height;
+    const radius = 0.012 * Math.min(canvas.width, canvas.height);
+    const ringRadius = radius + 2;
     ctx.save();
     ctx.globalAlpha = opacity;
-    ctx.globalCompositeOperation = "multiply";
+    ctx.fillStyle = "#ffffff";
+    ctx.beginPath();
+    ctx.arc(x, y, ringRadius, 0, Math.PI * 2);
+    ctx.fill();
     ctx.fillStyle = "#ff2a2a";
     ctx.beginPath();
-    ctx.arc(
-      state.x * canvas.width,
-      state.y * canvas.height,
-      0.012 * Math.min(canvas.width, canvas.height),
-      0,
-      Math.PI * 2
-    );
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
   }
@@ -642,7 +643,6 @@ var PresentShellController = class {
     canvas.style.inset = "0";
     canvas.style.zIndex = "4";
     canvas.style.pointerEvents = "none";
-    canvas.style.mixBlendMode = "multiply";
     canvas.style.width = "100%";
     canvas.style.height = "100%";
     this.root.appendChild(canvas);

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -905,6 +905,161 @@ function initialSlideIndex(slides) {
 }
 
 // src/shell.ts
+var DEFAULT_POINTER_BASE_COLOR = "#38bdf8";
+var DEFAULT_POINTER_CORE_COLOR = "#e0f2fe";
+var POINTER_TRAIL_DURATION_MS = 500;
+var POINTER_TRAIL_CAP = 64;
+var POINTER_CORE_MIX_TO_WHITE = 0.65;
+var CSS_NAMED_COLORS = {
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
+  black: "#000000",
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  blueviolet: "#8a2be2",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkgrey: "#a9a9a9",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkslategrey: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#adff2f",
+  grey: "#808080",
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightgrey: "#d3d3d3",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
+  red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: "#ffffff",
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32"
+};
 async function mountPresentShell(options) {
   const shell = new PresentShellController(options);
   await shell.load();
@@ -918,7 +1073,9 @@ function installPointerOverlay(options) {
   const log = options.console ?? console;
   const canvas = options.canvas;
   const ctx = canvas2dContext(canvas);
-  const state = { x: 0, y: 0, visible: false, lastUpAt: -Infinity };
+  const palette = pointerPalette(options.pointerColor);
+  const state = { x: 0, y: 0, visible: false };
+  const trail = [];
   let closed = false;
   let seq = 0;
   let session = null;
@@ -957,14 +1114,14 @@ function installPointerOverlay(options) {
     frame = requestFrame(() => {
       frame = null;
       draw();
-      if (!closed && fadeOpacity(state, now()) > 0) {
+      if (!closed && (state.visible || trail.length > 0)) {
         requestDraw();
       }
     });
   };
   const resetState = () => {
     state.visible = false;
-    state.lastUpAt = -Infinity;
+    trail.length = 0;
     clearCanvas();
   };
   const setSession = (nextSession) => {
@@ -981,7 +1138,7 @@ function installPointerOverlay(options) {
       state.x = event.x;
       state.y = event.y;
       state.visible = true;
-      state.lastUpAt = -Infinity;
+      pushTrailPoint({ x: event.x, y: event.y, timestamp: now() });
       requestDraw();
       return;
     }
@@ -990,7 +1147,6 @@ function installPointerOverlay(options) {
       return;
     }
     state.visible = false;
-    state.lastUpAt = now();
     requestDraw();
   };
   const delay = () => new Promise((resolve) => {
@@ -1083,24 +1239,48 @@ function installPointerOverlay(options) {
   };
   function draw() {
     if (ctx == null) return;
+    const context = ctx;
     clearCanvas();
-    const opacity = fadeOpacity(state, now());
-    if (opacity <= 0) return;
-    const x = state.x * canvas.width;
-    const y = state.y * canvas.height;
+    const nowMs = now();
     const radius = 0.012 * Math.min(canvas.width, canvas.height);
-    const ringRadius = radius + 2;
-    ctx.save();
-    ctx.globalAlpha = opacity;
-    ctx.fillStyle = "#ffffff";
-    ctx.beginPath();
-    ctx.arc(x, y, ringRadius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = "#ff2a2a";
-    ctx.beginPath();
-    ctx.arc(x, y, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.restore();
+    pruneTrail(nowMs);
+    const headIndex = state.visible ? trail.length - 1 : -1;
+    for (let index = trail.length - 1; index >= 0; index -= 1) {
+      if (index === headIndex) continue;
+      const point = trail[index];
+      const alpha = trailOpacity(point, nowMs);
+      if (alpha <= 0) continue;
+      drawPointerPoint(context, point, alpha, radius * (0.6 + 0.4 * alpha));
+    }
+    if (state.visible) {
+      drawPointerPoint(context, { x: state.x, y: state.y, timestamp: nowMs }, 1, radius);
+    }
+  }
+  function pushTrailPoint(point) {
+    trail.push(point);
+    if (trail.length > POINTER_TRAIL_CAP) {
+      trail.splice(0, trail.length - POINTER_TRAIL_CAP);
+    }
+  }
+  function pruneTrail(nowMs) {
+    while (trail.length > 0 && trailOpacity(trail[0], nowMs) <= 0) {
+      trail.shift();
+    }
+  }
+  function drawPointerPoint(context, point, alpha, radius) {
+    const x = point.x * canvas.width;
+    const y = point.y * canvas.height;
+    const gradient = context.createRadialGradient(x, y, 0, x, y, radius);
+    gradient.addColorStop(0, palette.coreColor);
+    gradient.addColorStop(0.25, palette.baseColor);
+    gradient.addColorStop(1, palette.transparentBase);
+    context.save();
+    context.globalAlpha = alpha;
+    context.fillStyle = gradient;
+    context.beginPath();
+    context.arc(x, y, radius, 0, Math.PI * 2);
+    context.fill();
+    context.restore();
   }
 }
 var PresentShellController = class {
@@ -1305,7 +1485,8 @@ var PresentShellController = class {
       bus: this.bus,
       window: this.win,
       now: this.now,
-      console: this.log
+      console: this.log,
+      pointerColor: this.manifest?.pointerColor ?? null
     });
   }
   resolveTarget(to) {
@@ -1417,10 +1598,61 @@ var PresentShellController = class {
     );
   }
 };
-function fadeOpacity(state, nowMs) {
-  if (state.visible) return 1;
-  if (!Number.isFinite(state.lastUpAt)) return 0;
-  return Math.max(0, Math.min(1, 1 - (nowMs - state.lastUpAt) / 150));
+function trailOpacity(point, nowMs) {
+  return Math.max(0, Math.min(1, 1 - (nowMs - point.timestamp) / POINTER_TRAIL_DURATION_MS));
+}
+function pointerPalette(pointerColor) {
+  const requestedColor = pointerColor?.trim() || DEFAULT_POINTER_BASE_COLOR;
+  const parsed = parsePointerColor(requestedColor);
+  const baseColor = parsed == null ? DEFAULT_POINTER_BASE_COLOR : requestedColor;
+  const rgb = parsed ?? parsePointerColor(DEFAULT_POINTER_BASE_COLOR);
+  const coreColor = baseColor.toLowerCase() === DEFAULT_POINTER_BASE_COLOR ? DEFAULT_POINTER_CORE_COLOR : mixToWhite(baseColor, POINTER_CORE_MIX_TO_WHITE);
+  return {
+    baseColor,
+    coreColor,
+    transparentBase: transparentRgb(rgb)
+  };
+}
+function mixToWhite(color, amount) {
+  const rgb = parsePointerColor(color);
+  if (rgb == null) {
+    throw new Error(`Unsupported pointer color: ${color}`);
+  }
+  const mix = Math.max(0, Math.min(1, amount));
+  return rgbToHex({
+    r: Math.round(rgb.r * (1 - mix) + 255 * mix),
+    g: Math.round(rgb.g * (1 - mix) + 255 * mix),
+    b: Math.round(rgb.b * (1 - mix) + 255 * mix)
+  });
+}
+function transparentRgb(color) {
+  return `rgba(${color.r}, ${color.g}, ${color.b}, 0)`;
+}
+function rgbToHex(color) {
+  const channel = (value) => value.toString(16).padStart(2, "0");
+  return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
+}
+function parsePointerColor(color) {
+  const value = color.trim().toLowerCase();
+  const hex = value.startsWith("#") ? value : CSS_NAMED_COLORS[value];
+  if (hex == null) return null;
+  return parseHexPointerColor(hex);
+}
+function parseHexPointerColor(color) {
+  const hex = color.slice(1);
+  if (![3, 4, 6, 8].includes(hex.length) || !/^[0-9a-f]+$/i.test(hex)) return null;
+  if (hex.length === 3 || hex.length === 4) {
+    return {
+      r: Number.parseInt(`${hex[0]}${hex[0]}`, 16),
+      g: Number.parseInt(`${hex[1]}${hex[1]}`, 16),
+      b: Number.parseInt(`${hex[2]}${hex[2]}`, 16)
+    };
+  }
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16)
+  };
 }
 function canvas2dContext(canvas) {
   try {

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -1086,18 +1086,19 @@ function installPointerOverlay(options) {
     clearCanvas();
     const opacity = fadeOpacity(state, now());
     if (opacity <= 0) return;
+    const x = state.x * canvas.width;
+    const y = state.y * canvas.height;
+    const radius = 0.012 * Math.min(canvas.width, canvas.height);
+    const ringRadius = radius + 2;
     ctx.save();
     ctx.globalAlpha = opacity;
-    ctx.globalCompositeOperation = "multiply";
+    ctx.fillStyle = "#ffffff";
+    ctx.beginPath();
+    ctx.arc(x, y, ringRadius, 0, Math.PI * 2);
+    ctx.fill();
     ctx.fillStyle = "#ff2a2a";
     ctx.beginPath();
-    ctx.arc(
-      state.x * canvas.width,
-      state.y * canvas.height,
-      0.012 * Math.min(canvas.width, canvas.height),
-      0,
-      Math.PI * 2
-    );
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
   }
@@ -1295,7 +1296,6 @@ var PresentShellController = class {
     canvas.style.inset = "0";
     canvas.style.zIndex = "4";
     canvas.style.pointerEvents = "none";
-    canvas.style.mixBlendMode = "multiply";
     canvas.style.width = "100%";
     canvas.style.height = "100%";
     this.root.appendChild(canvas);

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -910,6 +910,198 @@ async function mountPresentShell(options) {
   await shell.load();
   return shell;
 }
+function installPointerOverlay(options) {
+  const win = options.window ?? window;
+  const bus = options.bus ?? win;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const now = options.now ?? Date.now;
+  const log = options.console ?? console;
+  const canvas = options.canvas;
+  const ctx = canvas2dContext(canvas);
+  const state = { x: 0, y: 0, visible: false, lastUpAt: -Infinity };
+  let closed = false;
+  let seq = 0;
+  let session = null;
+  let frame = null;
+  let retryTimer = null;
+  const requestFrame = (callback) => {
+    if (typeof win.requestAnimationFrame === "function") {
+      return win.requestAnimationFrame(callback);
+    }
+    return win.setTimeout(() => callback(now()), 16);
+  };
+  const cancelFrame = (handle) => {
+    if (typeof win.cancelAnimationFrame === "function") {
+      win.cancelAnimationFrame(handle);
+      return;
+    }
+    win.clearTimeout(handle);
+  };
+  const resizeCanvas = () => {
+    const rect = canvas.getBoundingClientRect();
+    const fallbackWidth = win.innerWidth || 1;
+    const fallbackHeight = win.innerHeight || 1;
+    const cssWidth = rect.width > 0 ? rect.width : fallbackWidth;
+    const cssHeight = rect.height > 0 ? rect.height : fallbackHeight;
+    const scale = win.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.round(cssWidth * scale));
+    canvas.height = Math.max(1, Math.round(cssHeight * scale));
+    draw();
+  };
+  const clearCanvas = () => {
+    if (ctx == null) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+  const requestDraw = () => {
+    if (frame !== null) return;
+    frame = requestFrame(() => {
+      frame = null;
+      draw();
+      if (!closed && fadeOpacity(state, now()) > 0) {
+        requestDraw();
+      }
+    });
+  };
+  const resetState = () => {
+    state.visible = false;
+    state.lastUpAt = -Infinity;
+    clearCanvas();
+  };
+  const setSession = (nextSession) => {
+    if (session !== null && session !== nextSession) {
+      resetState();
+      session = nextSession;
+      return true;
+    }
+    session = nextSession;
+    return false;
+  };
+  const applyEvent = (event, options2 = {}) => {
+    if (event.kind === "move") {
+      state.x = event.x;
+      state.y = event.y;
+      state.visible = true;
+      state.lastUpAt = -Infinity;
+      requestDraw();
+      return;
+    }
+    if (options2.fadeUp === false) {
+      resetState();
+      return;
+    }
+    state.visible = false;
+    state.lastUpAt = now();
+    requestDraw();
+  };
+  const delay = () => new Promise((resolve) => {
+    retryTimer = win.setTimeout(() => {
+      retryTimer = null;
+      resolve();
+    }, 1e3);
+  });
+  const handshake = async () => {
+    try {
+      const response = await fetcher("/pointer");
+      if (closed) return false;
+      if (!response.ok) {
+        log.error(`Failed to start pointer polling: ${response.status}`);
+        await delay();
+        return false;
+      }
+      const body = await response.json();
+      if (!isPointerHandshakeResponse(body)) {
+        log.error("Invalid peitho pointer handshake");
+        await delay();
+        return false;
+      }
+      seq = body.seq;
+      setSession(body.session);
+      return true;
+    } catch (error) {
+      if (!closed) {
+        log.error(`Failed to start pointer polling: ${String(error)}`);
+        await delay();
+      }
+      return false;
+    }
+  };
+  const poll = async () => {
+    let needsHandshake = true;
+    while (!closed) {
+      while (!closed && needsHandshake && !await handshake()) {
+        continue;
+      }
+      if (closed) return;
+      needsHandshake = false;
+      try {
+        const response = await fetcher(`/pointer?seq=${seq}`);
+        if (closed) return;
+        if (response.status === 204) continue;
+        if (!response.ok) {
+          log.error(`Failed to poll pointer message: ${response.status}`);
+          await delay();
+          continue;
+        }
+        const body = pointerPollResponse(await response.json());
+        if (body == null) {
+          log.error("Invalid peitho pointer message");
+          await delay();
+          continue;
+        }
+        seq = body.seq;
+        const sessionChanged = setSession(body.session);
+        applyEvent(body.event, { fadeUp: !(sessionChanged && body.event.kind === "up") });
+      } catch (error) {
+        if (!closed) {
+          log.error(`Failed to poll pointer message: ${String(error)}`);
+          needsHandshake = true;
+          await delay();
+        }
+      }
+    }
+  };
+  const onNavigate = () => resetState();
+  if (ctx != null) {
+    resizeCanvas();
+    win.addEventListener("resize", resizeCanvas);
+    bus.addEventListener("peitho:navigate", onNavigate);
+    void poll();
+  }
+  return () => {
+    closed = true;
+    bus.removeEventListener("peitho:navigate", onNavigate);
+    win.removeEventListener("resize", resizeCanvas);
+    if (frame !== null) {
+      cancelFrame(frame);
+      frame = null;
+    }
+    if (retryTimer !== null) {
+      win.clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    clearCanvas();
+  };
+  function draw() {
+    if (ctx == null) return;
+    clearCanvas();
+    const opacity = fadeOpacity(state, now());
+    if (opacity <= 0) return;
+    ctx.save();
+    ctx.globalAlpha = opacity;
+    ctx.globalCompositeOperation = "multiply";
+    ctx.fillStyle = "#ff2a2a";
+    ctx.beginPath();
+    ctx.arc(
+      state.x * canvas.width,
+      state.y * canvas.height,
+      0.012 * Math.min(canvas.width, canvas.height),
+      0,
+      Math.PI * 2
+    );
+    ctx.fill();
+    ctx.restore();
+  }
+}
 var PresentShellController = class {
   manifest = null;
   currentIndex = -1;
@@ -925,6 +1117,7 @@ var PresentShellController = class {
   viewport;
   canvasCleanups = [];
   fontScopeCleanup = null;
+  pointerCleanup = null;
   startedAtValue = null;
   pausedAtValue = null;
   pausedTotalMs = 0;
@@ -990,6 +1183,7 @@ var PresentShellController = class {
         this.slides.push(view);
       }
       this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+      this.mountPointerOverlay();
     } catch (error) {
       this.clearCanvasRootProperties();
       this.root.replaceChildren();
@@ -1033,6 +1227,8 @@ var PresentShellController = class {
   }
   destroy() {
     this.endPresentation();
+    this.pointerCleanup?.();
+    this.pointerCleanup = null;
     this.fontScopeCleanup?.();
     this.fontScopeCleanup = null;
     while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
@@ -1090,6 +1286,27 @@ var PresentShellController = class {
     template.innerHTML = html;
     shadow.appendChild(template.content.cloneNode(true));
     return host;
+  }
+  mountPointerOverlay() {
+    if (this.viewport != null) return;
+    const canvas = this.doc.createElement("canvas");
+    canvas.dataset.peithoPointerOverlay = "true";
+    canvas.style.position = "absolute";
+    canvas.style.inset = "0";
+    canvas.style.zIndex = "4";
+    canvas.style.pointerEvents = "none";
+    canvas.style.mixBlendMode = "multiply";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    this.root.appendChild(canvas);
+    this.pointerCleanup = installPointerOverlay({
+      canvas,
+      fetcher: this.fetcher,
+      bus: this.bus,
+      window: this.win,
+      now: this.now,
+      console: this.log
+    });
   }
   resolveTarget(to) {
     if (to === "first") return 0;
@@ -1200,6 +1417,58 @@ var PresentShellController = class {
     );
   }
 };
+function fadeOpacity(state, nowMs) {
+  if (state.visible) return 1;
+  if (!Number.isFinite(state.lastUpAt)) return 0;
+  return Math.max(0, Math.min(1, 1 - (nowMs - state.lastUpAt) / 150));
+}
+function canvas2dContext(canvas) {
+  try {
+    return canvas.getContext("2d");
+  } catch (_error) {
+    return null;
+  }
+}
+function isPointerHandshakeResponse(value) {
+  return hasExactKeys(value, ["seq", "session"]) && typeof value.seq === "number" && Number.isFinite(value.seq) && typeof value.session === "string";
+}
+function pointerPollResponse(value) {
+  if (!hasExactKeys(value, ["seq", "event", "session"]) || typeof value.seq !== "number" || !Number.isFinite(value.seq) || typeof value.session !== "string") {
+    return null;
+  }
+  const event = pointerOverlayEvent(value.event);
+  if (event == null) return null;
+  return { seq: value.seq, event, session: value.session };
+}
+function pointerOverlayEvent(value) {
+  if (!isRecord(value)) return null;
+  if (hasExactKeys(value, ["up"])) {
+    return value.up === true ? { kind: "up" } : null;
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || !Object.hasOwn(value, "move")) {
+    return null;
+  }
+  const move = value.move;
+  if (!hasExactKeys(move, ["x", "y"])) {
+    return null;
+  }
+  if (!isUnitCoordinate(move.x) || !isUnitCoordinate(move.y)) {
+    return null;
+  }
+  return { kind: "move", x: move.x, y: move.y };
+}
+function hasExactKeys(value, keys) {
+  if (!isRecord(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+function isUnitCoordinate(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+}
 
 // src/swap.ts
 var SWAP_ROUTES = Object.freeze({
@@ -1226,35 +1495,35 @@ function installSwapShortcut(win = window, bus = win) {
 }
 
 // src/sync.ts
-function isRecord(value) {
+function isRecord2(value) {
   return typeof value === "object" && value !== null;
 }
 function isCloseSyncMessage(value) {
-  return isRecord(value) && value.close === true;
+  return isRecord2(value) && value.close === true;
 }
 function isIndexSyncMessage(value) {
-  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
+  return isRecord2(value) && typeof value.index === "number" && Number.isFinite(value.index);
 }
 function isSwappedSyncMessage(value) {
-  return isRecord(value) && typeof value.swapped === "boolean";
+  return isRecord2(value) && typeof value.swapped === "boolean";
 }
 function isSyncedSyncMessage(value) {
-  return isRecord(value) && value.synced === true;
+  return isRecord2(value) && value.synced === true;
 }
 function isSessionChangedSyncMessage(value) {
-  return isRecord(value) && value.sessionChanged === true;
+  return isRecord2(value) && value.sessionChanged === true;
 }
 function isNonNegativeFiniteNumber(value) {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 function isTimerSyncMessage(value) {
-  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
+  return isRecord2(value) && isRecord2(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs);
 }
 function isTimerReplaySyncMessage(value) {
-  return isRecord(value) && isRecord(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
+  return isRecord2(value) && isRecord2(value.timer) && typeof value.timer.running === "boolean" && isNonNegativeFiniteNumber(value.timer.elapsedMs) && isNonNegativeFiniteNumber(value.timer.atMs) && isNonNegativeFiniteNumber(value.nowMs);
 }
 function isGenerationSyncMessage(value) {
-  return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
+  return isRecord2(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
 }
 function defaultChannelFactory(name) {
   const channel = new BroadcastChannel(name);
@@ -2010,6 +2279,7 @@ export {
   installCloseOnEscape,
   installFullscreenShortcut,
   installKeyboardNavigation,
+  installPointerOverlay,
   installPresentationControls,
   installPresenterKeyboard,
   installRehearsalBridge,

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -31,7 +31,7 @@ export {
   installPresenterKeyboard
 } from "./keyboard";
 export { mountPresenterView } from "./presenter";
-export { mountPresentShell } from "./shell";
+export { installPointerOverlay, mountPresentShell } from "./shell";
 export { installSwapShortcut, swapRoute } from "./swap";
 export { installSyncBridge, serverSyncChannelFactory } from "./sync";
 export {
@@ -46,6 +46,7 @@ export type { SectionActuals, SectionActualsOptions, SectionActualsShell } from 
 export type {
   NavigateDetail,
   NavigateTarget,
+  PointerOverlayOptions,
   PresentShell,
   PresentationEndDetail,
   PresentationStartDetail,

--- a/packages/peitho-present/src/keyboard.ts
+++ b/packages/peitho-present/src/keyboard.ts
@@ -11,7 +11,9 @@ const navigationKeyMap = new Map<string, NavigateTarget>([
 
 const keyMap = new Map<string, NavigateTarget>([...navigationKeyMap, [" ", "next"]]);
 
-export function hasChordModifier(event: KeyboardEvent): boolean {
+export type ChordModifierEvent = Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "altKey">;
+
+export function hasChordModifier(event: ChordModifierEvent): boolean {
   return event.metaKey || event.ctrlKey || event.altKey;
 }
 

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -1,5 +1,6 @@
 import type { Manifest } from "../../../bindings/Manifest";
 import type { Notes } from "../../../bindings/Notes";
+import { hasChordModifier } from "./keyboard";
 import { sectionIndexForSlide } from "./sections";
 import {
   mountPresentShell as defaultMountPresentShell,
@@ -38,6 +39,9 @@ type RemoteTimerAnchor = {
 };
 
 type TimerVisualState = "stopped" | "running" | "paused";
+export type PointerMode = "off" | "pointer";
+export type PointerModeChangeDetail = { mode: PointerMode };
+export type PointerMoveDetail = { x: number; y: number };
 
 type RemoteViewState =
   | { kind: "loading" }
@@ -99,6 +103,15 @@ export type RemoteSyncBridgeOptions = {
   setSynced(): void;
   setEnded(): void;
   onSessionChange(): void;
+  console?: Pick<Console, "error">;
+};
+
+export type RemotePointerBridgeOptions = {
+  previewRoot: HTMLElement;
+  bus?: EventTarget;
+  fetcher?: typeof fetch;
+  window?: Window;
+  now?: () => number;
   console?: Pick<Console, "error">;
 };
 
@@ -207,14 +220,32 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   notesBody.dataset.peithoRemote = "notes";
   notesPanel.append(notesCaption, notesBody);
 
+  const pointerMode = createDimmableRow(doc, "div", "peitho-remote-pointer-mode");
+  pointerMode.dataset.peithoRemote = "pointer-mode";
+  pointerMode.setAttribute("role", "group");
+  pointerMode.setAttribute("aria-label", "Pointer mode");
+  const pointerOff = remotePointerModeButton(doc, "off", "Off");
+  const pointerOn = remotePointerModeButton(doc, "pointer", "Pointer");
+  pointerMode.append(pointerOff, pointerOn);
+
   const actions = doc.createElement("div");
   actions.className = "peitho-remote-actions";
   const prev = remoteButton(doc, "prev", "Previous");
   const next = remoteButton(doc, "next", "Next");
   actions.append(prev, next);
 
+  let currentPointerMode: PointerMode = "off";
+  const setPointerMode = (mode: PointerMode): void => {
+    if (mode === currentPointerMode) return;
+    currentPointerMode = mode;
+    pointerOff.setAttribute("aria-pressed", mode === "off" ? "true" : "false");
+    pointerOn.setAttribute("aria-pressed", mode === "pointer" ? "true" : "false");
+    dispatchPointerModeChange(bus, mode);
+  };
   const onPrev = (): void => dispatchNavigate(bus, "prev");
   const onNext = (): void => dispatchNavigate(bus, "next");
+  const onPointerOff = (): void => setPointerMode("off");
+  const onPointerOn = (): void => setPointerMode("pointer");
   const onTimer = (): void => {
     const action = timerButton.dataset.peithoTimerAction;
     if (action === "start" || action === "pause" || action === "resume") {
@@ -224,6 +255,8 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   const onReset = (): void => dispatchTimerControl(bus, "reset");
   prev.addEventListener("click", onPrev);
   next.addEventListener("click", onNext);
+  pointerOff.addEventListener("click", onPointerOff);
+  pointerOn.addEventListener("click", onPointerOn);
   timerButton.addEventListener("click", onTimer);
   resetButton.addEventListener("click", onReset);
 
@@ -238,6 +271,7 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
     { kind: "dimmable", element: chase },
     { kind: "dimmable", element: pace },
     { kind: "dimmable", element: notesPanel },
+    { kind: "dimmable", element: pointerMode },
     { kind: "actions", element: actions }
   ];
   container.append(...rows.map((row) => row.element));
@@ -246,6 +280,8 @@ export function installRemoteControls(options: RemoteControlsOptions): () => voi
   return () => {
     prev.removeEventListener("click", onPrev);
     next.removeEventListener("click", onNext);
+    pointerOff.removeEventListener("click", onPointerOff);
+    pointerOn.removeEventListener("click", onPointerOn);
     timerButton.removeEventListener("click", onTimer);
     resetButton.removeEventListener("click", onReset);
     container.remove();
@@ -260,6 +296,204 @@ export function createDimmableRow(
   const el = doc.createElement(tag);
   el.classList.add("peitho-remote-dim-on-end", ...classNames);
   return el as RemoteRowElement;
+}
+
+function remotePointerModeButton(
+  doc: Document,
+  mode: PointerMode,
+  label: string
+): HTMLButtonElement {
+  const button = doc.createElement("button");
+  button.type = "button";
+  button.dataset.peithoPointerMode = mode;
+  button.setAttribute("aria-pressed", mode === "off" ? "true" : "false");
+  button.textContent = label;
+  return button;
+}
+
+export function installRemotePointerBridge(options: RemotePointerBridgeOptions): () => void {
+  const win = options.window ?? window;
+  const bus = options.bus ?? win;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const log = options.console ?? console;
+  const now = options.now ?? Date.now;
+  const previewRoot = options.previewRoot;
+  let mode: PointerMode = "off";
+  let activePointerId: number | null = null;
+  let listenersInstalled = false;
+  let pendingMove: PointerMoveDetail | null = null;
+  let frame: number | null = null;
+  let previousTouchAction: string | null = null;
+
+  const requestFrame = (callback: FrameRequestCallback): number => {
+    if (typeof win.requestAnimationFrame === "function") {
+      return win.requestAnimationFrame(callback);
+    }
+    return win.setTimeout(() => callback(now()), 16);
+  };
+  const cancelFrame = (handle: number): void => {
+    if (typeof win.cancelAnimationFrame === "function") {
+      win.cancelAnimationFrame(handle);
+      return;
+    }
+    win.clearTimeout(handle);
+  };
+
+  const postPointer = (message: { move: PointerMoveDetail } | { up: true }): void => {
+    let request: Promise<Response>;
+    try {
+      request = fetcher("/pointer", {
+        method: "POST",
+        body: JSON.stringify(message),
+        keepalive: true,
+        headers: { "Content-Type": "application/json" }
+      });
+    } catch (error: unknown) {
+      log.error(`Failed to post pointer message: ${String(error)}`);
+      return;
+    }
+    void request
+      .then((response) => {
+        if (!response.ok) {
+          log.error(`Failed to post pointer message: ${response.status}`);
+        }
+      })
+      .catch((error: unknown) => {
+        log.error(`Failed to post pointer message: ${String(error)}`);
+      });
+  };
+
+  const cancelPendingMove = (): void => {
+    pendingMove = null;
+    if (frame === null) return;
+    cancelFrame(frame);
+    frame = null;
+  };
+
+  const flushMove = (): void => {
+    frame = null;
+    const move = pendingMove;
+    pendingMove = null;
+    if (mode !== "pointer" || move == null) return;
+    postPointer({ move });
+  };
+
+  const queueMove = (move: PointerMoveDetail): void => {
+    pendingMove = move;
+    if (frame !== null) return;
+    frame = requestFrame(flushMove);
+  };
+
+  const pointForEvent = (event: PointerEvent): PointerMoveDetail | null => {
+    const rect = previewRoot.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    return {
+      x: clamp01((event.clientX - rect.left) / rect.width),
+      y: clamp01((event.clientY - rect.top) / rect.height)
+    };
+  };
+
+  const onPointerDown = (event: PointerEvent): void => {
+    if (mode !== "pointer" || hasChordModifier(event) || event.button !== 0) return;
+    const point = pointForEvent(event);
+    if (point == null) return;
+    activePointerId = event.pointerId;
+    event.preventDefault();
+    dispatchPointerMove(bus, point);
+  };
+
+  const onPointerMove = (event: PointerEvent): void => {
+    if (mode !== "pointer" || activePointerId !== event.pointerId || hasChordModifier(event)) {
+      return;
+    }
+    const point = pointForEvent(event);
+    if (point == null) return;
+    event.preventDefault();
+    dispatchPointerMove(bus, point);
+  };
+
+  const onPointerEnd = (event: PointerEvent): void => {
+    if (mode !== "pointer" || activePointerId !== event.pointerId) return;
+    activePointerId = null;
+    event.preventDefault();
+    dispatchPointerUp(bus);
+  };
+
+  const installPointerListeners = (): void => {
+    if (listenersInstalled) return;
+    listenersInstalled = true;
+    previousTouchAction = previewRoot.style.touchAction;
+    previewRoot.style.touchAction = "none";
+    previewRoot.dataset.peithoPointerMode = "pointer";
+    previewRoot.addEventListener("pointerdown", onPointerDown);
+    previewRoot.addEventListener("pointermove", onPointerMove);
+    previewRoot.addEventListener("pointerup", onPointerEnd);
+    previewRoot.addEventListener("pointercancel", onPointerEnd);
+    previewRoot.addEventListener("pointerleave", onPointerEnd);
+  };
+
+  const removePointerListeners = (sendFinalUp: boolean): void => {
+    if (listenersInstalled) {
+      previewRoot.removeEventListener("pointerdown", onPointerDown);
+      previewRoot.removeEventListener("pointermove", onPointerMove);
+      previewRoot.removeEventListener("pointerup", onPointerEnd);
+      previewRoot.removeEventListener("pointercancel", onPointerEnd);
+      previewRoot.removeEventListener("pointerleave", onPointerEnd);
+      listenersInstalled = false;
+    }
+    activePointerId = null;
+    cancelPendingMove();
+    if (previousTouchAction !== null) {
+      previewRoot.style.touchAction = previousTouchAction;
+      previousTouchAction = null;
+    }
+    delete previewRoot.dataset.peithoPointerMode;
+    if (sendFinalUp) postPointer({ up: true });
+  };
+
+  const onModeChange = (event: Event): void => {
+    const next = (event as CustomEvent<PointerModeChangeDetail>).detail?.mode;
+    if (next !== "off" && next !== "pointer") {
+      log.error("Invalid peitho:pointermodechange event");
+      return;
+    }
+    if (next === mode) return;
+    mode = next;
+    if (mode === "pointer") {
+      installPointerListeners();
+    } else {
+      removePointerListeners(true);
+    }
+  };
+
+  const onPointerMoveRequest = (event: Event): void => {
+    if (mode !== "pointer") return;
+    const detail = (event as CustomEvent<PointerMoveDetail>).detail;
+    if (!isPointerMoveDetail(detail)) {
+      log.error("Invalid peitho:pointermove event");
+      return;
+    }
+    queueMove(detail);
+  };
+
+  const onPointerUpRequest = (): void => {
+    if (mode !== "pointer") return;
+    activePointerId = null;
+    cancelPendingMove();
+    postPointer({ up: true });
+  };
+
+  bus.addEventListener("peitho:pointermodechange", onModeChange);
+  bus.addEventListener("peitho:pointermove", onPointerMoveRequest);
+  bus.addEventListener("peitho:pointerup", onPointerUpRequest);
+
+  return () => {
+    bus.removeEventListener("peitho:pointermodechange", onModeChange);
+    bus.removeEventListener("peitho:pointermove", onPointerMoveRequest);
+    bus.removeEventListener("peitho:pointerup", onPointerUpRequest);
+    removePointerListeners(mode === "pointer");
+    mode = "off";
+  };
 }
 
 export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () => void {
@@ -365,6 +599,7 @@ class RemoteController implements RemoteView {
   private timerState: RemoteTimerAnchor | null = null;
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
+  private pointerCleanup: (() => void) | null = null;
   private previewShell: PresentShell | null = null;
   private timerInterval: number | null = null;
 
@@ -411,6 +646,14 @@ class RemoteController implements RemoteView {
           now: this.now,
           viewport: paneViewport(previewRoot)
         });
+        this.pointerCleanup = installRemotePointerBridge({
+          bus: this.bus,
+          previewRoot,
+          fetcher: this.fetcher,
+          window: this.win,
+          now: this.now,
+          console: this.log
+        });
       }
       this.render();
       this.syncCleanup = installRemoteSyncBridge({
@@ -434,6 +677,8 @@ class RemoteController implements RemoteView {
 
   destroy(): void {
     this.clearTimerInterval();
+    this.pointerCleanup?.();
+    this.pointerCleanup = null;
     this.syncCleanup?.();
     this.syncCleanup = null;
     this.previewShell?.destroy();
@@ -728,6 +973,30 @@ function dispatchNavigate(bus: EventTarget, to: "prev" | "next"): void {
 
 function dispatchTimerControl(bus: EventTarget, action: TimerControlDetail["action"]): void {
   bus.dispatchEvent(new CustomEvent<TimerControlDetail>("peitho:timercontrol", { detail: { action } }));
+}
+
+function dispatchPointerModeChange(bus: EventTarget, mode: PointerMode): void {
+  bus.dispatchEvent(
+    new CustomEvent<PointerModeChangeDetail>("peitho:pointermodechange", { detail: { mode } })
+  );
+}
+
+function dispatchPointerMove(bus: EventTarget, detail: PointerMoveDetail): void {
+  bus.dispatchEvent(new CustomEvent<PointerMoveDetail>("peitho:pointermove", { detail }));
+}
+
+function dispatchPointerUp(bus: EventTarget): void {
+  bus.dispatchEvent(new CustomEvent("peitho:pointerup"));
+}
+
+function isPointerMoveDetail(value: unknown): value is PointerMoveDetail {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<PointerMoveDetail>;
+  return isUnitCoordinate(candidate.x) && isUnitCoordinate(candidate.y);
+}
+
+function isUnitCoordinate(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
 }
 
 function resolveRemoteTarget(

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -275,18 +275,19 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
     clearCanvas();
     const opacity = fadeOpacity(state, now());
     if (opacity <= 0) return;
+    const x = state.x * canvas.width;
+    const y = state.y * canvas.height;
+    const radius = 0.012 * Math.min(canvas.width, canvas.height);
+    const ringRadius = radius + 2;
     ctx.save();
     ctx.globalAlpha = opacity;
-    ctx.globalCompositeOperation = "multiply";
+    ctx.fillStyle = "#ffffff";
+    ctx.beginPath();
+    ctx.arc(x, y, ringRadius, 0, Math.PI * 2);
+    ctx.fill();
     ctx.fillStyle = "#ff2a2a";
     ctx.beginPath();
-    ctx.arc(
-      state.x * canvas.width,
-      state.y * canvas.height,
-      0.012 * Math.min(canvas.width, canvas.height),
-      0,
-      Math.PI * 2
-    );
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
   }
@@ -505,7 +506,6 @@ class PresentShellController implements PresentShell {
     canvas.style.inset = "0";
     canvas.style.zIndex = "4";
     canvas.style.pointerEvents = "none";
-    canvas.style.mixBlendMode = "multiply";
     canvas.style.width = "100%";
     canvas.style.height = "100%";
     this.root.appendChild(canvas);

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -50,10 +50,28 @@ export type ShellOptions = {
   viewport?: () => CanvasViewport;
 };
 
+export type PointerOverlayOptions = {
+  canvas: HTMLCanvasElement;
+  fetcher?: typeof fetch;
+  bus?: EventTarget;
+  window?: Window;
+  now?: () => number;
+  console?: Pick<Console, "error">;
+};
+
 type CanvasDimensions = {
   width: number;
   height: number;
 };
+
+type PointerOverlayState = {
+  x: number;
+  y: number;
+  visible: boolean;
+  lastUpAt: number;
+};
+
+type PointerOverlayEvent = { kind: "move"; x: number; y: number } | { kind: "up" };
 
 export type SlideView = {
   meta: ManifestSlide;
@@ -64,6 +82,214 @@ export async function mountPresentShell(options: ShellOptions): Promise<PresentS
   const shell = new PresentShellController(options);
   await shell.load();
   return shell;
+}
+
+export function installPointerOverlay(options: PointerOverlayOptions): () => void {
+  const win = options.window ?? window;
+  const bus = options.bus ?? win;
+  const fetcher = options.fetcher ?? fetch.bind(globalThis);
+  const now = options.now ?? Date.now;
+  const log = options.console ?? console;
+  const canvas = options.canvas;
+  const ctx = canvas2dContext(canvas);
+  const state: PointerOverlayState = { x: 0, y: 0, visible: false, lastUpAt: -Infinity };
+  let closed = false;
+  let seq = 0;
+  let session: string | null = null;
+  let frame: number | null = null;
+  let retryTimer: number | null = null;
+
+  const requestFrame = (callback: FrameRequestCallback): number => {
+    if (typeof win.requestAnimationFrame === "function") {
+      return win.requestAnimationFrame(callback);
+    }
+    return win.setTimeout(() => callback(now()), 16);
+  };
+  const cancelFrame = (handle: number): void => {
+    if (typeof win.cancelAnimationFrame === "function") {
+      win.cancelAnimationFrame(handle);
+      return;
+    }
+    win.clearTimeout(handle);
+  };
+
+  const resizeCanvas = (): void => {
+    const rect = canvas.getBoundingClientRect();
+    const fallbackWidth = win.innerWidth || 1;
+    const fallbackHeight = win.innerHeight || 1;
+    const cssWidth = rect.width > 0 ? rect.width : fallbackWidth;
+    const cssHeight = rect.height > 0 ? rect.height : fallbackHeight;
+    const scale = win.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.round(cssWidth * scale));
+    canvas.height = Math.max(1, Math.round(cssHeight * scale));
+    draw();
+  };
+
+  const clearCanvas = (): void => {
+    if (ctx == null) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  };
+
+  const requestDraw = (): void => {
+    if (frame !== null) return;
+    frame = requestFrame(() => {
+      frame = null;
+      draw();
+      if (!closed && fadeOpacity(state, now()) > 0) {
+        requestDraw();
+      }
+    });
+  };
+
+  const resetState = (): void => {
+    state.visible = false;
+    state.lastUpAt = -Infinity;
+    clearCanvas();
+  };
+
+  const setSession = (nextSession: string): boolean => {
+    if (session !== null && session !== nextSession) {
+      resetState();
+      session = nextSession;
+      return true;
+    }
+    session = nextSession;
+    return false;
+  };
+
+  const applyEvent = (event: PointerOverlayEvent, options: { fadeUp?: boolean } = {}): void => {
+    if (event.kind === "move") {
+      state.x = event.x;
+      state.y = event.y;
+      state.visible = true;
+      state.lastUpAt = -Infinity;
+      requestDraw();
+      return;
+    }
+    if (options.fadeUp === false) {
+      resetState();
+      return;
+    }
+    state.visible = false;
+    state.lastUpAt = now();
+    requestDraw();
+  };
+
+  const delay = (): Promise<void> =>
+    new Promise((resolve) => {
+      retryTimer = win.setTimeout(() => {
+        retryTimer = null;
+        resolve();
+      }, 1000);
+    });
+
+  const handshake = async (): Promise<boolean> => {
+    try {
+      const response = await fetcher("/pointer");
+      if (closed) return false;
+      if (!response.ok) {
+        log.error(`Failed to start pointer polling: ${response.status}`);
+        await delay();
+        return false;
+      }
+      const body = (await response.json()) as unknown;
+      if (!isPointerHandshakeResponse(body)) {
+        log.error("Invalid peitho pointer handshake");
+        await delay();
+        return false;
+      }
+      seq = body.seq;
+      setSession(body.session);
+      return true;
+    } catch (error: unknown) {
+      if (!closed) {
+        log.error(`Failed to start pointer polling: ${String(error)}`);
+        await delay();
+      }
+      return false;
+    }
+  };
+
+  const poll = async (): Promise<void> => {
+    let needsHandshake = true;
+    while (!closed) {
+      while (!closed && needsHandshake && !(await handshake())) {
+        continue;
+      }
+      if (closed) return;
+      needsHandshake = false;
+      try {
+        const response = await fetcher(`/pointer?seq=${seq}`);
+        if (closed) return;
+        if (response.status === 204) continue;
+        if (!response.ok) {
+          log.error(`Failed to poll pointer message: ${response.status}`);
+          await delay();
+          continue;
+        }
+        const body = pointerPollResponse((await response.json()) as unknown);
+        if (body == null) {
+          log.error("Invalid peitho pointer message");
+          await delay();
+          continue;
+        }
+        seq = body.seq;
+        const sessionChanged = setSession(body.session);
+        applyEvent(body.event, { fadeUp: !(sessionChanged && body.event.kind === "up") });
+      } catch (error: unknown) {
+        if (!closed) {
+          log.error(`Failed to poll pointer message: ${String(error)}`);
+          needsHandshake = true;
+          await delay();
+        }
+      }
+    }
+  };
+
+  const onNavigate = (): void => resetState();
+
+  if (ctx != null) {
+    resizeCanvas();
+    win.addEventListener("resize", resizeCanvas);
+    bus.addEventListener("peitho:navigate", onNavigate);
+    void poll();
+  }
+
+  return () => {
+    closed = true;
+    bus.removeEventListener("peitho:navigate", onNavigate);
+    win.removeEventListener("resize", resizeCanvas);
+    if (frame !== null) {
+      cancelFrame(frame);
+      frame = null;
+    }
+    if (retryTimer !== null) {
+      win.clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+    clearCanvas();
+  };
+
+  function draw(): void {
+    if (ctx == null) return;
+    clearCanvas();
+    const opacity = fadeOpacity(state, now());
+    if (opacity <= 0) return;
+    ctx.save();
+    ctx.globalAlpha = opacity;
+    ctx.globalCompositeOperation = "multiply";
+    ctx.fillStyle = "#ff2a2a";
+    ctx.beginPath();
+    ctx.arc(
+      state.x * canvas.width,
+      state.y * canvas.height,
+      0.012 * Math.min(canvas.width, canvas.height),
+      0,
+      Math.PI * 2
+    );
+    ctx.fill();
+    ctx.restore();
+  }
 }
 
 class PresentShellController implements PresentShell {
@@ -81,6 +307,7 @@ class PresentShellController implements PresentShell {
   private readonly viewport?: () => CanvasViewport;
   private readonly canvasCleanups: Array<() => void> = [];
   private fontScopeCleanup: (() => void) | null = null;
+  private pointerCleanup: (() => void) | null = null;
   private startedAtValue: number | null = null;
   private pausedAtValue: number | null = null;
   private pausedTotalMs = 0;
@@ -148,6 +375,7 @@ class PresentShellController implements PresentShell {
         this.slides.push(view);
       }
       this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+      this.mountPointerOverlay();
     } catch (error) {
       this.clearCanvasRootProperties();
       this.root.replaceChildren();
@@ -197,6 +425,8 @@ class PresentShellController implements PresentShell {
 
   destroy(): void {
     this.endPresentation();
+    this.pointerCleanup?.();
+    this.pointerCleanup = null;
     this.fontScopeCleanup?.();
     this.fontScopeCleanup = null;
     while (this.canvasCleanups.length > 0) this.canvasCleanups.pop()?.();
@@ -265,6 +495,28 @@ class PresentShellController implements PresentShell {
     template.innerHTML = html;
     shadow.appendChild(template.content.cloneNode(true));
     return host;
+  }
+
+  private mountPointerOverlay(): void {
+    if (this.viewport != null) return;
+    const canvas = this.doc.createElement("canvas");
+    canvas.dataset.peithoPointerOverlay = "true";
+    canvas.style.position = "absolute";
+    canvas.style.inset = "0";
+    canvas.style.zIndex = "4";
+    canvas.style.pointerEvents = "none";
+    canvas.style.mixBlendMode = "multiply";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    this.root.appendChild(canvas);
+    this.pointerCleanup = installPointerOverlay({
+      canvas,
+      fetcher: this.fetcher,
+      bus: this.bus,
+      window: this.win,
+      now: this.now,
+      console: this.log
+    });
   }
 
   private resolveTarget(to: NavigateTarget): number | null {
@@ -389,4 +641,79 @@ class PresentShellController implements PresentShell {
       })
     );
   }
+}
+
+function fadeOpacity(state: PointerOverlayState, nowMs: number): number {
+  if (state.visible) return 1;
+  if (!Number.isFinite(state.lastUpAt)) return 0;
+  return Math.max(0, Math.min(1, 1 - (nowMs - state.lastUpAt) / 150));
+}
+
+function canvas2dContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null {
+  try {
+    return canvas.getContext("2d");
+  } catch (_error: unknown) {
+    return null;
+  }
+}
+
+function isPointerHandshakeResponse(value: unknown): value is { seq: number; session: string } {
+  return (
+    hasExactKeys(value, ["seq", "session"]) &&
+    typeof value.seq === "number" &&
+    Number.isFinite(value.seq) &&
+    typeof value.session === "string"
+  );
+}
+
+function pointerPollResponse(
+  value: unknown
+): { seq: number; event: PointerOverlayEvent; session: string } | null {
+  if (
+    !hasExactKeys(value, ["seq", "event", "session"]) ||
+    typeof value.seq !== "number" ||
+    !Number.isFinite(value.seq) ||
+    typeof value.session !== "string"
+  ) {
+    return null;
+  }
+  const event = pointerOverlayEvent(value.event);
+  if (event == null) return null;
+  return { seq: value.seq, event, session: value.session };
+}
+
+function pointerOverlayEvent(value: unknown): PointerOverlayEvent | null {
+  if (!isRecord(value)) return null;
+  if (hasExactKeys(value, ["up"])) {
+    return value.up === true ? { kind: "up" } : null;
+  }
+  const keys = Object.keys(value);
+  if (keys.length !== 1 || !Object.hasOwn(value, "move")) {
+    return null;
+  }
+  const move = (value as { move?: unknown }).move;
+  if (!hasExactKeys(move, ["x", "y"])) {
+    return null;
+  }
+  if (!isUnitCoordinate(move.x) || !isUnitCoordinate(move.y)) {
+    return null;
+  }
+  return { kind: "move", x: move.x, y: move.y };
+}
+
+function hasExactKeys<T extends string>(
+  value: unknown,
+  keys: readonly T[]
+): value is Record<T, unknown> {
+  if (!isRecord(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isUnitCoordinate(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
 }

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -52,6 +52,7 @@ export type ShellOptions = {
 
 export type PointerOverlayOptions = {
   canvas: HTMLCanvasElement;
+  pointerColor?: string | null;
   fetcher?: typeof fetch;
   bus?: EventTarget;
   window?: Window;
@@ -68,10 +69,184 @@ type PointerOverlayState = {
   x: number;
   y: number;
   visible: boolean;
-  lastUpAt: number;
 };
 
 type PointerOverlayEvent = { kind: "move"; x: number; y: number } | { kind: "up" };
+
+type PointerTrailPoint = {
+  x: number;
+  y: number;
+  timestamp: number;
+};
+
+type PointerPalette = {
+  baseColor: string;
+  coreColor: string;
+  transparentBase: string;
+};
+
+type RgbColor = {
+  r: number;
+  g: number;
+  b: number;
+};
+
+const DEFAULT_POINTER_BASE_COLOR = "#38bdf8";
+const DEFAULT_POINTER_CORE_COLOR = "#e0f2fe";
+const POINTER_TRAIL_DURATION_MS = 500;
+const POINTER_TRAIL_CAP = 64;
+const POINTER_CORE_MIX_TO_WHITE = 0.65;
+
+const CSS_NAMED_COLORS: Record<string, string> = {
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
+  black: "#000000",
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  blueviolet: "#8a2be2",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkgrey: "#a9a9a9",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkslategrey: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#adff2f",
+  grey: "#808080",
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightgrey: "#d3d3d3",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
+  red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: "#ffffff",
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32"
+};
 
 export type SlideView = {
   meta: ManifestSlide;
@@ -92,7 +267,9 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
   const log = options.console ?? console;
   const canvas = options.canvas;
   const ctx = canvas2dContext(canvas);
-  const state: PointerOverlayState = { x: 0, y: 0, visible: false, lastUpAt: -Infinity };
+  const palette = pointerPalette(options.pointerColor);
+  const state: PointerOverlayState = { x: 0, y: 0, visible: false };
+  const trail: PointerTrailPoint[] = [];
   let closed = false;
   let seq = 0;
   let session: string | null = null;
@@ -135,7 +312,7 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
     frame = requestFrame(() => {
       frame = null;
       draw();
-      if (!closed && fadeOpacity(state, now()) > 0) {
+      if (!closed && (state.visible || trail.length > 0)) {
         requestDraw();
       }
     });
@@ -143,7 +320,7 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
 
   const resetState = (): void => {
     state.visible = false;
-    state.lastUpAt = -Infinity;
+    trail.length = 0;
     clearCanvas();
   };
 
@@ -162,7 +339,7 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
       state.x = event.x;
       state.y = event.y;
       state.visible = true;
-      state.lastUpAt = -Infinity;
+      pushTrailPoint({ x: event.x, y: event.y, timestamp: now() });
       requestDraw();
       return;
     }
@@ -171,7 +348,6 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
       return;
     }
     state.visible = false;
-    state.lastUpAt = now();
     requestDraw();
   };
 
@@ -272,24 +448,56 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
 
   function draw(): void {
     if (ctx == null) return;
+    const context = ctx;
     clearCanvas();
-    const opacity = fadeOpacity(state, now());
-    if (opacity <= 0) return;
-    const x = state.x * canvas.width;
-    const y = state.y * canvas.height;
+    const nowMs = now();
     const radius = 0.012 * Math.min(canvas.width, canvas.height);
-    const ringRadius = radius + 2;
-    ctx.save();
-    ctx.globalAlpha = opacity;
-    ctx.fillStyle = "#ffffff";
-    ctx.beginPath();
-    ctx.arc(x, y, ringRadius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.fillStyle = "#ff2a2a";
-    ctx.beginPath();
-    ctx.arc(x, y, radius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.restore();
+    pruneTrail(nowMs);
+    const headIndex = state.visible ? trail.length - 1 : -1;
+    for (let index = trail.length - 1; index >= 0; index -= 1) {
+      if (index === headIndex) continue;
+      const point = trail[index];
+      const alpha = trailOpacity(point, nowMs);
+      if (alpha <= 0) continue;
+      drawPointerPoint(context, point, alpha, radius * (0.6 + 0.4 * alpha));
+    }
+    if (state.visible) {
+      drawPointerPoint(context, { x: state.x, y: state.y, timestamp: nowMs }, 1, radius);
+    }
+  }
+
+  function pushTrailPoint(point: PointerTrailPoint): void {
+    trail.push(point);
+    if (trail.length > POINTER_TRAIL_CAP) {
+      trail.splice(0, trail.length - POINTER_TRAIL_CAP);
+    }
+  }
+
+  function pruneTrail(nowMs: number): void {
+    while (trail.length > 0 && trailOpacity(trail[0], nowMs) <= 0) {
+      trail.shift();
+    }
+  }
+
+  function drawPointerPoint(
+    context: CanvasRenderingContext2D,
+    point: PointerTrailPoint,
+    alpha: number,
+    radius: number
+  ): void {
+    const x = point.x * canvas.width;
+    const y = point.y * canvas.height;
+    const gradient = context.createRadialGradient(x, y, 0, x, y, radius);
+    gradient.addColorStop(0, palette.coreColor);
+    gradient.addColorStop(0.25, palette.baseColor);
+    gradient.addColorStop(1, palette.transparentBase);
+    context.save();
+    context.globalAlpha = alpha;
+    context.fillStyle = gradient;
+    context.beginPath();
+    context.arc(x, y, radius, 0, Math.PI * 2);
+    context.fill();
+    context.restore();
   }
 }
 
@@ -515,7 +723,8 @@ class PresentShellController implements PresentShell {
       bus: this.bus,
       window: this.win,
       now: this.now,
-      console: this.log
+      console: this.log,
+      pointerColor: this.manifest?.pointerColor ?? null
     });
   }
 
@@ -643,10 +852,70 @@ class PresentShellController implements PresentShell {
   }
 }
 
-function fadeOpacity(state: PointerOverlayState, nowMs: number): number {
-  if (state.visible) return 1;
-  if (!Number.isFinite(state.lastUpAt)) return 0;
-  return Math.max(0, Math.min(1, 1 - (nowMs - state.lastUpAt) / 150));
+function trailOpacity(point: PointerTrailPoint, nowMs: number): number {
+  return Math.max(0, Math.min(1, 1 - (nowMs - point.timestamp) / POINTER_TRAIL_DURATION_MS));
+}
+
+function pointerPalette(pointerColor: string | null | undefined): PointerPalette {
+  const requestedColor = pointerColor?.trim() || DEFAULT_POINTER_BASE_COLOR;
+  const parsed = parsePointerColor(requestedColor);
+  const baseColor = parsed == null ? DEFAULT_POINTER_BASE_COLOR : requestedColor;
+  const rgb = parsed ?? parsePointerColor(DEFAULT_POINTER_BASE_COLOR)!;
+  const coreColor =
+    baseColor.toLowerCase() === DEFAULT_POINTER_BASE_COLOR
+      ? DEFAULT_POINTER_CORE_COLOR
+      : mixToWhite(baseColor, POINTER_CORE_MIX_TO_WHITE);
+  return {
+    baseColor,
+    coreColor,
+    transparentBase: transparentRgb(rgb)
+  };
+}
+
+export function mixToWhite(color: string, amount: number): string {
+  const rgb = parsePointerColor(color);
+  if (rgb == null) {
+    throw new Error(`Unsupported pointer color: ${color}`);
+  }
+  const mix = Math.max(0, Math.min(1, amount));
+  return rgbToHex({
+    r: Math.round(rgb.r * (1 - mix) + 255 * mix),
+    g: Math.round(rgb.g * (1 - mix) + 255 * mix),
+    b: Math.round(rgb.b * (1 - mix) + 255 * mix)
+  });
+}
+
+function transparentRgb(color: RgbColor): string {
+  return `rgba(${color.r}, ${color.g}, ${color.b}, 0)`;
+}
+
+function rgbToHex(color: RgbColor): string {
+  const channel = (value: number): string => value.toString(16).padStart(2, "0");
+  return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
+}
+
+function parsePointerColor(color: string): RgbColor | null {
+  const value = color.trim().toLowerCase();
+  const hex = value.startsWith("#") ? value : CSS_NAMED_COLORS[value];
+  if (hex == null) return null;
+  return parseHexPointerColor(hex);
+}
+
+function parseHexPointerColor(color: string): RgbColor | null {
+  const hex = color.slice(1);
+  if (![3, 4, 6, 8].includes(hex.length) || !/^[0-9a-f]+$/i.test(hex)) return null;
+  if (hex.length === 3 || hex.length === 4) {
+    return {
+      r: Number.parseInt(`${hex[0]}${hex[0]}`, 16),
+      g: Number.parseInt(`${hex[1]}${hex[1]}`, 16),
+      b: Number.parseInt(`${hex[2]}${hex[2]}`, 16)
+    };
+  }
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16)
+  };
 }
 
 function canvas2dContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null {

--- a/packages/peitho-present/test/generated.test.ts
+++ b/packages/peitho-present/test/generated.test.ts
@@ -8,6 +8,7 @@ import {
   installCanvasScaler,
   installCloseOnEscape,
   installFullscreenShortcut,
+  installPointerOverlay,
   installPresentationControls,
   mountPresenterView,
   mountPresentShell,
@@ -114,6 +115,7 @@ describe("generated manifest contract", () => {
     expect(typeof installCanvasClickNavigation).toBe("function");
     expect(typeof installCloseOnEscape).toBe("function");
     expect(typeof installFullscreenShortcut).toBe("function");
+    expect(typeof installPointerOverlay).toBe("function");
     expect(typeof mountPresentShell).toBe("function");
     expect(typeof mountPresenterView).toBe("function");
   });

--- a/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
+++ b/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { installKeyboardNavigation, installPresenterKeyboard, mountPresentShell } from "../src/index";
 import type { PresentShell } from "../src/index";
 
@@ -50,6 +50,12 @@ const fontCssText = `
 const mountedShells: PresentShell[] = [];
 const windowListenerCleanups: Array<() => void> = [];
 
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    (() => null) as HTMLCanvasElement["getContext"]
+  );
+});
+
 afterEach(() => {
   while (mountedShells.length > 0) {
     mountedShells.pop()?.destroy();
@@ -60,6 +66,7 @@ afterEach(() => {
   document.documentElement.style.removeProperty("--peitho-canvas-width");
   document.documentElement.style.removeProperty("--peitho-canvas-height");
   document.documentElement.style.removeProperty("--peitho-canvas-aspect");
+  vi.restoreAllMocks();
 });
 
 async function mountForTest(options: Parameters<typeof mountPresentShell>[0]): Promise<PresentShell> {

--- a/packages/peitho-present/test/pointerOverlay.test.ts
+++ b/packages/peitho-present/test/pointerOverlay.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { installPointerOverlay } from "../src/shell";
+
+type DeferredPoll = {
+  url: string;
+  resolve(response: Response): void;
+};
+
+type MockCanvasContext = CanvasRenderingContext2D & {
+  clearRect: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  restore: ReturnType<typeof vi.fn>;
+  beginPath: ReturnType<typeof vi.fn>;
+  arc: ReturnType<typeof vi.fn>;
+  fill: ReturnType<typeof vi.fn>;
+};
+
+const cleanups: Array<() => void> = [];
+
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    (() => null) as HTMLCanvasElement["getContext"]
+  );
+});
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+function okJson(value: unknown): Response {
+  return { ok: true, status: 200, json: async () => value } as Response;
+}
+
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function installFrameMock(): FrameRequestCallback[] {
+  const frames: FrameRequestCallback[] = [];
+  const originalRequest = window.requestAnimationFrame;
+  const originalCancel = window.cancelAnimationFrame;
+  window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
+    frames.push(callback);
+    return frames.length;
+  });
+  window.cancelAnimationFrame = vi.fn();
+  cleanups.push(() => {
+    window.requestAnimationFrame = originalRequest;
+    window.cancelAnimationFrame = originalCancel;
+  });
+  return frames;
+}
+
+function canvasFixture(): {
+  canvas: HTMLCanvasElement;
+  context: MockCanvasContext;
+  alphas: number[];
+} {
+  const canvas = document.createElement("canvas");
+  const alphas: number[] = [];
+  const context = {
+    globalAlpha: 1,
+    globalCompositeOperation: "source-over",
+    fillStyle: "",
+    clearRect: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(() => {
+      alphas.push(context.globalAlpha);
+    })
+  } as unknown as MockCanvasContext;
+  vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    top: 0,
+    right: 200,
+    bottom: 100,
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    toJSON: () => ({})
+  });
+  vi.spyOn(canvas, "getContext").mockReturnValue(context);
+  document.body.append(canvas);
+  return { canvas, context, alphas };
+}
+
+function pointerFetch(): { fetcher: typeof fetch; polls: DeferredPoll[] } {
+  const polls: DeferredPoll[] = [];
+  const fetcher = vi.fn((url: string) => {
+    if (url === "/pointer") {
+      return Promise.resolve(okJson({ seq: 0, session: "session-a" }));
+    }
+    return new Promise<Response>((resolve) => {
+      polls.push({ url, resolve });
+    });
+  }) as typeof fetch;
+  return { fetcher, polls };
+}
+
+async function setupOverlay(now: () => number = () => 0): Promise<{
+  bus: EventTarget;
+  frames: FrameRequestCallback[];
+  polls: DeferredPoll[];
+  context: MockCanvasContext;
+  alphas: number[];
+}> {
+  const frames = installFrameMock();
+  const { canvas, context, alphas } = canvasFixture();
+  const { fetcher, polls } = pointerFetch();
+  const bus = new EventTarget();
+  cleanups.push(installPointerOverlay({ canvas, fetcher, bus, window, now }));
+  await flushPromises();
+  expect(polls[0]?.url).toBe("/pointer?seq=0");
+  return { bus, frames, polls, context, alphas };
+}
+
+it("pointer overlay renders a dot on move messages", async () => {
+  const { frames, polls, context } = await setupOverlay();
+
+  polls.shift()?.resolve(
+    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
+  );
+  await flushPromises();
+  frames.shift()?.(0);
+
+  expect(context.arc).toHaveBeenCalledWith(50, 50, 1.2, 0, Math.PI * 2);
+  expect(context.globalCompositeOperation).toBe("multiply");
+  expect(context.fillStyle).toBe("#ff2a2a");
+});
+
+it("pointer overlay fades after up messages", async () => {
+  let now = 0;
+  const { frames, polls, alphas } = await setupOverlay(() => now);
+
+  polls.shift()?.resolve(
+    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
+  );
+  await flushPromises();
+  frames.shift()?.(0);
+  alphas.length = 0;
+
+  now = 1000;
+  polls.shift()?.resolve(okJson({ seq: 2, event: { up: true }, session: "session-a" }));
+  await flushPromises();
+  frames.shift()?.(1000);
+  now = 1075;
+  frames.shift()?.(1075);
+
+  expect(alphas[0]).toBe(1);
+  expect(alphas[1]).toBeCloseTo(0.5);
+});
+
+it("pointer overlay clears immediately on navigation", async () => {
+  const { bus, frames, polls, context } = await setupOverlay();
+  polls.shift()?.resolve(
+    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
+  );
+  await flushPromises();
+  frames.shift()?.(0);
+  context.clearRect.mockClear();
+
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+
+  expect(context.clearRect).toHaveBeenCalledWith(0, 0, 200, 100);
+});
+
+it("pointer overlay resets state on a different session id", async () => {
+  const { frames, polls, context } = await setupOverlay();
+  polls.shift()?.resolve(
+    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
+  );
+  await flushPromises();
+  frames.shift()?.(0);
+  context.arc.mockClear();
+  context.clearRect.mockClear();
+
+  polls.shift()?.resolve(okJson({ seq: 2, event: { up: true }, session: "session-b" }));
+  await flushPromises();
+  while (frames.length > 0) {
+    frames.shift()?.(0);
+  }
+
+  expect(context.clearRect).toHaveBeenCalled();
+  expect(context.arc).not.toHaveBeenCalled();
+});

--- a/packages/peitho-present/test/pointerOverlay.test.ts
+++ b/packages/peitho-present/test/pointerOverlay.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { installPointerOverlay } from "../src/shell";
+import { installPointerOverlay, mixToWhite } from "../src/shell";
 
 type DeferredPoll = {
   url: string;
@@ -13,6 +13,12 @@ type MockCanvasContext = CanvasRenderingContext2D & {
   beginPath: ReturnType<typeof vi.fn>;
   arc: ReturnType<typeof vi.fn>;
   fill: ReturnType<typeof vi.fn>;
+  createRadialGradient: ReturnType<typeof vi.fn>;
+};
+
+type MockCanvasGradient = CanvasGradient & {
+  stops: Array<[number, string]>;
+  addColorStop: ReturnType<typeof vi.fn>;
 };
 
 const cleanups: Array<() => void> = [];
@@ -59,11 +65,11 @@ function canvasFixture(): {
   canvas: HTMLCanvasElement;
   context: MockCanvasContext;
   alphas: number[];
-  fillStyles: string[];
+  gradients: MockCanvasGradient[];
 } {
   const canvas = document.createElement("canvas");
   const alphas: number[] = [];
-  const fillStyles: string[] = [];
+  const gradients: MockCanvasGradient[] = [];
   const context = {
     globalAlpha: 1,
     globalCompositeOperation: "source-over",
@@ -73,9 +79,19 @@ function canvasFixture(): {
     restore: vi.fn(),
     beginPath: vi.fn(),
     arc: vi.fn(),
+    createRadialGradient: vi.fn(() => {
+      const gradient = {
+        stops: [],
+        addColorStop: vi.fn()
+      } as unknown as MockCanvasGradient;
+      gradient.addColorStop.mockImplementation((offset: number, color: string) => {
+        gradient.stops.push([offset, color]);
+      });
+      gradients.push(gradient);
+      return gradient;
+    }),
     fill: vi.fn(() => {
       alphas.push(context.globalAlpha);
-      fillStyles.push(String(context.fillStyle));
     })
   } as unknown as MockCanvasContext;
   vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
@@ -91,7 +107,7 @@ function canvasFixture(): {
   });
   vi.spyOn(canvas, "getContext").mockReturnValue(context);
   document.body.append(canvas);
-  return { canvas, context, alphas, fillStyles };
+  return { canvas, context, alphas, gradients };
 }
 
 function pointerFetch(): { fetcher: typeof fetch; polls: DeferredPoll[] } {
@@ -107,84 +123,127 @@ function pointerFetch(): { fetcher: typeof fetch; polls: DeferredPoll[] } {
   return { fetcher, polls };
 }
 
-async function setupOverlay(now: () => number = () => 0): Promise<{
+async function setupOverlay(
+  now: () => number = () => 0,
+  pointerColor?: string | null
+): Promise<{
   bus: EventTarget;
   frames: FrameRequestCallback[];
   polls: DeferredPoll[];
   context: MockCanvasContext;
   alphas: number[];
-  fillStyles: string[];
+  gradients: MockCanvasGradient[];
 }> {
   const frames = installFrameMock();
-  const { canvas, context, alphas, fillStyles } = canvasFixture();
+  const { canvas, context, alphas, gradients } = canvasFixture();
   const { fetcher, polls } = pointerFetch();
   const bus = new EventTarget();
-  cleanups.push(installPointerOverlay({ canvas, fetcher, bus, window, now }));
+  cleanups.push(installPointerOverlay({ canvas, fetcher, bus, window, now, pointerColor }));
   await flushPromises();
   expect(polls[0]?.url).toBe("/pointer?seq=0");
-  return { bus, frames, polls, context, alphas, fillStyles };
+  return { bus, frames, polls, context, alphas, gradients };
 }
 
-it("pointer overlay renders a dot on move messages", async () => {
-  const { frames, polls, context, fillStyles } = await setupOverlay();
+function resolveMove(
+  polls: DeferredPoll[],
+  seq: number,
+  x: number,
+  y: number,
+  session = "session-a"
+): void {
+  polls.shift()?.resolve(okJson({ seq, event: { move: { x, y } }, session }));
+}
 
-  polls.shift()?.resolve(
-    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
-  );
+it("pointer overlay renders the default cyan gradient when no pointer color is present", async () => {
+  const { frames, polls, context, gradients } = await setupOverlay();
+
+  resolveMove(polls, 1, 0.25, 0.5);
   await flushPromises();
   frames.shift()?.(0);
 
-  expect(context.arc).toHaveBeenNthCalledWith(1, 50, 50, 3.2, 0, Math.PI * 2);
-  expect(context.arc).toHaveBeenNthCalledWith(2, 50, 50, 1.2, 0, Math.PI * 2);
+  expect(context.createRadialGradient).toHaveBeenCalledWith(50, 50, 0, 50, 50, 1.2);
+  expect(context.arc).toHaveBeenCalledWith(50, 50, 1.2, 0, Math.PI * 2);
   expect(context.globalCompositeOperation).toBe("source-over");
-  expect(fillStyles).toEqual(["#ffffff", "#ff2a2a"]);
+  expect(gradients[0]?.stops).toEqual([
+    [0, "#e0f2fe"],
+    [0.25, "#38bdf8"],
+    [1, "rgba(56, 189, 248, 0)"]
+  ]);
 });
 
-it("pointer overlay fades after up messages", async () => {
+it("pointer overlay uses the manifest pointer color when present", async () => {
+  const { frames, polls, gradients } = await setupOverlay(() => 0, "#ff2a2a");
+
+  resolveMove(polls, 1, 0.25, 0.5);
+  await flushPromises();
+  frames.shift()?.(0);
+
+  expect(gradients[0]?.stops).toEqual([
+    [0, "#ffb4b4"],
+    [0.25, "#ff2a2a"],
+    [1, "rgba(255, 42, 42, 0)"]
+  ]);
+});
+
+it("mixToWhite mixes supported pointer colors in sRGB", () => {
+  expect(mixToWhite("#ff2a2a", 0.65)).toBe("#ffb4b4");
+  expect(mixToWhite("#f00", 0.65)).toBe("#ffa6a6");
+  expect(mixToWhite("cyan", 0.65)).toBe("#a6ffff");
+});
+
+it("pointer overlay fades the trail after up messages", async () => {
   let now = 0;
   const { frames, polls, alphas } = await setupOverlay(() => now);
 
-  polls.shift()?.resolve(
-    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
-  );
+  resolveMove(polls, 1, 0.25, 0.5);
   await flushPromises();
-  frames.shift()?.(0);
-  alphas.length = 0;
 
-  now = 1000;
+  now = 250;
   polls.shift()?.resolve(okJson({ seq: 2, event: { up: true }, session: "session-a" }));
   await flushPromises();
-  frames.shift()?.(1000);
-  now = 1075;
-  frames.shift()?.(1075);
+  frames.shift()?.(250);
 
-  expect(alphas.slice(0, 2)).toEqual([1, 1]);
-  expect(alphas[2]).toBeCloseTo(0.5);
-  expect(alphas[3]).toBeCloseTo(0.5);
+  expect(alphas[0]).toBeCloseTo(0.5);
+});
+
+it("pointer overlay bounds the trail buffer", async () => {
+  let now = 0;
+  const { frames, polls, context } = await setupOverlay(() => now);
+
+  for (let index = 0; index < 70; index += 1) {
+    now = index;
+    resolveMove(polls, index + 1, 0.25, 0.5);
+    await flushPromises();
+  }
+  frames.shift()?.(70);
+
+  expect(context.fill).toHaveBeenCalledTimes(64);
 });
 
 it("pointer overlay clears immediately on navigation", async () => {
   const { bus, frames, polls, context } = await setupOverlay();
-  polls.shift()?.resolve(
-    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
-  );
+  resolveMove(polls, 1, 0.25, 0.5);
   await flushPromises();
   frames.shift()?.(0);
   context.clearRect.mockClear();
+  context.fill.mockClear();
 
   bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+  while (frames.length > 0) {
+    frames.shift()?.(0);
+  }
 
   expect(context.clearRect).toHaveBeenCalledWith(0, 0, 200, 100);
+  expect(context.fill).not.toHaveBeenCalled();
 });
 
 it("pointer overlay resets state on a different session id", async () => {
   const { frames, polls, context } = await setupOverlay();
-  polls.shift()?.resolve(
-    okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
-  );
+  resolveMove(polls, 1, 0.25, 0.5);
   await flushPromises();
   frames.shift()?.(0);
   context.arc.mockClear();
+  context.fill.mockClear();
   context.clearRect.mockClear();
 
   polls.shift()?.resolve(okJson({ seq: 2, event: { up: true }, session: "session-b" }));
@@ -195,4 +254,5 @@ it("pointer overlay resets state on a different session id", async () => {
 
   expect(context.clearRect).toHaveBeenCalled();
   expect(context.arc).not.toHaveBeenCalled();
+  expect(context.fill).not.toHaveBeenCalled();
 });

--- a/packages/peitho-present/test/pointerOverlay.test.ts
+++ b/packages/peitho-present/test/pointerOverlay.test.ts
@@ -59,9 +59,11 @@ function canvasFixture(): {
   canvas: HTMLCanvasElement;
   context: MockCanvasContext;
   alphas: number[];
+  fillStyles: string[];
 } {
   const canvas = document.createElement("canvas");
   const alphas: number[] = [];
+  const fillStyles: string[] = [];
   const context = {
     globalAlpha: 1,
     globalCompositeOperation: "source-over",
@@ -73,6 +75,7 @@ function canvasFixture(): {
     arc: vi.fn(),
     fill: vi.fn(() => {
       alphas.push(context.globalAlpha);
+      fillStyles.push(String(context.fillStyle));
     })
   } as unknown as MockCanvasContext;
   vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue({
@@ -88,7 +91,7 @@ function canvasFixture(): {
   });
   vi.spyOn(canvas, "getContext").mockReturnValue(context);
   document.body.append(canvas);
-  return { canvas, context, alphas };
+  return { canvas, context, alphas, fillStyles };
 }
 
 function pointerFetch(): { fetcher: typeof fetch; polls: DeferredPoll[] } {
@@ -110,19 +113,20 @@ async function setupOverlay(now: () => number = () => 0): Promise<{
   polls: DeferredPoll[];
   context: MockCanvasContext;
   alphas: number[];
+  fillStyles: string[];
 }> {
   const frames = installFrameMock();
-  const { canvas, context, alphas } = canvasFixture();
+  const { canvas, context, alphas, fillStyles } = canvasFixture();
   const { fetcher, polls } = pointerFetch();
   const bus = new EventTarget();
   cleanups.push(installPointerOverlay({ canvas, fetcher, bus, window, now }));
   await flushPromises();
   expect(polls[0]?.url).toBe("/pointer?seq=0");
-  return { bus, frames, polls, context, alphas };
+  return { bus, frames, polls, context, alphas, fillStyles };
 }
 
 it("pointer overlay renders a dot on move messages", async () => {
-  const { frames, polls, context } = await setupOverlay();
+  const { frames, polls, context, fillStyles } = await setupOverlay();
 
   polls.shift()?.resolve(
     okJson({ seq: 1, event: { move: { x: 0.25, y: 0.5 } }, session: "session-a" })
@@ -130,9 +134,10 @@ it("pointer overlay renders a dot on move messages", async () => {
   await flushPromises();
   frames.shift()?.(0);
 
-  expect(context.arc).toHaveBeenCalledWith(50, 50, 1.2, 0, Math.PI * 2);
-  expect(context.globalCompositeOperation).toBe("multiply");
-  expect(context.fillStyle).toBe("#ff2a2a");
+  expect(context.arc).toHaveBeenNthCalledWith(1, 50, 50, 3.2, 0, Math.PI * 2);
+  expect(context.arc).toHaveBeenNthCalledWith(2, 50, 50, 1.2, 0, Math.PI * 2);
+  expect(context.globalCompositeOperation).toBe("source-over");
+  expect(fillStyles).toEqual(["#ffffff", "#ff2a2a"]);
 });
 
 it("pointer overlay fades after up messages", async () => {
@@ -153,8 +158,9 @@ it("pointer overlay fades after up messages", async () => {
   now = 1075;
   frames.shift()?.(1075);
 
-  expect(alphas[0]).toBe(1);
-  expect(alphas[1]).toBeCloseTo(0.5);
+  expect(alphas.slice(0, 2)).toEqual([1, 1]);
+  expect(alphas[2]).toBeCloseTo(0.5);
+  expect(alphas[3]).toBeCloseTo(0.5);
 });
 
 it("pointer overlay clears immediately on navigation", async () => {

--- a/packages/peitho-present/test/remote-pointer.test.ts
+++ b/packages/peitho-present/test/remote-pointer.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { installRemoteControls, installRemotePointerBridge } from "../src/remote";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()?.();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+function pointerEvent(
+  type: string,
+  init: MouseEventInit & { pointerId?: number } = {}
+): PointerEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...init
+  }) as PointerEvent;
+  Object.defineProperty(event, "pointerId", {
+    configurable: true,
+    value: init.pointerId ?? 1
+  });
+  return event;
+}
+
+function previewRoot(): HTMLElement {
+  const preview = document.createElement("div");
+  document.body.append(preview);
+  vi.spyOn(preview, "getBoundingClientRect").mockReturnValue({
+    left: 10,
+    top: 20,
+    right: 110,
+    bottom: 70,
+    x: 10,
+    y: 20,
+    width: 100,
+    height: 50,
+    toJSON: () => ({})
+  });
+  return preview;
+}
+
+function installFrameMock(): FrameRequestCallback[] {
+  const frames: FrameRequestCallback[] = [];
+  const originalRequest = window.requestAnimationFrame;
+  const originalCancel = window.cancelAnimationFrame;
+  window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
+    frames.push(callback);
+    return frames.length;
+  });
+  window.cancelAnimationFrame = vi.fn();
+  cleanups.push(() => {
+    window.requestAnimationFrame = originalRequest;
+    window.cancelAnimationFrame = originalCancel;
+  });
+  return frames;
+}
+
+function fetchRecorder(): { fetcher: typeof fetch; bodies: unknown[] } {
+  const bodies: unknown[] = [];
+  const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {
+    bodies.push(JSON.parse(String(init?.body)));
+    return { ok: true, status: 200 } as Response;
+  }) as typeof fetch;
+  return { fetcher, bodies };
+}
+
+it("remote pointer mode toggle emits mode change requests", () => {
+  const root = document.createElement("main");
+  const bus = new EventTarget();
+  const requests: unknown[] = [];
+  bus.addEventListener("peitho:pointermodechange", (event) => {
+    requests.push((event as CustomEvent).detail);
+  });
+  cleanups.push(installRemoteControls({ root, document, bus }));
+
+  root.querySelector<HTMLButtonElement>('[data-peitho-pointer-mode="pointer"]')?.click();
+  root.querySelector<HTMLButtonElement>('[data-peitho-pointer-mode="off"]')?.click();
+
+  expect(requests).toEqual([{ mode: "pointer" }, { mode: "off" }]);
+});
+
+it("remote pointer bridge posts move and up bodies", () => {
+  const frames = installFrameMock();
+  const bus = new EventTarget();
+  const preview = previewRoot();
+  const { fetcher, bodies } = fetchRecorder();
+  cleanups.push(installRemotePointerBridge({ bus, previewRoot: preview, fetcher, window }));
+
+  bus.dispatchEvent(new CustomEvent("peitho:pointermodechange", { detail: { mode: "pointer" } }));
+  preview.dispatchEvent(pointerEvent("pointerdown", { clientX: 60, clientY: 45 }));
+  frames.shift()?.(0);
+  preview.dispatchEvent(pointerEvent("pointerup", { clientX: 60, clientY: 45 }));
+
+  expect(bodies).toEqual([{ move: { x: 0.5, y: 0.5 } }, { up: true }]);
+  expect(fetcher).toHaveBeenCalledWith("/pointer", {
+    method: "POST",
+    body: JSON.stringify({ move: { x: 0.5, y: 0.5 } }),
+    keepalive: true,
+    headers: { "Content-Type": "application/json" }
+  });
+});
+
+it("remote pointer bridge removes preview listeners and posts final up on off", () => {
+  const frames = installFrameMock();
+  const bus = new EventTarget();
+  const preview = previewRoot();
+  const { fetcher, bodies } = fetchRecorder();
+  cleanups.push(installRemotePointerBridge({ bus, previewRoot: preview, fetcher, window }));
+
+  bus.dispatchEvent(new CustomEvent("peitho:pointermodechange", { detail: { mode: "pointer" } }));
+  bus.dispatchEvent(new CustomEvent("peitho:pointermodechange", { detail: { mode: "off" } }));
+  preview.dispatchEvent(pointerEvent("pointerdown", { clientX: 60, clientY: 45 }));
+  frames.shift()?.(0);
+
+  expect(bodies).toEqual([{ up: true }]);
+  expect(fetcher).toHaveBeenCalledTimes(1);
+});
+
+it("remote pointer bridge coalesces moves to one post per frame", () => {
+  const frames = installFrameMock();
+  const bus = new EventTarget();
+  const preview = previewRoot();
+  const { fetcher, bodies } = fetchRecorder();
+  cleanups.push(installRemotePointerBridge({ bus, previewRoot: preview, fetcher, window }));
+
+  bus.dispatchEvent(new CustomEvent("peitho:pointermodechange", { detail: { mode: "pointer" } }));
+  preview.dispatchEvent(pointerEvent("pointerdown", { clientX: 20, clientY: 25 }));
+  preview.dispatchEvent(pointerEvent("pointermove", { clientX: 60, clientY: 45 }));
+  preview.dispatchEvent(pointerEvent("pointermove", { clientX: 90, clientY: 60 }));
+  expect(frames).toHaveLength(1);
+
+  frames.shift()?.(0);
+
+  expect(bodies).toEqual([{ move: { x: 0.8, y: 0.8 } }]);
+});
+
+it("remote pointer bridge clamps preview coordinates to the unit square", () => {
+  const frames = installFrameMock();
+  const bus = new EventTarget();
+  const preview = previewRoot();
+  const { fetcher, bodies } = fetchRecorder();
+  cleanups.push(installRemotePointerBridge({ bus, previewRoot: preview, fetcher, window }));
+
+  bus.dispatchEvent(new CustomEvent("peitho:pointermodechange", { detail: { mode: "pointer" } }));
+  preview.dispatchEvent(pointerEvent("pointerdown", { clientX: 0, clientY: 100 }));
+  frames.shift()?.(0);
+
+  expect(bodies).toEqual([{ move: { x: 0, y: 1 } }]);
+});

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -214,8 +214,9 @@ it("remote controls compose dimmable rows and actions in fixed order", () => {
   const chase = root.querySelector<HTMLElement>('[data-peitho-remote="chase"]');
   const pace = root.querySelector<HTMLElement>(".peitho-remote-pace");
   const notesPanel = root.querySelector<HTMLElement>(".peitho-remote-notes");
+  const pointerMode = root.querySelector<HTMLElement>('[data-peitho-remote="pointer-mode"]');
   const actions = root.querySelector<HTMLElement>(".peitho-remote-actions");
-  const dimmableRows = [preview, titlebar, chase, pace, notesPanel];
+  const dimmableRows = [preview, titlebar, chase, pace, notesPanel, pointerMode];
 
   expect(Array.from(container.children)).toEqual([
     preview,
@@ -223,9 +224,10 @@ it("remote controls compose dimmable rows and actions in fixed order", () => {
     chase,
     pace,
     notesPanel,
+    pointerMode,
     actions
   ]);
-  expect(dimmableRows).toHaveLength(5);
+  expect(dimmableRows).toHaveLength(6);
   for (const element of dimmableRows) {
     expect(element?.classList).toContain("peitho-remote-dim-on-end");
   }

--- a/packages/peitho-present/test/session.test.ts
+++ b/packages/peitho-present/test/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { Manifest } from "../../../bindings/Manifest";
 import { mountPresentShell } from "../src/index";
 import type { PresentShell } from "../src/index";
@@ -55,8 +55,15 @@ function standardFetch(): typeof fetch {
 
 const shells: PresentShell[] = [];
 
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    (() => null) as HTMLCanvasElement["getContext"]
+  );
+});
+
 afterEach(() => {
   while (shells.length > 0) shells.pop()?.destroy();
+  vi.restoreAllMocks();
 });
 
 it("does not start the presentation on mount", async () => {

--- a/packages/peitho-present/test/sync.test.ts
+++ b/packages/peitho-present/test/sync.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import {
   installCloseOnEscape,
   installSyncBridge,
@@ -510,6 +510,12 @@ it("server sync channel aborts the active poll on close", async () => {
 
 const shells: PresentShell[] = [];
 const cleanups: Array<() => void> = [];
+
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    (() => null) as HTMLCanvasElement["getContext"]
+  );
+});
 
 afterEach(() => {
   while (cleanups.length > 0) cleanups.pop()?.();


### PR DESCRIPTION
## Summary

- Adds a Pointer mode to `/remote` so the presenter can point at the slides window in real time from their phone.
- Draws a cyan gradient "laser" pointer with a 500 ms fading trail on the slides overlay canvas.
- Introduces a `pointer_color` frontmatter key so a deck can override the base color (invalid values fail with a line-numbered build error via the `PointerColor` newtype).

## What changed

- **Transport** (`crates/peitho/src/server.rs`): new `PointerHub` + `/pointer` GET/POST. Same session id as `SyncHub`; long poll with a 5 s timeout; POST `{"move":{x,y}}` / `{"up":true}`; unknown JSON or out-of-range coordinates return 400 (silent-drop forbidden).
- **Frontmatter** (`crates/peitho-core/src/{parser,phase,manifest}.rs`): `pointer_color` accepts `#rgb`, `#rrggbb`, `#rgba`, `#rrggbbaa`, or a standard CSS named color; anything else is a line-numbered build error. The value rides `DeckSettings` → `Manifest::pointer_color` (`bindings/Manifest.ts` regenerated).
- **Remote UI** (`packages/peitho-present/src/remote.ts`): Off/Pointer toggle. When Pointer is on, the preview region captures Pointer Events, hit-tests to normalized `[0,1]²`, and POSTs at ~30 Hz (rAF-coalesced, `fetch(..., {keepalive: true})`). Emits `peitho:pointermodechange` / `peitho:pointermove` / `peitho:pointerup`; shell is what actually POSTs (§16 contract).
- **Slides overlay** (`packages/peitho-present/src/shell.ts`): full-viewport `<canvas>` with `pointer-events: none`. Cyan radial gradient (`#e0f2fe` core → `#38bdf8` at 25% → transparent); overridable via `pointer_color`. Trail is a bounded 64-point ring buffer, alpha decays over 500 ms per point. Cleared on `peitho:navigate` and on `/pointer` handshake session change.
- **Cleanup**: `Manifest` constructors were about to grow a `with_X_and_Y_and_Z` suffix chain; collapsed to `Manifest::new(...).with_images(...).with_pointer_color(...)` so future optional fields compose independently.

## Docs

- Design record: `docs/plans/2026-07-20-remote-pointer.md`

## Test plan

- [x] `cargo test --workspace` (× 3, all pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/` (regenerated `Manifest.ts` committed)
- [x] `packages/peitho-present`: `npm run build && npm test && npm run typecheck` (297 tests pass)
- [x] `git diff --exit-code packages/peitho-present/dist/` (rebuilt bundles committed)
- [ ] Real-device E2E:
  - Pointer visible on white / dark / photo / brand-cyan / warm backgrounds
  - Trail fades over ~500 ms
  - `pointer_color: '#ff2a2a'` in a deck's frontmatter changes the color
  - Invalid `pointer_color` fails with a line-numbered build error
  - Advancing a slide clears the pointer immediately
  - Server restart / rejoin shows no stale pointer

## Non-goals for v1

- Draw mode (stroke retention), color / size pickers in the UI, presenter-window pointer preview, multi-presenter pointer.