### PR TITLE
Add remote haptic on timer urgency transitions

### DIFF
--- a/docs/plans/2026-07-20-remote-urgency-haptic.md
+++ b/docs/plans/2026-07-20-remote-urgency-haptic.md
@@ -1,0 +1,19 @@
+# Remote urgency haptic transitions (Issue #327)
+
+## Scope
+
+Add deck-level urgency transition events for timer threshold changes and let the remote vibrate on those transitions. This intentionally does not add section-level urgency, presenter-side event tracking, remote visual UI, or CSS changes.
+
+## Design
+
+- Keep `urgencyFor(elapsedMs, plannedDurationMs)` unchanged as the pure derivation.
+- Add `installUrgencyTracker()` as a small state machine that polls the shell every 250ms, derives deck urgency, and emits `peitho:urgencychange` on forward band changes.
+- Use the fixed order `normal -> warning -> urgent -> overrun`; when elapsed jumps across multiple bands, emit each intermediate transition in order rather than silently dropping middle bands.
+- Treat rewinds and resets as silent state updates back toward `normal`.
+- In `/remote`, install the tracker against the remote's absolute timer state and subscribe a haptic bridge that maps `warning`, `urgent`, and `overrun` to vibration patterns. The bridge buffers events dispatched within a single JS turn and flushes once via `queueMicrotask`, merging patterns with a 200 ms pause: `navigator.vibrate()` cancels any prior pending vibration, so a multi-band jump like `normal→overrun` would otherwise only feel the terminal band. `HAPTIC_PATTERNS` is a total `Record<TimerUrgency, readonly number[] | null>` (with `normal: null`), so adding a new urgency variant is a compile error at both the rank map and the pattern table.
+
+## Tests
+
+- Extend `timerUrgency.test.ts` with fake-timer tests for null plans, boundaries, multi-band jumps, rewinds, repeated ticks, reset snapping, and `destroy()`.
+- Extend `remote.test.ts` with direct bridge tests for vibration patterns, missing `navigator.vibrate`, and listener cleanup.
+- Run `npm test`, `npm run typecheck`, and `npm run build` in `packages/peitho-present`; commit regenerated `dist/` bundles.

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -1290,9 +1290,71 @@ function serverSyncChannelFactory(options = {}) {
   };
 }
 
+// src/timerUrgency.ts
+var URGENCY_ORDER = ["normal", "warning", "urgent", "overrun"];
+var URGENCY_RANK = {
+  normal: 0,
+  warning: 1,
+  urgent: 2,
+  overrun: 3
+};
+function urgencyFor(elapsedMs, plannedDurationMs) {
+  if (plannedDurationMs == null) return "normal";
+  if (isOverrun(elapsedMs, plannedDurationMs)) return "overrun";
+  const remainingMs = plannedDurationMs - elapsedMs;
+  if (remainingMs <= 6e4) return "urgent";
+  if (remainingMs <= 18e4) return "warning";
+  return "normal";
+}
+function installUrgencyTracker(options) {
+  const win = options.window ?? window;
+  const bus = options.bus;
+  let lastKnown = null;
+  const emit = (from, to) => {
+    bus.dispatchEvent(
+      new CustomEvent("peitho:urgencychange", {
+        detail: { from, to }
+      })
+    );
+  };
+  const tick = () => {
+    if (options.shell.startedAt() === null) {
+      lastKnown = null;
+      return;
+    }
+    const target = urgencyFor(options.shell.elapsedMs(), options.plannedDurationMs);
+    if (lastKnown === null) {
+      lastKnown = target;
+      return;
+    }
+    const fromIndex = URGENCY_RANK[lastKnown];
+    const toIndex = URGENCY_RANK[target];
+    if (toIndex <= fromIndex) {
+      lastKnown = target;
+      return;
+    }
+    for (let index = fromIndex; index < toIndex; index += 1) {
+      emit(URGENCY_ORDER[index], URGENCY_ORDER[index + 1]);
+    }
+    lastKnown = target;
+  };
+  const interval = win.setInterval(tick, 250);
+  return {
+    destroy() {
+      win.clearInterval(interval);
+    }
+  };
+}
+
 // src/remote.ts
 var isReadOnly = (state) => state.kind === "ended";
 var canInteract = (state) => state.kind === "active";
