### PR TITLE
Release v1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.13.0"
+version = "1.14.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Bump version to 1.14.0.

## Included since v1.13.0

- #326 Remote pointer: laser-style pointer with fading trail from the phone remote