+var HAPTIC_PATTERNS = {
+  normal: null,
+  warning: [80],
+  urgent: [120],
+  overrun: [180, 80, 180]
+};
 async function mountRemoteView(options) {
   const view = new RemoteController(options);
   await view.load();
@@ -1627,6 +1689,42 @@ function installRemotePointerBridge(options) {
     mode = "off";
   };
 }
+function installRemoteHapticBridge(options) {
+  const win = options.window ?? window;
+  const bus = options.bus;
+  const vibrate = typeof win.navigator.vibrate === "function" ? win.navigator.vibrate.bind(win.navigator) : null;
+  if (vibrate == null) return () => void 0;
+  let pendingPatterns = [];
+  let flushScheduled = false;
+  let destroyed = false;
+  const flush = () => {
+    flushScheduled = false;
+    if (destroyed || pendingPatterns.length === 0) return;
+    const merged = [];
+    pendingPatterns.forEach((pattern, index) => {
+      if (index > 0) merged.push(200);
+      merged.push(...pattern);
+    });
+    pendingPatterns = [];
+    vibrate(merged);
+  };
+  const onUrgencyChange = (event) => {
+    if (destroyed) return;
+    const to = event.detail?.to;
+    const pattern = to == null ? null : HAPTIC_PATTERNS[to];
+    if (pattern === null) return;
+    pendingPatterns.push(pattern);
+    if (!flushScheduled) {
+      flushScheduled = true;
+      queueMicrotask(flush);
+    }
+  };
+  bus.addEventListener("peitho:urgencychange", onUrgencyChange);
+  return () => {
+    destroyed = true;
+    bus.removeEventListener("peitho:urgencychange", onUrgencyChange);
+  };
+}
 function installRemoteSyncBridge(options) {
   const bus = options.bus ?? window;
   const log = options.console ?? console;
@@ -1722,6 +1820,8 @@ var RemoteController = class {
   controlsCleanup = null;
   syncCleanup = null;
   pointerCleanup = null;
+  hapticCleanup = null;
+  urgencyTracker = null;
   previewShell = null;
   timerInterval = null;
   constructor(options) {
@@ -1752,6 +1852,23 @@ var RemoteController = class {
       this.controlsCleanup = installRemoteControls({
         root: this.root,
         document: this.doc,
+        bus: this.bus
+      });
+      this.hapticCleanup = installRemoteHapticBridge({
+        bus: this.bus,
+        window: this.win
+      });
+      this.urgencyTracker = installUrgencyTracker({
+        shell: {
+          elapsedMs: () => this.currentElapsedMs(),
+          startedAt: () => {
+            const elapsedMs = this.currentElapsedMs();
+            if (timerVisualState(this.timerState, elapsedMs) === "stopped") return null;
+            return this.timerState.receivedAtMs;
+          }
+        },
+        plannedDurationMs: validPlannedDurationMs(manifest),
+        window: this.win,
         bus: this.bus
       });
       const previewRoot = this.root.querySelector('[data-peitho-remote="preview"]');
@@ -1796,6 +1913,10 @@ var RemoteController = class {
   }
   destroy() {
     this.clearTimerInterval();
+    this.urgencyTracker?.destroy();
+    this.urgencyTracker = null;
+    this.hapticCleanup?.();
+    this.hapticCleanup = null;
     this.pointerCleanup?.();
     this.pointerCleanup = null;
     this.syncCleanup?.();
@@ -2203,6 +2324,7 @@ export {
   createDimmableRow,
   expectedElapsedAtSlide,
   installRemoteControls,
+  installRemoteHapticBridge,
   installRemotePointerBridge,
   installRemoteSyncBridge,
   mountPresentShell,

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -21,6 +21,12 @@ import {
   serverSyncChannelFactory,
   type SyncChannelFactory
 } from "./sync";
+import {
+  installUrgencyTracker,
+  type TimerUrgency,
+  type UrgencyChangeDetail,
+  type UrgencyTracker
+} from "./timerUrgency";
 import { clamp01, formatMinuteSeconds, isOverrun, isValidDurationMs } from "./timeTracker";
 
 export { mountPresentShell } from "./shell";
@@ -114,6 +120,18 @@ export type RemotePointerBridgeOptions = {
   now?: () => number;
   console?: Pick<Console, "error">;
 };
+
+export type RemoteHapticBridgeOptions = {
+  bus: EventTarget;
+  window?: Window;
+};
+
+const HAPTIC_PATTERNS = {
+  normal: null,
+  warning: [80],
+  urgent: [120],
+  overrun: [180, 80, 180]
+} as const satisfies Record<TimerUrgency, readonly number[] | null>;
 
 export async function mountRemoteView(options: RemoteViewOptions): Promise<RemoteView> {
   const view = new RemoteController(options);
@@ -496,6 +514,50 @@ export function installRemotePointerBridge(options: RemotePointerBridgeOptions):
   };
 }
 
+export function installRemoteHapticBridge(options: RemoteHapticBridgeOptions): () => void {
+  const win = options.window ?? window;
+  const bus = options.bus;
+  const vibrate =
+    typeof win.navigator.vibrate === "function"
+      ? win.navigator.vibrate.bind(win.navigator)
+      : null;
+  if (vibrate == null) return () => undefined;
+
+  let pendingPatterns: (readonly number[])[] = [];
+  let flushScheduled = false;
+  let destroyed = false;
+
+  const flush = (): void => {
+    flushScheduled = false;
+    if (destroyed || pendingPatterns.length === 0) return;
+    const merged: number[] = [];
+    pendingPatterns.forEach((pattern, index) => {
+      if (index > 0) merged.push(200);
+      merged.push(...pattern);
+    });
+    pendingPatterns = [];
+    vibrate(merged);
+  };
+
+  const onUrgencyChange = (event: Event): void => {
+    if (destroyed) return;
+    const to = (event as CustomEvent<UrgencyChangeDetail>).detail?.to;
+    const pattern = to == null ? null : HAPTIC_PATTERNS[to];
+    if (pattern === null) return;
+    pendingPatterns.push(pattern);
+    if (!flushScheduled) {
+      flushScheduled = true;
+      queueMicrotask(flush);
+    }
+  };
+
+  bus.addEventListener("peitho:urgencychange", onUrgencyChange);
+  return () => {
+    destroyed = true;
+    bus.removeEventListener("peitho:urgencychange", onUrgencyChange);
+  };
+}
+
 export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () => void {
   const bus = options.bus ?? window;
   const log = options.console ?? console;
@@ -600,6 +662,8 @@ class RemoteController implements RemoteView {
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
   private pointerCleanup: (() => void) | null = null;
+  private hapticCleanup: (() => void) | null = null;
+  private urgencyTracker: UrgencyTracker | null = null;
   private previewShell: PresentShell | null = null;
   private timerInterval: number | null = null;
 
@@ -632,6 +696,23 @@ class RemoteController implements RemoteView {
       this.controlsCleanup = installRemoteControls({
         root: this.root,
         document: this.doc,
+        bus: this.bus
+      });
+      this.hapticCleanup = installRemoteHapticBridge({
+        bus: this.bus,
+        window: this.win
+      });
+      this.urgencyTracker = installUrgencyTracker({
+        shell: {
+          elapsedMs: () => this.currentElapsedMs(),
+          startedAt: () => {
+            const elapsedMs = this.currentElapsedMs();
+            if (timerVisualState(this.timerState, elapsedMs) === "stopped") return null;
+            return this.timerState!.receivedAtMs;
+          }
+        },
+        plannedDurationMs: validPlannedDurationMs(manifest),
+        window: this.win,
         bus: this.bus
       });
       const previewRoot = this.root.querySelector<HTMLElement>('[data-peitho-remote="preview"]');
@@ -677,6 +758,10 @@ class RemoteController implements RemoteView {
 
   destroy(): void {
     this.clearTimerInterval();
+    this.urgencyTracker?.destroy();
+    this.urgencyTracker = null;
+    this.hapticCleanup?.();
+    this.hapticCleanup = null;
     this.pointerCleanup?.();
     this.pointerCleanup = null;
     this.syncCleanup?.();

--- a/packages/peitho-present/src/timerUrgency.ts
+++ b/packages/peitho-present/src/timerUrgency.ts
@@ -1,6 +1,29 @@
+import type { PresentShell } from "./shell";
 import { isOverrun } from "./timeTracker";
 
-export type TimerUrgency = "normal" | "warning" | "urgent" | "overrun";
+const URGENCY_ORDER = ["normal", "warning", "urgent", "overrun"] as const;
+
+export type TimerUrgency = (typeof URGENCY_ORDER)[number];
+
+export type UrgencyChangeDetail = { from: TimerUrgency; to: TimerUrgency };
+
+export type UrgencyTracker = { destroy(): void };
+
+export type UrgencyTrackerShell = Pick<PresentShell, "elapsedMs" | "startedAt">;
+
+export type UrgencyTrackerOptions = {
+  shell: UrgencyTrackerShell;
+  plannedDurationMs: number | null;
+  window?: Window;
+  bus: EventTarget;
+};
+
+const URGENCY_RANK = {
+  normal: 0,
+  warning: 1,
+  urgent: 2,
+  overrun: 3
+} as const satisfies Record<TimerUrgency, number>;
 
 export function urgencyFor(
   elapsedMs: number,
@@ -13,4 +36,48 @@ export function urgencyFor(
   if (remainingMs <= 60_000) return "urgent";
   if (remainingMs <= 180_000) return "warning";
   return "normal";
+}
+
+export function installUrgencyTracker(options: UrgencyTrackerOptions): UrgencyTracker {
+  const win = options.window ?? window;
+  const bus = options.bus;
+  let lastKnown: TimerUrgency | null = null;
+
+  const emit = (from: TimerUrgency, to: TimerUrgency): void => {
+    bus.dispatchEvent(
+      new CustomEvent<UrgencyChangeDetail>("peitho:urgencychange", {
+        detail: { from, to }
+      })
+    );
+  };
+
+  const tick = (): void => {
+    if (options.shell.startedAt() === null) {
+      lastKnown = null;
+      return;
+    }
+    const target = urgencyFor(options.shell.elapsedMs(), options.plannedDurationMs);
+    if (lastKnown === null) {
+      lastKnown = target;
+      return;
+    }
+    const fromIndex = URGENCY_RANK[lastKnown];
+    const toIndex = URGENCY_RANK[target];
+    if (toIndex <= fromIndex) {
+      lastKnown = target;
+      return;
+    }
+    for (let index = fromIndex; index < toIndex; index += 1) {
+      emit(URGENCY_ORDER[index], URGENCY_ORDER[index + 1]);
+    }
+    lastKnown = target;
+  };
+
+  const interval = win.setInterval(tick, 250);
+
+  return {
+    destroy(): void {
+      win.clearInterval(interval);
+    }
+  };
 }

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -4,6 +4,7 @@ import type { Notes } from "../../../bindings/Notes";
 import {
   createDimmableRow,
   expectedElapsedAtSlide,
+  installRemoteHapticBridge,
   installRemoteControls,
   mountRemoteView,
   remotePaceState,
@@ -148,6 +149,125 @@ function mockMountPresentShell(navigations: unknown[] = []): (options: ShellOpti
     };
   });
 }
+
+function mockWindowVibrate(vibrate: ReturnType<typeof vi.fn>): void {
+  const descriptor = Object.getOwnPropertyDescriptor(window.navigator, "vibrate");
+  Object.defineProperty(window.navigator, "vibrate", {
+    configurable: true,
+    value: vibrate
+  });
+  cleanups.push(() => {
+    if (descriptor == null) {
+      Reflect.deleteProperty(window.navigator, "vibrate");
+      return;
+    }
+    Object.defineProperty(window.navigator, "vibrate", descriptor);
+  });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+}
+
+it("remote haptic bridge merges synchronous urgency transitions into one vibration", async () => {
+  const bus = new EventTarget();
+  const vibrate = vi.fn();
+  cleanups.push(
+    installRemoteHapticBridge({
+      bus,
+      window: { navigator: { vibrate } } as unknown as Window
+    })
+  );
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:urgencychange", { detail: { from: "normal", to: "warning" } })
+  );
+  bus.dispatchEvent(
+    new CustomEvent("peitho:urgencychange", { detail: { from: "warning", to: "urgent" } })
+  );
+  bus.dispatchEvent(
+    new CustomEvent("peitho:urgencychange", { detail: { from: "urgent", to: "overrun" } })
+  );
+  await flushMicrotasks();
+
+  expect(vibrate.mock.calls).toEqual([[[80, 200, 120, 200, 180, 80, 180]]]);
+});
+
+it("remote haptic bridge is safe when navigator.vibrate is absent", () => {
+  const bus = new EventTarget();
+  const cleanup = installRemoteHapticBridge({
+    bus,
+    window: { navigator: {} } as unknown as Window
+  });
+  cleanups.push(cleanup);
+
+  expect(() => {
+    bus.dispatchEvent(
+      new CustomEvent("peitho:urgencychange", { detail: { from: "normal", to: "warning" } })
+    );
+  }).not.toThrow();
+});
+
+it("remote haptic bridge cleanup removes the urgency listener", async () => {
+  const bus = new EventTarget();
+  const vibrate = vi.fn();
+  const cleanup = installRemoteHapticBridge({
+    bus,
+    window: { navigator: { vibrate } } as unknown as Window
+  });
+
+  cleanup();
+  bus.dispatchEvent(
+    new CustomEvent("peitho:urgencychange", { detail: { from: "normal", to: "warning" } })
+  );
+  await flushMicrotasks();
+
+  expect(vibrate).not.toHaveBeenCalled();
+});
+
+it("remote haptic bridge cleanup cancels a pending microtask flush", async () => {
+  const bus = new EventTarget();
+  const vibrate = vi.fn();
+  const cleanup = installRemoteHapticBridge({
+    bus,
+    window: { navigator: { vibrate } } as unknown as Window
+  });
+
+  bus.dispatchEvent(
+    new CustomEvent("peitho:urgencychange", { detail: { from: "normal", to: "warning" } })
+  );
+  cleanup();
+  await flushMicrotasks();
+
+  expect(vibrate).not.toHaveBeenCalled();
+});
+
+it("remote controller wires timer urgency transitions to haptics", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  const vibrate = vi.fn(() => true);
+  mockWindowVibrate(vibrate);
+  const { channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro" }, { key: "end" }], {
+      plannedDurationMs: 300_000
+    })
+  );
+
+  channel.deliver({ timer: { running: true, elapsedMs: 0, atMs: 0 }, nowMs: 0 });
+  vi.advanceTimersByTime(250);
+  await flushMicrotasks();
+  channel.deliver({ timer: { running: true, elapsedMs: 119_750, atMs: 250 }, nowMs: 250 });
+  vi.advanceTimersByTime(250);
+  await flushMicrotasks();
+  channel.deliver({ timer: { running: true, elapsedMs: 239_750, atMs: 500 }, nowMs: 500 });
+  vi.advanceTimersByTime(250);
+  await flushMicrotasks();
+  channel.deliver({ timer: { running: true, elapsedMs: 300_001, atMs: 750 }, nowMs: 750 });
+  vi.advanceTimersByTime(250);
+  await flushMicrotasks();
+
+  expect(vibrate.mock.calls).toEqual([[[80]], [[120]], [[180, 80, 180]]]);
+});
 
 it("remote buttons dispatch navigate request events only", () => {
   const root = document.createElement("main");

--- a/packages/peitho-present/test/timerUrgency.test.ts
+++ b/packages/peitho-present/test/timerUrgency.test.ts
@@ -1,5 +1,10 @@
-import { expect, it } from "vitest";
-import { urgencyFor } from "../src/timerUrgency";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  installUrgencyTracker,
+  urgencyFor,
+  type UrgencyChangeDetail,
+  type UrgencyTrackerShell
+} from "../src/timerUrgency";
 
 it.each([
   ["planned duration is unset", 120_000, null, "normal"],
@@ -14,4 +19,151 @@ it.each([
   ["thirty second plans start at urgent", 0, 30_000, "urgent"]
 ] as const)("returns %s", (_label, elapsedMs, plannedDurationMs, expected) => {
   expect(urgencyFor(elapsedMs, plannedDurationMs)).toBe(expected);
+});
+
+const trackers: Array<{ destroy(): void }> = [];
+
+afterEach(() => {
+  while (trackers.length > 0) trackers.pop()?.destroy();
+  vi.useRealTimers();
+});
+
+function fakeShell(initialElapsedMs = 0): UrgencyTrackerShell & {
+  setElapsedMs(value: number): void;
+  setStartedAt(value: number | null): void;
+} {
+  let elapsed = initialElapsedMs;
+  let startedAt: number | null = 1;
+  return {
+    elapsedMs: () => elapsed,
+    startedAt: () => startedAt,
+    setElapsedMs(value: number) {
+      elapsed = value;
+    },
+    setStartedAt(value: number | null) {
+      startedAt = value;
+    }
+  };
+}
+
+function installTrackerForTest(options: {
+  plannedDurationMs: number | null;
+  elapsedMs?: number;
+}) {
+  vi.useFakeTimers();
+  const bus = new EventTarget();
+  const events: UrgencyChangeDetail[] = [];
+  bus.addEventListener("peitho:urgencychange", (event) => {
+    events.push((event as CustomEvent<UrgencyChangeDetail>).detail);
+  });
+  const shell = fakeShell(options.elapsedMs);
+  trackers.push(
+    installUrgencyTracker({
+      shell,
+      plannedDurationMs: options.plannedDurationMs,
+      bus,
+      window
+    })
+  );
+  return { bus, events, shell };
+}
+
+it("urgency tracker emits nothing when planned duration is unset", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: null });
+
+  shell.setElapsedMs(10 * 60_000);
+  vi.advanceTimersByTime(1_000);
+
+  expect(events).toEqual([]);
+});
+
+it("urgency tracker emits no initial event for the current urgency", () => {
+  const { events } = installTrackerForTest({
+    plannedDurationMs: 300_000,
+    elapsedMs: 240_000
+  });
+
+  vi.advanceTimersByTime(250);
+
+  expect(events).toEqual([]);
+});
+
+it("urgency tracker emits normal to warning at the boundary", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: 300_000 });
+
+  vi.advanceTimersByTime(250);
+  shell.setElapsedMs(120_000);
+  vi.advanceTimersByTime(250);
+
+  expect(events).toEqual([{ from: "normal", to: "warning" }]);
+});
+
+it("urgency tracker emits every intermediate transition on a multi-band jump", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: 300_000 });
+
+  vi.advanceTimersByTime(250);
+  shell.setElapsedMs(300_001);
+  vi.advanceTimersByTime(250);
+
+  expect(events).toEqual([
+    { from: "normal", to: "warning" },
+    { from: "warning", to: "urgent" },
+    { from: "urgent", to: "overrun" }
+  ]);
+});
+
+it("urgency tracker emits nothing on rewind to a less urgent band", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: 300_000 });
+
+  vi.advanceTimersByTime(250);
+  shell.setElapsedMs(240_000);
+  vi.advanceTimersByTime(250);
+  events.length = 0;
+  shell.setElapsedMs(0);
+  vi.advanceTimersByTime(250);
+
+  expect(events).toEqual([]);
+});
+
+it("urgency tracker emits nothing on repeated ticks with the same urgency", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: 300_000 });
+
+  vi.advanceTimersByTime(250);
+  shell.setElapsedMs(120_000);
+  vi.advanceTimersByTime(250);
+  events.length = 0;
+  vi.advanceTimersByTime(1_000);
+
+  expect(events).toEqual([]);
+});
+
+it("urgency tracker snaps back to normal silently on timer reset", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: 300_000 });
+
+  vi.advanceTimersByTime(250);
+  shell.setElapsedMs(240_000);
+  vi.advanceTimersByTime(250);
+  events.length = 0;
+  shell.setStartedAt(null);
+  shell.setElapsedMs(0);
+  vi.advanceTimersByTime(250);
+  expect(events).toEqual([]);
+
+  shell.setStartedAt(2);
+  shell.setElapsedMs(0);
+  vi.advanceTimersByTime(250);
+  shell.setElapsedMs(120_000);
+  vi.advanceTimersByTime(250);
+
+  expect(events).toEqual([{ from: "normal", to: "warning" }]);
+});
+
+it("urgency tracker destroy stops ticking", () => {
+  const { events, shell } = installTrackerForTest({ plannedDurationMs: 300_000 });
+
+  trackers.pop()?.destroy();
+  shell.setElapsedMs(300_001);
+  vi.advanceTimersByTime(1_000);
+
+  expect(events).toEqual([]);
 });


### PR DESCRIPTION
## Summary

Closes #327.

Adds a deck-scoped urgency state machine (`installUrgencyTracker`) that emits `peitho:urgencychange` on each forward band change, and a remote-only `installRemoteHapticBridge` that vibrates on those transitions:

- `→warning` = `[80]` (80 ms)
- `→urgent` = `[120]` (120 ms)
- `→overrun` = `[180, 80, 180]` (double buzz)

Multi-band jumps (e.g. remote joining mid-talk, clock skew, sleep/resume) emit every intermediate transition in order — no silent drops. The haptic bridge coalesces synchronous events via `queueMicrotask` and calls `navigator.vibrate` **once** with the merged pattern (200 ms pause between bands), because the Vibration API cancels any prior pending vibration, so three synchronous `vibrate()` calls would otherwise only feel the terminal band.

## Scope

Deliberately narrow per the issue's post-consultation decisions:

- Deck-level urgency only. No per-section urgency (see the Undecided section of the issue — sections were dropped by author decision).
- Remote-only haptics. No presenter changes, no new visual UI on the remote, no CSS.
- Presenter's inline `urgencyFor` per-tick class update stays exactly as it is.

## Type-safety notes

- `URGENCY_ORDER` is the single-source `as const` tuple; `TimerUrgency` derives from `typeof URGENCY_ORDER[number]`, and `URGENCY_RANK` uses `satisfies Record<TimerUrgency, number>` so adding a variant is a compile error at the rank map.
- `HAPTIC_PATTERNS` is a total `Record<TimerUrgency, readonly number[] | null>` (with `normal: null`), so adding a variant is a compile error at the pattern table too.
- `UrgencyTrackerShell` reuses `Pick<PresentShell, "elapsedMs" | "startedAt">` rather than duplicating the shell shape.
- The remote's tracker shim routes "is the timer active?" through the existing `timerVisualState` predicate — no re-derivation of the stopped-timer rule.

## Vibration API caveat

- Android Chrome supports `navigator.vibrate`. iOS Safari does not — the bridge feature-gates and returns a no-op cleanup without installing the listener.
- A cold multi-band jump (e.g. `normal → overrun` in one tick after a long sync gap) produces one merged 1040 ms buzz; that is intentional and matches the plan's "feel every band" requirement.

## Test plan

- [x] Unit tests for the state machine: silent first observation, boundary crossing, multi-band emission order, rewind silence, repeated-tick silence, reset snap-back, destroy.
- [x] Haptic bridge tests: correct patterns per band, safe when `navigator.vibrate` absent, cleanup removes listener, cleanup cancels a pending microtask flush, end-to-end RemoteController wiring.
- [x] `cargo test --workspace` (green x3), `cargo clippy`, `cargo fmt --check`, `git diff bindings/` empty.
- [x] `npm test` (310 pass), `npm run typecheck`, `npm run build`.
- [x] `dist/shell.js` / `dist/preview.js` unchanged; only `dist/remote.js` updated.
- [ ] Real Android device haptic verification (Vibration API requires hardware).

Design record: `docs/plans/2026-07-20-remote-urgency-haptic.md`.