### PR TITLE
Add slide-level Markdown include for splitting decks across files

### DIFF
--- a/crates/peitho-core/src/error.rs
+++ b/crates/peitho-core/src/error.rs
@@ -1,4 +1,8 @@
-use std::{error::Error, fmt};
+use std::{
+    error::Error,
+    fmt,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorKind {
@@ -22,6 +26,7 @@ pub struct ErrorSlide {
 pub struct BuildError {
     pub kind: ErrorKind,
     pub line: Option<usize>,
+    pub origin_file: Option<PathBuf>,
     pub message: String,
     pub help: String,
     pub slide: Option<ErrorSlide>,
@@ -37,10 +42,16 @@ impl BuildError {
         Self {
             kind,
             line,
+            origin_file: None,
             message: message.into(),
             help: help.into(),
             slide: None,
         }
+    }
+
+    pub fn with_origin_file(mut self, path: impl AsRef<Path>) -> Self {
+        self.origin_file = Some(path.as_ref().to_path_buf());
+        self
     }
 
     pub fn with_slide(mut self, number: usize, key: Option<&str>) -> Self {
@@ -54,8 +65,29 @@ impl BuildError {
 
 impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match (&self.slide, self.line) {
-            (Some(slide), Some(line)) => match &slide.key {
+        match (&self.slide, self.line, &self.origin_file) {
+            (Some(slide), Some(line), Some(file)) => match &slide.key {
+                Some(key) => write!(
+                    f,
+                    "{}:{}, slide {} ('{}'): {}\n  = help: {}",
+                    file.display(),
+                    line,
+                    slide.number,
+                    key,
+                    self.message,
+                    self.help
+                ),
+                None => write!(
+                    f,
+                    "{}:{}, slide {}: {}\n  = help: {}",
+                    file.display(),
+                    line,
+                    slide.number,
+                    self.message,
+                    self.help
+                ),
+            },
+            (Some(slide), Some(line), None) => match &slide.key {
                 Some(key) => write!(
                     f,
                     "slide {} ('{}'), line {}: {}\n  = help: {}",
@@ -67,7 +99,7 @@ impl fmt::Display for BuildError {
                     slide.number, line, self.message, self.help
                 ),
             },
-            (Some(slide), None) => match &slide.key {
+            (Some(slide), None, _) => match &slide.key {
                 Some(key) => write!(
                     f,
                     "slide {} ('{}'): {}\n  = help: {}",
@@ -79,12 +111,20 @@ impl fmt::Display for BuildError {
                     slide.number, self.message, self.help
                 ),
             },
-            (None, Some(line)) => write!(
+            (None, Some(line), Some(file)) => write!(
+                f,
+                "{}:{}: {}\n  = help: {}",
+                file.display(),
+                line,
+                self.message,
+                self.help
+            ),
+            (None, Some(line), None) => write!(
                 f,
                 "line {}: {}\n  = help: {}",
                 line, self.message, self.help
             ),
-            (None, None) => write!(f, "{}\n  = help: {}", self.message, self.help),
+            (None, None, _) => write!(f, "{}\n  = help: {}", self.message, self.help),
         }
     }
 }

--- a/crates/peitho-core/src/include.rs
+++ b/crates/peitho-core/src/include.rs
@@ -1,0 +1,1203 @@
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use serde_json::Value;
+
+use crate::{
+    error::{BuildError, ErrorKind},
+    Result,
+};
+
+const MAX_INCLUDE_DEPTH: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpandedSource {
+    pub source: String,
+    pub body_start: usize,
+    pub line_map: LineMap,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineMap {
+    origins: Vec<LineOrigin>,
+}
+
+impl LineMap {
+    pub fn len(&self) -> usize {
+        self.origins.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.origins.is_empty()
+    }
+
+    pub fn translate(&self, line: usize) -> (PathBuf, usize) {
+        if line == 0 {
+            return (PathBuf::new(), line);
+        }
+
+        let mut output_line = 0usize;
+        let mut previous = None;
+        for origin in &self.origins {
+            if origin.original_line == 0 {
+                if output_line + 1 == line && previous.is_none() {
+                    return (origin.file.clone(), 1);
+                }
+                continue;
+            }
+
+            output_line += 1;
+            if output_line == line {
+                return (origin.file.clone(), origin.original_line);
+            }
+            previous = Some(origin);
+        }
+
+        let index = line - 1;
+        if self
+            .origins
+            .get(index)
+            .is_some_and(|origin| origin.original_line == 0)
+        {
+            return self.translate_synthetic_origin(index);
+        }
+
+        (PathBuf::new(), line)
+    }
+
+    pub fn origins(&self) -> &[LineOrigin] {
+        &self.origins
+    }
+
+    fn translate_synthetic_origin(&self, synthetic_index: usize) -> (PathBuf, usize) {
+        let synthetic = &self.origins[synthetic_index];
+        self.origins
+            .get(..synthetic_index)
+            .unwrap_or_default()
+            .iter()
+            .rev()
+            .find(|origin| origin.original_line != 0)
+            .map(|origin| (origin.file.clone(), origin.original_line))
+            .unwrap_or_else(|| (synthetic.file.clone(), 1))
+    }
+
+    fn for_source(source: &str, path: &Path) -> Self {
+        Self {
+            origins: (1..=line_count(source))
+                .map(|line| LineOrigin {
+                    file: path.to_path_buf(),
+                    original_line: line,
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineOrigin {
+    pub file: PathBuf,
+    pub original_line: usize,
+}
+
+pub fn expand_includes(
+    top_source: &str,
+    top_body_start: usize,
+    top_path: &Path,
+) -> Result<ExpandedSource> {
+    let mut stack = vec![path_key(top_path)];
+    let deck_root = include_deck_root(top_path);
+    expand_includes_for_source(top_source, top_body_start, top_path, &deck_root, &mut stack)
+}
+
+fn expand_includes_for_source(
+    source_input: &str,
+    body_start: usize,
+    current_path: &Path,
+    deck_root: &Path,
+    stack: &mut Vec<PathBuf>,
+) -> Result<ExpandedSource> {
+    let regions = scan_slide_regions(source_input, body_start)
+        .map_err(|err| err.with_origin_file(current_path))?;
+    if regions.iter().all(|region| region.includes.is_empty()) {
+        return Ok(ExpandedSource {
+            source: source_input.to_owned(),
+            body_start,
+            line_map: LineMap::for_source(source_input, current_path),
+        });
+    }
+
+    let mut source = String::new();
+    let mut origins = Vec::new();
+    let mut cursor = 0usize;
+    for region in regions.iter().filter(|region| !region.includes.is_empty()) {
+        append_chunk(
+            &mut source,
+            &mut origins,
+            source_input,
+            cursor,
+            region.start,
+            current_path,
+        );
+        // validate_include_region guarantees region.includes.len() == 1 before we reach here.
+        let include = &region.includes[0];
+        validate_include_target(current_path, &include.target, deck_root, include.line)
+            .map_err(|err| err.with_origin_file(current_path))?;
+        let include_path = resolve_include_path(current_path, &include.target);
+        let include_key = path_key(&include_path);
+        if let Some(position) = stack.iter().position(|path| path == &include_key) {
+            return Err(
+                include_cycle_error(include.line, stack, position, &include_key)
+                    .with_origin_file(current_path),
+            );
+        }
+        if stack.len() >= MAX_INCLUDE_DEPTH {
+            return Err(include_depth_error(include.line).with_origin_file(current_path));
+        }
+        let included_source = fs::read_to_string(&include_path).map_err(|err| {
+            include_read_error(&include.target, &include_path, include.line, err)
+                .with_origin_file(current_path)
+        })?;
+        if source_has_no_content(&included_source) {
+            return Err(
+                included_file_has_no_slides_error(&include.target, include.line)
+                    .with_origin_file(current_path),
+            );
+        }
+        if let Some(line) = crate::parser::detect_frontmatter_present(&included_source) {
+            return Err(included_frontmatter_error(line).with_origin_file(&include_path));
+        }
+        stack.push(include_key);
+        let expanded =
+            expand_includes_for_source(&included_source, 0, &include_path, deck_root, stack)?;
+        stack.pop();
+        append_region_leading_newline_if_needed(
+            &mut source,
+            &mut origins,
+            source_input,
+            region.start,
+            &expanded,
+            current_path,
+        );
+        source.push_str(&expanded.source);
+        origins.extend(expanded.line_map.origins);
+        append_separator_boundary_newline_if_needed(
+            &mut source,
+            &mut origins,
+            source_input,
+            region.end,
+            current_path,
+        );
+        cursor = region.end;
+    }
+    append_chunk(
+        &mut source,
+        &mut origins,
+        source_input,
+        cursor,
+        source_input.len(),
+        current_path,
+    );
+    Ok(ExpandedSource {
+        source,
+        body_start,
+        line_map: LineMap { origins },
+    })
+}
+
+fn path_key(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| lexically_normalize(path))
+}
+
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+            Component::RootDir | Component::Prefix(_) => normalized.push(component.as_os_str()),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+fn include_deck_root(top_path: &Path) -> PathBuf {
+    normalize_existing_path_for_include_check(parent_dir_or_dot(top_path))
+}
+
+fn parent_dir_or_dot(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn normalize_existing_path_for_include_check(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| lexically_normalize_preserving_parent(path))
+}
+
+fn lexically_normalize_preserving_parent(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match normalized.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    normalized.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => normalized.push(".."),
+            },
+            Component::Normal(part) => normalized.push(part),
+            Component::RootDir | Component::Prefix(_) => normalized.push(component.as_os_str()),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+fn append_region_leading_newline_if_needed(
+    output: &mut String,
+    origins: &mut Vec<LineOrigin>,
+    source: &str,
+    region_start: usize,
+    replacement: &ExpandedSource,
+    current_path: &Path,
+) {
+    if replacement.source.is_empty() || output.is_empty() || output.ends_with('\n') {
+        return;
+    }
+    if source[region_start..].starts_with('\n') {
+        output.push('\n');
+        origins.push(synthetic_boundary_origin(current_path));
+    }
+}
+
+fn append_separator_boundary_newline_if_needed(
+    output: &mut String,
+    origins: &mut Vec<LineOrigin>,
+    source: &str,
+    next: usize,
+    current_path: &Path,
+) {
+    if output.is_empty() || output.ends_with('\n') {
+        return;
+    }
+    let next_line = source[next..]
+        .split_inclusive('\n')
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('\n')
+        .trim_end_matches('\r');
+    if is_slide_separator(next_line) {
+        output.push('\n');
+        origins.push(synthetic_boundary_origin(current_path));
+    }
+}
+
+fn synthetic_boundary_origin(current_path: &Path) -> LineOrigin {
+    LineOrigin {
+        file: current_path.to_path_buf(),
+        original_line: 0,
+    }
+}
+
+fn include_cycle_error(
+    line: usize,
+    stack: &[PathBuf],
+    cycle_start: usize,
+    target: &Path,
+) -> BuildError {
+    let mut parts = stack[cycle_start..]
+        .iter()
+        .map(|path| path_label(path))
+        .collect::<Vec<_>>();
+    parts.push(path_label(target));
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        format!("include cycle detected: {}", parts.join(" -> ")),
+        "remove one of the include comments in the cycle",
+    )
+}
+
+fn include_depth_error(line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        format!("include chain exceeds max depth of {MAX_INCLUDE_DEPTH}"),
+        "reduce include nesting",
+    )
+}
+
+fn path_label(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn line_count(source: &str) -> usize {
+    source.lines().count()
+}
+
+#[derive(Debug)]
+struct SlideRegion<'a> {
+    start: usize,
+    end: usize,
+    lines: Vec<&'a str>,
+    includes: Vec<IncludeDirective>,
+}
+
+#[derive(Debug)]
+struct IncludeDirective {
+    target: PathBuf,
+    line: usize,
+}
+
+#[derive(Debug)]
+struct SourceLine<'a> {
+    line: &'a str,
+    line_no: usize,
+    start: usize,
+    end: usize,
+}
+
+fn scan_slide_regions(source: &str, body_start: usize) -> Result<Vec<SlideRegion<'_>>> {
+    let mut regions = Vec::new();
+    let mut current = SlideRegion {
+        start: body_start,
+        end: body_start,
+        lines: Vec::new(),
+        includes: Vec::new(),
+    };
+    let mut in_code_fence: Option<(char, usize)> = None;
+
+    for source_line in source_lines_from(source, body_start) {
+        let trimmed = source_line.line.trim_end_matches('\r');
+
+        if in_code_fence.is_none() && source_line.start >= body_start && is_slide_separator(trimmed)
+        {
+            current.end = source_line.start;
+            validate_include_region(&current)?;
+            regions.push(current);
+            current = SlideRegion {
+                start: source_line.end,
+                end: source_line.end,
+                lines: Vec::new(),
+                includes: Vec::new(),
+            };
+            continue;
+        }
+
+        let include = if in_code_fence.is_none() {
+            parse_include_comment(trimmed, source_line.line_no)?
+        } else {
+            None
+        };
+
+        current.lines.push(source_line.line);
+        if let Some(include) = include {
+            current.includes.push(include);
+        }
+
+        if let Some((fence_char, fence_len)) = in_code_fence {
+            if crate::parser::is_closing_code_fence(trimmed, fence_char, fence_len) {
+                in_code_fence = None;
+            }
+        } else if let Some((fence_char, fence_len)) = crate::parser::opening_code_fence(trimmed) {
+            in_code_fence = Some((fence_char, fence_len));
+        }
+    }
+
+    current.end = source.len();
+    validate_include_region(&current)?;
+    regions.push(current);
+    Ok(regions)
+}
+
+fn source_lines_from(source: &str, body_start: usize) -> Vec<SourceLine<'_>> {
+    let mut lines = Vec::new();
+    let mut offset = 0usize;
+    for (index, raw_line) in source.split_inclusive('\n').enumerate() {
+        let start = offset;
+        let end = start + raw_line.len();
+        offset = end;
+        if end <= body_start {
+            continue;
+        }
+        let slice_start = body_start.saturating_sub(start);
+        let line = raw_line[slice_start..]
+            .strip_suffix('\n')
+            .unwrap_or(&raw_line[slice_start..]);
+        lines.push(SourceLine {
+            line,
+            line_no: index + 1,
+            start,
+            end,
+        });
+    }
+    lines
+}
+
+fn validate_include_region(region: &SlideRegion<'_>) -> Result<()> {
+    if region.includes.is_empty() {
+        return Ok(());
+    }
+    let include = &region.includes[0];
+    let significant_lines = region
+        .lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .count();
+    if region.includes.len() != 1 || significant_lines != 1 {
+        return Err(include_container_error(include.line));
+    }
+    Ok(())
+}
+
+fn parse_include_comment(line: &str, line_no: usize) -> Result<Option<IncludeDirective>> {
+    let trimmed = line.trim();
+    let Some(json) = trimmed
+        .strip_prefix("<!--")
+        .and_then(|comment| comment.strip_suffix("-->"))
+        .map(str::trim)
+    else {
+        return Ok(None);
+    };
+    if !json.contains("\"include\"") {
+        return Ok(None);
+    }
+
+    let parsed: Value =
+        serde_json::from_str(json).map_err(|err| invalid_include_comment_error(line_no, err))?;
+    let Value::Object(object) = parsed else {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            Some(line_no),
+            "include comment must be a JSON object",
+            r#"use <!-- {"include":"path/to/slides.md"} -->"#,
+        ));
+    };
+    if !object.contains_key("include") {
+        return Ok(None);
+    }
+    if object.len() != 1 {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            Some(line_no),
+            "include comment accepts only include",
+            r#"use <!-- {"include":"path/to/slides.md"} --> on a slide with no other settings"#,
+        ));
+    }
+    let Some(include) = object.get("include").and_then(Value::as_str) else {
+        return Err(include_value_error(line_no));
+    };
+    if include.trim().is_empty() {
+        return Err(include_value_error(line_no));
+    }
+    Ok(Some(IncludeDirective {
+        target: PathBuf::from(include),
+        line: line_no,
+    }))
+}
+
+fn include_value_error(line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        "include value must be a non-empty string",
+        r#"set "include" to a deck-relative Markdown file path"#,
+    )
+}
+
+fn invalid_include_comment_error(line: usize, err: serde_json::Error) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        format!("invalid include comment: {err}"),
+        r#"use <!-- {"include":"path/to/slides.md"} -->"#,
+    )
+}
+
+fn include_container_error(line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        "include comment must be the only content of its slide",
+        "place the include comment in its own slide bounded by `---`",
+    )
+}
+
+fn resolve_include_path(current_path: &Path, target: &Path) -> PathBuf {
+    parent_dir_or_dot(current_path).join(target)
+}
+
+fn validate_include_target(
+    current_path: &Path,
+    target: &Path,
+    deck_root: &Path,
+    line: usize,
+) -> Result<()> {
+    if target.is_absolute() {
+        return Err(absolute_include_path_error(line));
+    }
+
+    let current_dir = normalize_existing_path_for_include_check(parent_dir_or_dot(current_path));
+    let resolved = lexically_normalize_preserving_parent(&current_dir.join(target));
+    if !resolved.starts_with(deck_root) {
+        return Err(escaping_include_path_error(line));
+    }
+    Ok(())
+}
+
+fn absolute_include_path_error(line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        "include path must be deck-relative, not absolute",
+        "use a path relative to the including file (e.g. `shared/intro.md`)",
+    )
+}
+
+fn escaping_include_path_error(line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        "include path must not escape the deck directory",
+        "keep includes within the deck's directory or a subdirectory",
+    )
+}
+
+fn include_read_error(
+    target: &Path,
+    resolved: &Path,
+    line: usize,
+    err: std::io::Error,
+) -> BuildError {
+    match err.kind() {
+        std::io::ErrorKind::NotFound => BuildError::new(
+            ErrorKind::Parse,
+            Some(line),
+            format!("include file not found: {}", target.display()),
+            "create the included file or fix the include path",
+        ),
+        std::io::ErrorKind::IsADirectory => include_directory_error(target, line),
+        _ if resolved.is_dir() => include_directory_error(target, line),
+        _ => BuildError::new(
+            ErrorKind::Parse,
+            Some(line),
+            format!("failed to read include file {}: {err}", target.display()),
+            "make the included file readable or fix the include path",
+        ),
+    }
+}
+
+fn include_directory_error(target: &Path, line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        format!(
+            "include target is a directory, not a file: {}",
+            target.display()
+        ),
+        "point include at a Markdown file, not a directory",
+    )
+}
+
+fn included_file_has_no_slides_error(target: &Path, line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        format!("included file has no slides: {}", target.display()),
+        "add at least one slide to the included file or remove the include comment",
+    )
+}
+
+fn included_frontmatter_error(line: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        "included file has frontmatter, which is not supported",
+        "move frontmatter to the top-level deck; included files may only contain slides",
+    )
+}
+
+fn append_chunk(
+    output: &mut String,
+    origins: &mut Vec<LineOrigin>,
+    source: &str,
+    start: usize,
+    end: usize,
+    path: &Path,
+) {
+    if start == end {
+        return;
+    }
+    let chunk = &source[start..end];
+    let first_line = crate::parser::line_for_offset(source, start);
+    output.push_str(chunk);
+    origins.extend((0..line_count(chunk)).map(|index| LineOrigin {
+        file: path.to_path_buf(),
+        original_line: first_line + index,
+    }));
+}
+
+fn is_slide_separator(line: &str) -> bool {
+    line.trim() == "---"
+}
+
+fn source_has_no_content(source: &str) -> bool {
+    source
+        .strip_prefix('\u{feff}')
+        .unwrap_or(source)
+        .trim()
+        .is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use crate::domain::{FragmentKind, SlotName};
+
+    use super::*;
+
+    #[test]
+    fn expand_includes_returns_source_unchanged_when_no_include_comment_is_present() {
+        let source = "---\ntime: 1m\n---\n# Intro\n\nBody\n";
+        let expanded = expand_includes(source, 17, Path::new("deck.md")).unwrap();
+
+        assert_eq!(expanded.source, source);
+        assert_eq!(expanded.body_start, 17);
+        assert_eq!(expanded.line_map.len(), source.lines().count());
+        assert_eq!(
+            expanded.line_map.translate(4),
+            (Path::new("deck.md").to_path_buf(), 4)
+        );
+    }
+
+    #[test]
+    fn include_comment_with_sibling_heading_is_an_error() {
+        let source = "# Container\n\n<!-- {\"include\":\"shared.md\"} -->\n";
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(3));
+        assert!(err
+            .message
+            .contains("include comment must be the only content of its slide"));
+        assert!(err
+            .help
+            .contains("place the include comment in its own slide"));
+    }
+
+    #[test]
+    fn include_comment_with_sibling_page_settings_comment_is_an_error() {
+        let source = "<!-- {\"key\":\"container\"} -->\n<!-- {\"include\":\"shared.md\"} -->\n";
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(2));
+        assert!(err
+            .message
+            .contains("include comment must be the only content of its slide"));
+    }
+
+    #[test]
+    fn include_comment_with_sibling_speaker_note_is_an_error() {
+        let source = "<!-- presenter note -->\n<!-- {\"include\":\"shared.md\"} -->\n";
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(2));
+        assert!(err
+            .message
+            .contains("include comment must be the only content of its slide"));
+    }
+
+    #[test]
+    fn two_include_comments_in_the_same_slide_are_an_error() {
+        let source = "<!-- {\"include\":\"a.md\"} -->\n<!-- {\"include\":\"b.md\"} -->\n";
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert!(err
+            .message
+            .contains("include comment must be the only content of its slide"));
+    }
+
+    #[test]
+    fn include_comment_rejects_page_settings_keys_on_the_same_comment() {
+        for (name, extra) in [
+            ("draft", r#""draft":true"#),
+            ("skip", r#""skip":true"#),
+            ("section", r#""section":"Intro","time":"1m""#),
+            ("layout", r#""layout":"cover""#),
+            ("key", r#""key":"intro""#),
+            ("page_number", r#""page_number":false"#),
+        ] {
+            let source = format!(r#"<!-- {{"include":"shared.md",{extra}}} -->"#);
+            let err = expand_includes(&source, 0, Path::new("deck.md")).unwrap_err();
+
+            assert_eq!(err.line, Some(1), "{name}");
+            assert!(
+                err.message.contains("include comment accepts only include"),
+                "{name}: {}",
+                err.message
+            );
+        }
+    }
+
+    #[test]
+    fn include_comment_rejects_non_string_include_value() {
+        let source = r#"<!-- {"include":42} -->"#;
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert!(err
+            .message
+            .contains("include value must be a non-empty string"));
+    }
+
+    #[test]
+    fn include_comment_rejects_empty_include_value() {
+        let source = r#"<!-- {"include":""} -->"#;
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert!(err
+            .message
+            .contains("include value must be a non-empty string"));
+    }
+
+    #[test]
+    fn include_comment_rejects_invalid_json() {
+        let source = r#"<!-- {"include":} -->"#;
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert!(err.message.contains("invalid include comment"));
+    }
+
+    #[test]
+    fn include_comment_inside_fenced_code_block_is_preserved() {
+        let source =
+            "```markdown\n<!-- {\"include\":\"shared.md\",\"layout\":\"cover\"} -->\n```\n";
+        let expanded = expand_includes(source, 0, Path::new("deck.md")).unwrap();
+
+        assert_eq!(expanded.source, source);
+    }
+
+    #[test]
+    fn malformed_non_include_page_comment_is_left_for_the_parser() {
+        let source = r#"<!-- {"key":} -->"#;
+        let expanded = expand_includes(source, 0, Path::new("deck.md")).unwrap();
+
+        assert_eq!(expanded.source, source);
+    }
+
+    #[test]
+    fn missing_include_target_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let source = "# Before\n\n---\n<!-- {\"include\":\"missing.md\"} -->\n---\n# After\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(4));
+        assert!(err.message.contains("include file not found"));
+        assert!(err.message.contains("missing.md"));
+    }
+
+    #[test]
+    fn directory_include_target_is_a_friendly_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::create_dir(dir.path().join("shared")).unwrap();
+        let source = "<!-- {\"include\":\"shared\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert_eq!(err.origin_file, Some(deck));
+        assert_eq!(
+            err.message,
+            "include target is a directory, not a file: shared"
+        );
+        assert_eq!(
+            err.help,
+            "point include at a Markdown file, not a directory"
+        );
+    }
+
+    #[test]
+    fn included_file_with_frontmatter_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "---\ntime: 1m\n---\n# Included\n",
+        )
+        .unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert_eq!(
+            err.message,
+            "included file has frontmatter, which is not supported"
+        );
+        assert!(err.help.contains("move frontmatter to the top-level deck"));
+    }
+
+    #[test]
+    fn included_file_with_malformed_frontmatter_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(dir.path().join("shared.md"), "---\ntime: 1m").unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert_eq!(err.origin_file, Some(dir.path().join("shared.md")));
+        assert_eq!(
+            err.message,
+            "included file has frontmatter, which is not supported"
+        );
+    }
+
+    #[test]
+    fn empty_included_file_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(dir.path().join("shared.md"), " \n\t\n").unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(4));
+        assert_eq!(err.origin_file, Some(deck));
+        assert_eq!(err.message, "included file has no slides: shared.md");
+        assert!(err.help.contains("add at least one slide"));
+    }
+
+    #[test]
+    fn absolute_include_target_is_a_line_numbered_error() {
+        let source = "# Before\n\n---\n<!-- {\"include\":\"/etc/passwd\"} -->\n";
+
+        let err = expand_includes(source, 0, Path::new("deck.md")).unwrap_err();
+
+        assert_eq!(err.line, Some(4));
+        assert_eq!(err.origin_file, Some(Path::new("deck.md").to_path_buf()));
+        assert_eq!(
+            err.message,
+            "include path must be deck-relative, not absolute"
+        );
+        assert_eq!(
+            err.help,
+            "use a path relative to the including file (e.g. `shared/intro.md`)"
+        );
+    }
+
+    #[test]
+    fn parent_directory_include_escape_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck_dir = dir.path().join("dir");
+        fs::create_dir(&deck_dir).unwrap();
+        let deck = deck_dir.join("deck.md");
+        fs::write(dir.path().join("secret.md"), "# Secret\n").unwrap();
+        let source = "<!-- {\"include\":\"../secret.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert_eq!(err.origin_file, Some(deck));
+        assert_eq!(
+            err.message,
+            "include path must not escape the deck directory"
+        );
+        assert_eq!(
+            err.help,
+            "keep includes within the deck's directory or a subdirectory"
+        );
+    }
+
+    #[test]
+    fn subdirectory_include_under_deck_root_is_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let subdir = dir.path().join("subdir");
+        fs::create_dir(&subdir).unwrap();
+        fs::write(subdir.join("foo.md"), "# Included\n").unwrap();
+        let source = "<!-- {\"include\":\"subdir/foo.md\"} -->\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+
+        assert_eq!(expanded.source, "# Included\n");
+        assert_eq!(
+            expanded.line_map.translate(1),
+            (dir.path().join("subdir/foo.md"), 1)
+        );
+    }
+
+    #[test]
+    fn nested_parent_directory_include_escape_uses_top_deck_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck_dir = dir.path().join("dir");
+        fs::create_dir(&deck_dir).unwrap();
+        let deck = deck_dir.join("deck.md");
+        let included = deck_dir.join("a.md");
+        fs::write(&included, "<!-- {\"include\":\"../B.md\"} -->\n").unwrap();
+        fs::write(dir.path().join("B.md"), "# B\n").unwrap();
+        let source = "<!-- {\"include\":\"a.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert_eq!(err.origin_file, Some(included));
+        assert_eq!(
+            err.message,
+            "include path must not escape the deck directory"
+        );
+        assert_eq!(
+            err.help,
+            "keep includes within the deck's directory or a subdirectory"
+        );
+    }
+
+    #[test]
+    fn single_file_include_splices_slides_and_removes_container_slide() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let included = dir.path().join("shared.md");
+        fs::write(
+            &included,
+            "# Included One\n\n---\n<!-- {\"section\":\"Shared\",\"time\":\"1m\"} -->\n# Included Two\n",
+        )
+        .unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+
+        assert_eq!(
+            expanded.source,
+            "# Before\n\n---\n# Included One\n\n---\n<!-- {\"section\":\"Shared\",\"time\":\"1m\"} -->\n# Included Two\n---\n# After\n"
+        );
+        assert_eq!(
+            expanded.line_map.translate(4),
+            (included.clone(), 1),
+            "included slide should retain its source file line"
+        );
+    }
+
+    #[test]
+    fn include_without_trailing_newline_keeps_following_separator_on_new_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(dir.path().join("shared.md"), "# Included").unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+
+        assert_eq!(
+            expanded.source,
+            "# Before\n\n---\n# Included\n---\n# After\n"
+        );
+        assert_eq!(expanded.line_map.translate(6), (deck, 6));
+    }
+
+    #[test]
+    fn include_after_top_frontmatter_keeps_frontmatter_separator_on_its_own_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(dir.path().join("shared.md"), "# Included\n").unwrap();
+        let source = "---\ntime: 1m\n---\n<!-- {\"include\":\"shared.md\"} -->\n";
+        let frontmatter = crate::parser::parse_frontmatter(source).unwrap();
+
+        let expanded = expand_includes(source, frontmatter.body_start(), &deck).unwrap();
+
+        assert_eq!(expanded.source, "---\ntime: 1m\n---\n# Included\n");
+        assert_eq!(
+            expanded.line_map.translate(4),
+            (dir.path().join("shared.md"), 1)
+        );
+        assert!(expanded
+            .line_map
+            .origins
+            .iter()
+            .any(|origin| origin.file == deck && origin.original_line == 0));
+    }
+
+    #[test]
+    fn expanded_source_with_included_section_marker_parses_as_one_deck() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "<!-- {\"section\":\"Shared\",\"time\":\"1m\"} -->\n# Included\n",
+        )
+        .unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 2);
+        assert_eq!(parsed.settings().sections()[0].name(), "Shared");
+        assert_eq!(parsed.settings().sections()[0].start(), 0);
+        assert_eq!(parsed.settings().sections()[0].end(), 1);
+    }
+
+    #[test]
+    fn included_explicit_body_slot_survives_expand_parse_and_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included title\n\n::: {slot=body}\n\nIncluded body content\n\n:::\n",
+        )
+        .unwrap();
+        let source = "# Deck slide\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n";
+        let top_frontmatter = crate::parser::parse_frontmatter(source).unwrap();
+
+        let expanded = expand_includes(source, top_frontmatter.body_start(), &deck).unwrap();
+
+        assert_eq!(
+            expanded.source,
+            "# Deck slide\n\n---\n# Included title\n\n::: {slot=body}\n\nIncluded body content\n\n:::\n"
+        );
+
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 2);
+        let included = &parsed.parsed_slides()[1];
+        let slot_group = included
+            .fragments
+            .iter()
+            .find(|fragment| matches!(fragment.kind(), FragmentKind::SlotGroup { .. }))
+            .expect("included slide should keep its explicit slot group");
+        let FragmentKind::SlotGroup { name, children } = slot_group.kind() else {
+            unreachable!();
+        };
+        assert_eq!(name.as_slot_name().as_str(), "body");
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].kind(), &FragmentKind::Paragraph);
+        assert_eq!(children[0].markdown(), "Included body content");
+
+        let layout = crate::layout::parse_layout(
+            "title-body",
+            r#"<section>
+                <slot name="title" accepts="inline" arity="1"></slot>
+                <slot name="body" accepts="blocks" arity="0..*"></slot>
+            </section>"#,
+        )
+        .unwrap();
+        let mapped = crate::mapping::map_by_convention(parsed, &layout).unwrap();
+        let body_slot = SlotName::new("body").unwrap();
+        let body_fragments = mapped.mapped_slides()[1].slots[&body_slot].fragments();
+
+        assert_eq!(body_fragments.len(), 1);
+        assert_eq!(body_fragments[0].kind(), &FragmentKind::Paragraph);
+        assert_eq!(body_fragments[0].markdown(), "Included body content");
+    }
+
+    #[test]
+    fn nested_include_chain_splices_all_slides_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("a.md"),
+            "# A\n\n---\n<!-- {\"include\":\"b.md\"} -->\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b.md"),
+            "# B\n\n---\n<!-- {\"include\":\"c.md\"} -->\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("c.md"), "# C\n").unwrap();
+        let source = "<!-- {\"include\":\"a.md\"} -->\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+
+        assert_eq!(expanded.source, "# A\n\n---\n# B\n\n---\n# C\n");
+        assert_eq!(expanded.line_map.translate(7), (dir.path().join("c.md"), 1));
+    }
+
+    #[test]
+    fn acyclic_include_chain_over_max_depth_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        for index in 1..=70 {
+            let path = dir.path().join(format!("{index}.md"));
+            let source = if index == 70 {
+                "# Leaf\n".to_owned()
+            } else {
+                format!("\n<!-- {{\"include\":\"{}.md\"}} -->\n", index + 1)
+            };
+            fs::write(path, source).unwrap();
+        }
+        let source = "\n<!-- {\"include\":\"1.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(2));
+        assert_eq!(err.message, "include chain exceeds max depth of 64");
+        assert_eq!(err.help, "reduce include nesting");
+    }
+
+    #[test]
+    fn self_include_cycle_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "<!-- {\"include\":\"shared.md\"} -->\n",
+        )
+        .unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert!(err.message.contains("include cycle detected"));
+        assert!(err.message.contains("shared.md -> shared.md"));
+    }
+
+    #[test]
+    fn multi_file_include_cycle_is_a_line_numbered_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(dir.path().join("a.md"), "<!-- {\"include\":\"b.md\"} -->\n").unwrap();
+        fs::write(dir.path().join("b.md"), "<!-- {\"include\":\"a.md\"} -->\n").unwrap();
+        let source = "<!-- {\"include\":\"a.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(1));
+        assert!(err.message.contains("include cycle detected"));
+        assert!(err.message.contains("a.md -> b.md -> a.md"));
+    }
+}

--- a/crates/peitho-core/src/lib.rs
+++ b/crates/peitho-core/src/lib.rs
@@ -1,8 +1,11 @@
+#![allow(clippy::result_large_err)]
+
 pub mod check;
 pub mod code_images;
 pub mod domain;
 pub mod error;
 pub mod highlight;
+pub mod include;
 mod json;
 pub mod layout;
 pub mod manifest;

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -360,6 +360,7 @@ struct RawFrontmatter {
     yaml: String,
 }
 
+#[derive(Clone)]
 pub struct ParsedFrontmatter {
     settings: DeckSettings,
     pub(crate) body_start: usize,
@@ -373,6 +374,10 @@ impl ParsedFrontmatter {
 
     pub fn key_line(&self, key: &str) -> Option<usize> {
         self.key_lines.get(key).copied()
+    }
+
+    pub fn body_start(&self) -> usize {
+        self.body_start
     }
 }
 
@@ -390,6 +395,23 @@ pub fn parse_frontmatter(source: &str) -> Result<ParsedFrontmatter> {
         body_start,
         key_lines,
     })
+}
+
+pub(crate) fn detect_frontmatter_present(source: &str) -> Option<usize> {
+    let source = source.strip_prefix('\u{feff}').unwrap_or(source);
+    match leading_frontmatter(source) {
+        Ok((Some(raw), _)) => Some(raw.line),
+        Ok((None, _)) => leading_frontmatter_start_line(source),
+        Err(err) => leading_frontmatter_start_line(source)
+            .or(err.line)
+            .or(Some(1)),
+    }
+}
+
+fn leading_frontmatter_start_line(source: &str) -> Option<usize> {
+    first_nonblank_source_line(source)
+        .filter(|(_, line)| line.trim() == "---")
+        .map(|(offset, _)| line_for_offset(source, offset))
 }
 
 pub(crate) fn parse_markdown(
@@ -1380,7 +1402,7 @@ fn scan_slot_div_markers(
 /// Extract the leading fence character (`\`` or `~`) and its length, if this
 /// line opens a code fence. Only fences of three or more of the same character
 /// count, matching pulldown-cmark semantics.
-fn opening_code_fence(line: &str) -> Option<(char, usize)> {
+pub(crate) fn opening_code_fence(line: &str) -> Option<(char, usize)> {
     let trimmed = line.trim_start();
     let ch = trimmed.chars().next()?;
     if ch != '`' && ch != '~' {
@@ -1395,7 +1417,7 @@ fn opening_code_fence(line: &str) -> Option<(char, usize)> {
 }
 
 /// A closing fence must be the same character and at least as long.
-fn is_closing_code_fence(line: &str, ch: char, min_len: usize) -> bool {
+pub(crate) fn is_closing_code_fence(line: &str, ch: char, min_len: usize) -> bool {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return false;
@@ -2344,6 +2366,18 @@ fn parse_page_comment(raw: &str, line: usize) -> Result<Option<PageSettings>> {
     if !json.starts_with('{') {
         return Ok(None);
     }
+    if serde_json::from_str::<serde_json::Value>(json).is_ok_and(|value| {
+        value
+            .as_object()
+            .is_some_and(|object| object.contains_key("include"))
+    }) {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            Some(line),
+            "include comment must be the only content of its slide",
+            "place the include comment in its own slide bounded by `---`",
+        ));
+    }
     let parsed: PageComment = serde_json::from_str(json).map_err(|err| {
         BuildError::new(
             ErrorKind::Parse,
@@ -2463,7 +2497,7 @@ fn is_html_comment(raw: &str) -> bool {
     trimmed.starts_with("<!--") && trimmed.ends_with("-->")
 }
 
-fn line_for_offset(source: &str, offset: usize) -> usize {
+pub(crate) fn line_for_offset(source: &str, offset: usize) -> usize {
     source[..offset]
         .bytes()
         .filter(|byte| *byte == b'\n')
@@ -4421,6 +4455,20 @@ After list
         assert_eq!(section.line, 7);
         assert_eq!(settings.layout.as_deref(), Some("cover"));
         assert_eq!(settings.key.unwrap().as_str(), "cover");
+    }
+
+    #[test]
+    fn parse_page_comment_rejects_include_key_if_it_reaches_the_parser() {
+        let err = parse_page_comment(r#"<!-- {"include":"shared.md"} -->"#, 7).unwrap_err();
+
+        assert_eq!(err.line, Some(7));
+        assert_eq!(
+            err.message,
+            "include comment must be the only content of its slide"
+        );
+        assert!(err
+            .help
+            .contains("place the include comment in its own slide"));
     }
 
     #[test]

--- a/crates/peitho-core/tests/code_images.rs
+++ b/crates/peitho-core/tests/code_images.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use std::fs;
 
 use peitho_core::{

--- a/crates/peitho/src/doctor.rs
+++ b/crates/peitho/src/doctor.rs
@@ -443,34 +443,23 @@ fn shell_check(name: &'static str, source: &str) -> DoctorCheck {
 }
 
 fn push_asset_checks(checks: &mut Vec<DoctorCheck>, deck: &Path) {
-    let markdown = match fs::read_to_string(deck) {
-        Ok(markdown) => markdown,
+    let loaded = match crate::load_and_expand_deck_source(deck) {
+        Ok(loaded) => loaded,
         Err(err) => {
             checks.push(DoctorCheck {
                 category: DoctorCategory::Assets,
                 name: "deck",
                 status: DoctorStatus::Fail,
-                message: format!("failed to read {}: {err}", deck.display()),
-                help: Some("pass the deck path explicitly if it lives elsewhere".to_owned()),
+                message: err.to_string(),
+                help: Some("fix the deck source before checking assets".to_owned()),
                 details: Some(serde_json::json!({ "path": deck.display().to_string() })),
             });
             return;
         }
     };
-    let frontmatter = match peitho_core::parse_frontmatter(&markdown) {
-        Ok(frontmatter) => frontmatter,
-        Err(err) => {
-            checks.push(asset_error_check(
-                "frontmatter",
-                err,
-                Some(serde_json::json!({ "path": deck.display().to_string() })),
-            ));
-            return;
-        }
-    };
 
     for key in AssetKey::ALL {
-        match asset_resolution::resolve_asset(deck, &frontmatter, key) {
+        match asset_resolution::resolve_asset(deck, &loaded.frontmatter, key) {
             Ok(provenance) => checks.push(asset_pass_check(key, provenance)),
             Err(err) => {
                 checks.push(asset_error_check(key.as_str(), err, None));
@@ -1065,6 +1054,7 @@ mod tests {
             peitho_core::error::BuildError {
                 kind: peitho_core::error::ErrorKind::Parse,
                 line: None,
+                origin_file: None,
                 message: "css path is invalid".to_owned(),
                 help: String::new(),
                 slide: None,

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use std::{
     collections::{BTreeMap, HashSet},
     env,
@@ -38,6 +40,33 @@ struct BuildArtifacts {
     manifest_json: String,
     image_assets: Vec<peitho_core::ResolvedImageAsset>,
     fonts_source: Option<PathBuf>,
+}
+
+pub(crate) struct LoadedDeckSource {
+    pub(crate) deck_path: PathBuf,
+    pub(crate) source: String,
+    pub(crate) frontmatter: peitho_core::ParsedFrontmatter,
+    pub(crate) line_map: peitho_core::include::LineMap,
+}
+
+impl LoadedDeckSource {
+    pub(crate) fn translate<T>(&self, result: peitho_core::Result<T>) -> miette::Result<T> {
+        core_for_deck(result, &self.deck_path, Some(&self.line_map))
+    }
+
+    pub(crate) fn included_files(&self) -> Vec<PathBuf> {
+        let mut files: Vec<PathBuf> = Vec::new();
+        for origin in self.line_map.origins() {
+            if same_watch_path(&origin.file, &self.deck_path) {
+                continue;
+            }
+            if files.iter().any(|path| same_watch_path(path, &origin.file)) {
+                continue;
+            }
+            files.push(origin.file.clone());
+        }
+        files
+    }
 }
 
 struct CliSvgRunner {
@@ -89,6 +118,7 @@ struct WatchRoot {
 struct WatchTargets {
     roots: Vec<WatchRoot>,
     assets: ResolvedAssets,
+    included_files: Vec<PathBuf>,
 }
 
 struct WatchState {
@@ -155,6 +185,15 @@ impl WatchState {
         write_suppressed_watch_note(&key, &note, stderr, &mut self.emitted_watch_error_notes)?;
         Ok(())
     }
+
+    fn is_source_change(&self, changed: &Path) -> bool {
+        same_watch_path(&self.input, changed)
+            || self
+                .targets
+                .included_files
+                .iter()
+                .any(|path| same_watch_path(path, changed))
+    }
 }
 
 struct WatchRuntime {
@@ -166,11 +205,15 @@ struct WatchRuntime {
 impl WatchTargets {
     /// The deck file plus the resolved asset paths. Each asset path may be a
     /// single file or a directory whose matching extension files are watched.
-    fn new(input: PathBuf, assets: ResolvedAssets) -> Self {
+    fn new(input: PathBuf, assets: ResolvedAssets, included_files: Vec<PathBuf>) -> Self {
         let mut roots = vec![WatchRoot {
-            path: input,
+            path: input.clone(),
             ext: Some("md"),
         }];
+        roots.extend(included_files.iter().cloned().map(|path| WatchRoot {
+            path,
+            ext: Some("md"),
+        }));
         if let Some(path) = assets.layouts.path() {
             roots.push(WatchRoot {
                 path: path.to_path_buf(),
@@ -195,7 +238,11 @@ impl WatchTargets {
                 ext: None,
             });
         }
-        Self { roots, assets }
+        Self {
+            roots,
+            assets,
+            included_files,
+        }
     }
 
     fn is_relevant_change(&self, changed: &Path) -> bool {
@@ -621,14 +668,8 @@ fn export_pdf(input: PathBuf, out: Option<PathBuf>) -> miette::Result<()> {
 }
 
 fn cmd_layouts(input: PathBuf, explain: Option<String>, json: bool) -> miette::Result<()> {
-    let markdown = fs::read_to_string(&input).map_err(|err| {
-        miette::miette!(
-            "failed to read {}\nhelp: the deck argument defaults to deck.md in the current directory when omitted; pass the deck path explicitly if it lives elsewhere\ncaused by: {err}",
-            input.display()
-        )
-    })?;
-    let frontmatter = core(peitho_core::parse_frontmatter(&markdown))?;
-    let assets = resolve_assets(&input, &frontmatter)?;
+    let loaded = load_and_expand_deck_source(&input)?;
+    let assets = resolve_assets(&input, &loaded.frontmatter)?;
     let layouts = load_layouts(assets.layouts.path())?;
 
     let Some(key) = explain else {
@@ -641,9 +682,9 @@ fn cmd_layouts(input: PathBuf, explain: Option<String>, json: bool) -> miette::R
     };
 
     let highlighter = load_highlighter(assets.syntaxes.path())?;
-    let parsed = core(peitho_core::code_images::parse_deck_and_transform(
-        &markdown,
-        frontmatter,
+    let parsed = loaded.translate(peitho_core::code_images::parse_deck_and_transform(
+        &loaded.source,
+        loaded.frontmatter.clone(),
         &highlighter,
         &CliSvgRunner::for_deck(&input),
         &code_images_cache_dir(&input),
@@ -1071,9 +1112,9 @@ where
     if relevant
         && changed_paths
             .iter()
-            .any(|changed| same_watch_path(&state.input, changed))
+            .any(|changed| state.is_source_change(changed))
     {
-        refresh_watch_targets_after_deck_change(state, stderr)?;
+        refresh_watch_targets_after_source_change(state, stderr)?;
     }
 
     let watch_set_changed = state.reconcile_after_events(watcher, stderr)?;
@@ -1193,8 +1234,13 @@ where
 }
 
 fn resolve_watch_targets(input: &Path) -> miette::Result<WatchTargets> {
-    let assets = resolve_deck_assets(input)?;
-    Ok(WatchTargets::new(input.to_path_buf(), assets))
+    let loaded = load_and_expand_deck_source(input)?;
+    let assets = resolve_assets(input, &loaded.frontmatter)?;
+    Ok(WatchTargets::new(
+        input.to_path_buf(),
+        assets,
+        loaded.included_files(),
+    ))
 }
 
 fn resolve_watch_targets_or_deck_only(input: &Path) -> WatchTargets {
@@ -1210,29 +1256,31 @@ fn deck_only_watch_targets(input: &Path) -> WatchTargets {
             syntaxes: Provenance::Builtin,
             fonts: Provenance::Builtin,
         },
+        Vec::new(),
     )
 }
 
-fn resolve_deck_assets(input: &Path) -> miette::Result<ResolvedAssets> {
-    let markdown = fs::read_to_string(input).into_diagnostic()?;
-    let frontmatter = core(peitho_core::parse_frontmatter(&markdown))?;
-    resolve_assets(input, &frontmatter)
-}
-
-fn refresh_watch_targets_after_deck_change(
+fn refresh_watch_targets_after_source_change(
     state: &mut WatchState,
     stderr: &mut dyn Write,
 ) -> miette::Result<()> {
-    let current_assets = match resolve_deck_assets(&state.input) {
-        Ok(assets) => assets,
+    let current_targets = match resolve_watch_targets(&state.input) {
+        Ok(targets) => targets,
         Err(_) => {
             return Ok(());
         }
     };
-    let paths_changed = resolved_asset_paths_changed(&state.targets.assets, &current_assets);
-    let next_targets = WatchTargets::new(state.input.clone(), current_assets);
-    state.targets = next_targets;
-    if !paths_changed {
+    let asset_paths_changed =
+        resolved_asset_paths_changed(&state.targets.assets, &current_targets.assets);
+    let include_paths_changed = path_lists_changed(
+        &state.targets.included_files,
+        &current_targets.included_files,
+    );
+    state.targets = current_targets;
+    if !asset_paths_changed && !include_paths_changed {
+        return Ok(());
+    }
+    if !asset_paths_changed {
         return Ok(());
     }
     writeln!(
@@ -1250,6 +1298,14 @@ fn resolved_asset_paths_changed(old: &ResolvedAssets, new: &ResolvedAssets) -> b
         || old.css.path() != new.css.path()
         || old.syntaxes.path() != new.syntaxes.path()
         || old.fonts.path() != new.fonts.path()
+}
+
+fn path_lists_changed(old: &[PathBuf], new: &[PathBuf]) -> bool {
+    old.len() != new.len()
+        || old
+            .iter()
+            .zip(new)
+            .any(|(old_path, new_path)| !same_watch_path(old_path, new_path))
 }
 
 fn watch_all_dirs(watcher: &mut dyn WatchController, dirs: &[PathBuf]) -> miette::Result<()> {
@@ -1475,26 +1531,20 @@ fn load_css(css_path: Option<&Path>) -> miette::Result<Vec<peitho_core::CssFile>
 }
 
 fn build_artifacts(input: &Path) -> miette::Result<BuildArtifacts> {
-    let markdown = fs::read_to_string(input).map_err(|err| {
-        miette::miette!(
-            "failed to read {}\nhelp: the deck argument defaults to deck.md in the current directory when omitted; pass the deck path explicitly if it lives elsewhere\ncaused by: {err}",
-            input.display()
-        )
-    })?;
-    let frontmatter = core(peitho_core::parse_frontmatter(&markdown))?;
-    let assets = resolve_assets(input, &frontmatter)?;
+    let loaded = load_and_expand_deck_source(input)?;
+    let assets = resolve_assets(input, &loaded.frontmatter)?;
     let highlighter = load_highlighter(assets.syntaxes.path())?;
     let layouts = load_layouts(assets.layouts.path())?;
     let css_files = load_css(assets.css.path())?;
-    let parsed = core(peitho_core::code_images::parse_deck_and_transform(
-        &markdown,
-        frontmatter,
+    let parsed = loaded.translate(peitho_core::code_images::parse_deck_and_transform(
+        &loaded.source,
+        loaded.frontmatter.clone(),
         &highlighter,
         &CliSvgRunner::for_deck(input),
         &code_images_cache_dir(input),
     ))?;
-    let mapped = core(peitho_core::dispatch_by_convention(parsed, &layouts))?;
-    let checked = core(peitho_core::check_deck(mapped))?;
+    let mapped = loaded.translate(peitho_core::dispatch_by_convention(parsed, &layouts))?;
+    let checked = loaded.translate(peitho_core::check_deck(mapped))?;
     let slide_count = checked.slide_count();
     let theme_css = core(peitho_core::build_theme_css(
         &css_files,
@@ -1503,12 +1553,13 @@ fn build_artifacts(input: &Path) -> miette::Result<BuildArtifacts> {
         &layouts.root_classes(),
     ))?;
     let mut image_resolver = ImageResolver::new(input);
-    let (resolved, image_assets) = core(peitho_core::resolve_image_paths(checked, |request| {
-        image_resolver.resolve(request)
-    }))?;
+    let (resolved, image_assets) = loaded
+        .translate(peitho_core::resolve_image_paths(checked, |request| {
+            image_resolver.resolve(request)
+        }))?;
     let manifest = peitho_core::build_manifest(&resolved, &image_assets);
     let manifest_json = core(peitho_core::manifest_json(&manifest))?;
-    let rendered = core(peitho_core::render_deck(resolved, &highlighter, theme_css))?;
+    let rendered = loaded.translate(peitho_core::render_deck(resolved, &highlighter, theme_css))?;
 
     Ok(BuildArtifacts {
         slide_count,
@@ -1516,6 +1567,31 @@ fn build_artifacts(input: &Path) -> miette::Result<BuildArtifacts> {
         manifest_json,
         image_assets,
         fonts_source: assets.fonts.path().map(Path::to_path_buf),
+    })
+}
+
+pub(crate) fn load_and_expand_deck_source(input: &Path) -> miette::Result<LoadedDeckSource> {
+    let markdown = read_deck_source(input)?;
+    let frontmatter = core_for_deck(peitho_core::parse_frontmatter(&markdown), input, None)?;
+    let expanded = core_for_deck(
+        peitho_core::include::expand_includes(&markdown, frontmatter.body_start(), input),
+        input,
+        None,
+    )?;
+    Ok(LoadedDeckSource {
+        deck_path: input.to_path_buf(),
+        source: expanded.source,
+        frontmatter,
+        line_map: expanded.line_map,
+    })
+}
+
+fn read_deck_source(input: &Path) -> miette::Result<String> {
+    fs::read_to_string(input).map_err(|err| {
+        miette::miette!(
+            "failed to read {}\nhelp: the deck argument defaults to deck.md in the current directory when omitted; pass the deck path explicitly if it lives elsewhere\ncaused by: {err}",
+            input.display()
+        )
     })
 }
 
@@ -3641,6 +3717,49 @@ fn core<T>(result: peitho_core::Result<T>) -> miette::Result<T> {
     result.map_err(|err| miette::miette!("{err}"))
 }
 
+fn core_for_deck<T>(
+    result: peitho_core::Result<T>,
+    deck: &Path,
+    line_map: Option<&peitho_core::include::LineMap>,
+) -> miette::Result<T> {
+    result.map_err(|err| miette::miette!("{}", translate_deck_error(err, deck, line_map)))
+}
+
+fn translate_deck_error(
+    mut err: peitho_core::BuildError,
+    deck: &Path,
+    line_map: Option<&peitho_core::include::LineMap>,
+) -> peitho_core::BuildError {
+    if let Some(origin) = err.origin_file.take() {
+        err.origin_file = Some(origin_for_display(&origin, deck));
+        return err;
+    }
+
+    let Some(line) = err.line else {
+        return err;
+    };
+    let Some(line_map) = line_map else {
+        err.origin_file = Some(origin_for_display(deck, deck));
+        return err;
+    };
+    let (origin, original_line) = line_map.translate(line);
+    if origin.as_os_str().is_empty() {
+        return err;
+    }
+    err.line = Some(original_line);
+    if !same_watch_path(&origin, deck) {
+        err.origin_file = Some(origin_for_display(&origin, deck));
+    }
+    err
+}
+
+fn origin_for_display(origin: &Path, deck: &Path) -> PathBuf {
+    origin
+        .strip_prefix(asset_resolution::deck_parent(deck))
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| origin.to_path_buf())
+}
+
 fn layout_name(path: &Path) -> String {
     path.file_stem()
         .and_then(|stem| stem.to_str())
@@ -3666,6 +3785,59 @@ contexts:
       scope: keyword.control.carina
 "#;
     const TEST_LAYOUT_HTML: &str = r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot></section>"#;
+
+    #[test]
+    fn load_and_expand_deck_source_returns_source_frontmatter_and_line_map() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let source = "---\ntime: 1m\n---\n# Intro\n";
+        fs::write(&deck, source).unwrap();
+
+        let loaded = load_and_expand_deck_source(&deck).unwrap();
+
+        assert_eq!(loaded.source, source);
+        assert_eq!(loaded.frontmatter.body_start(), 16);
+        assert_eq!(loaded.line_map.translate(4), (deck.clone(), 4));
+    }
+
+    #[test]
+    fn load_and_expand_deck_source_reports_distinct_included_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let shared = dir.path().join("shared");
+        let intro = shared.join("intro.md");
+        let outro = shared.join("outro.md");
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(&intro, "# Intro\n").unwrap();
+        fs::write(&outro, "# Outro\n").unwrap();
+        fs::write(
+            &deck,
+            "<!-- {\"include\":\"shared/intro.md\"} -->\n---\n# Middle\n---\n<!-- {\"include\":\"shared/intro.md\"} -->\n---\n<!-- {\"include\":\"shared/outro.md\"} -->\n",
+        )
+        .unwrap();
+
+        let loaded = load_and_expand_deck_source(&deck).unwrap();
+
+        assert_eq!(loaded.included_files(), vec![intro, outro]);
+    }
+
+    #[test]
+    fn load_and_expand_deck_source_frontmatter_errors_include_deck_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(&deck, "---\ntime: [\n---\n# Intro\n").unwrap();
+
+        let err = match load_and_expand_deck_source(&deck) {
+            Ok(_) => panic!("invalid frontmatter should fail"),
+            Err(err) => err,
+        };
+
+        let message = err.to_string();
+        assert!(
+            message.contains("deck.md:3: invalid deck frontmatter"),
+            "actual error: {message}"
+        );
+    }
 
     #[test]
     fn watch_dependency_types_are_available() {
@@ -3694,6 +3866,7 @@ contexts:
                 syntaxes: Provenance::Explicit(syntaxes.clone()),
                 fonts: Provenance::Builtin,
             },
+            Vec::new(),
         );
 
         assert!(targets.is_relevant_change(&dir.path().join("deck.md")));
@@ -3723,6 +3896,7 @@ contexts:
                 syntaxes: Provenance::Builtin,
                 fonts: Provenance::Explicit(fonts.clone()),
             },
+            Vec::new(),
         );
 
         assert!(targets.is_relevant_change(&fonts.join("deck-font.woff2")));
@@ -3747,6 +3921,7 @@ contexts:
                 syntaxes: Provenance::Builtin,
                 fonts: Provenance::Explicit(fonts.clone()),
             },
+            Vec::new(),
         );
 
         assert!(!targets.is_relevant_change(&fonts.join(".DS_Store")));
@@ -3768,6 +3943,7 @@ contexts:
                 syntaxes: Provenance::Builtin,
                 fonts: Provenance::Explicit(fonts.clone()),
             },
+            Vec::new(),
         );
 
         assert!(targets.is_relevant_change(&nested.join("400.woff2")));
@@ -3794,6 +3970,7 @@ contexts:
                 syntaxes: Provenance::Builtin,
                 fonts: Provenance::Explicit(missing_fonts.clone()),
             },
+            Vec::new(),
         );
 
         let dirs = targets.watch_dirs();
@@ -3816,7 +3993,7 @@ contexts:
 
     #[test]
     fn build_options_with_builtin_assets_watch_only_the_deck() {
-        let targets = WatchTargets::new(PathBuf::from("deck.md"), empty_assets());
+        let targets = WatchTargets::new(PathBuf::from("deck.md"), empty_assets(), Vec::new());
 
         assert!(targets.is_relevant_change(Path::new("deck.md")));
         assert!(!targets.is_relevant_change(Path::new("layout.html")));
@@ -4153,6 +4330,7 @@ contexts:
                 syntaxes: Provenance::Builtin,
                 fonts: Provenance::Builtin,
             },
+            Vec::new(),
         );
 
         assert_eq!(targets.watch_dirs(), vec![dir.path().to_path_buf()]);
@@ -4242,6 +4420,55 @@ contexts:
         .unwrap();
 
         let manifest = fs::read_to_string(fixture.options.out.join("manifest.json")).unwrap();
+        assert!(manifest.contains(r#""slideCount": 2"#));
+        assert!(String::from_utf8(stdout)
+            .unwrap()
+            .contains("built 2 slide(s)"));
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn watch_path_handler_rebuilds_after_included_markdown_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let shared = dir.path().join("shared");
+        let included = shared.join("intro.md");
+        let out = dir.path().join("dist");
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(&included, "# Intro\n").unwrap();
+        fs::write(&deck, "<!-- {\"include\":\"shared/intro.md\"} -->\n").unwrap();
+        let options = BuildOptions {
+            input: deck.clone(),
+            out,
+        };
+        let targets = resolve_watch_targets(&deck).unwrap();
+        assert!(targets.is_relevant_change(&included));
+        let watched_dirs = targets.watch_dirs();
+        assert!(
+            watched_dirs.iter().any(|path| path == &shared),
+            "actual dirs: {watched_dirs:?}"
+        );
+        let mut state = WatchState::new(deck, targets, watched_dirs);
+        let mut watcher = RecordingWatchController::default();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        rebuild_once_for_watch(&options, &mut stdout, &mut stderr).unwrap();
+        stdout.clear();
+        stderr.clear();
+        fs::write(&included, "# Intro\n\n---\n# Included Details\n").unwrap();
+
+        handle_watch_paths_with_rebuild(
+            &mut state,
+            &mut watcher,
+            std::slice::from_ref(&included),
+            &mut stdout,
+            &mut stderr,
+            |stdout, stderr| rebuild_once_for_watch(&options, stdout, stderr),
+        )
+        .unwrap();
+
+        let manifest = fs::read_to_string(options.out.join("manifest.json")).unwrap();
         assert!(manifest.contains(r#""slideCount": 2"#));
         assert!(String::from_utf8(stdout)
             .unwrap()
@@ -4387,6 +4614,44 @@ contexts:
     }
 
     #[test]
+    fn watch_path_handler_rewatches_when_include_paths_change() {
+        let fixture = WatchFixture::new("# Intro\n");
+        let mut state = watch_state_for_fixture(&fixture);
+        let mut watcher = RecordingWatchController::default();
+        let shared = fixture._dir.path().join("shared");
+        let included = shared.join("intro.md");
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut rebuilds = 0;
+
+        fs::create_dir_all(&shared).unwrap();
+        fs::write(&included, "# Included\n").unwrap();
+        fs::write(
+            &fixture.options.input,
+            "<!-- {\"include\":\"shared/intro.md\"} -->\n",
+        )
+        .unwrap();
+
+        handle_watch_paths_with_rebuild(
+            &mut state,
+            &mut watcher,
+            std::slice::from_ref(&fixture.options.input),
+            &mut stdout,
+            &mut stderr,
+            |_stdout, _stderr| {
+                rebuilds += 1;
+                Ok(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(rebuilds, 1);
+        assert!(state.targets.is_relevant_change(&included));
+        assert!(watcher.watched.iter().any(|path| path == &shared));
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
     fn deck_refresh_updates_targets_without_reconciling_watched_dirs() {
         let fixture = WatchFixture::new("# Intro\n");
         let old_layouts = fixture._dir.path().join("layouts");
@@ -4410,7 +4675,7 @@ contexts:
         .unwrap();
         let mut stderr = Vec::new();
 
-        refresh_watch_targets_after_deck_change(&mut state, &mut stderr).unwrap();
+        refresh_watch_targets_after_source_change(&mut state, &mut stderr).unwrap();
 
         assert!(state.watched_dirs.iter().any(|path| path == &old_layouts));
         assert_eq!(
@@ -4440,7 +4705,7 @@ contexts:
         fs::write(&deck, "---\nlayouts: ./layouts\n---\n# Intro\n").unwrap();
         let mut stderr = Vec::new();
 
-        refresh_watch_targets_after_deck_change(&mut state, &mut stderr).unwrap();
+        refresh_watch_targets_after_source_change(&mut state, &mut stderr).unwrap();
 
         assert!(
             stderr.is_empty(),

--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -130,6 +130,71 @@ fn build_fails_for_undefined_footnote_reference_with_line_and_help() {
 }
 
 #[test]
+fn build_reports_parse_errors_from_included_file_with_file_and_line() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let out = dir.path().join("dist");
+    fs::write(&deck, "<!-- {\"include\":\"shared.md\"} -->\n").unwrap();
+    fs::write(
+        dir.path().join("shared.md"),
+        "<!-- {\"key\":\"Bad Key\"} -->\n# Included\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("shared.md:1"))
+        .stderr(predicate::str::contains(
+            "slide key must use lowercase ascii",
+        ))
+        .stderr(predicate::str::contains("help: use lowercase ascii"));
+}
+
+#[test]
+fn build_reports_section_total_mismatch_from_included_file_with_file_and_line() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let out = dir.path().join("dist");
+    fs::write(
+        &deck,
+        "---\ntime: 5m\n---\n<!-- {\"include\":\"shared.md\"} -->\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("shared.md"),
+        "<!-- {\"section\":\"Foo\",\"time\":\"1m\"} -->\n# Included\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("shared.md:1"))
+        .stderr(predicate::str::contains(
+            "frontmatter time 300000ms does not match section total",
+        ))
+        .stderr(predicate::str::contains("60000ms"))
+        .stderr(predicate::str::contains(
+            "help: adjust frontmatter time or section times so the totals match",
+        ));
+}
+
+#[test]
 fn build_fails_for_root_class_width_override_with_line_and_help() {
     let dir = tempdir().unwrap();
     let deck = dir.path().join("deck.md");

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -89,6 +89,54 @@ fn present_no_serve_writes_clean_present_cache() {
 }
 
 #[test]
+fn present_no_serve_expands_two_file_deck_into_manifest_and_notes() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let layout = dir.path().join("layout.html");
+    let css_dir = dir.path().join("css");
+    fs::create_dir_all(&css_dir).unwrap();
+    fs::write(
+        &deck,
+        deck_with_assets(
+            "./layout.html",
+            "# Cover\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# End\n",
+        ),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("shared.md"),
+        "<!-- {\"key\":\"shared\"} -->\n# Shared\n\n<!-- Speaker note from include. -->\n",
+    )
+    .unwrap();
+    fs::write(
+        &layout,
+        r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="0..*"></slot></section>"#,
+    )
+    .unwrap();
+    fs::write(css_dir.join("base.css"), "").unwrap();
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .current_dir(dir.path())
+        .args(["present", deck.to_str().unwrap(), "--no-serve", "--no-open"])
+        .assert()
+        .success();
+
+    let cache = dir.path().join(".peitho/present-cache");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(cache.join("manifest.json")).unwrap()).unwrap();
+    assert_eq!(manifest["slideCount"].as_u64(), Some(3));
+    let slides = manifest["slides"].as_array().unwrap();
+    assert_eq!(slides[0]["key"].as_str(), Some("cover"));
+    assert_eq!(slides[1]["key"].as_str(), Some("shared"));
+    assert_eq!(slides[2]["key"].as_str(), Some("end"));
+    assert_eq!(slides[1]["hasNotes"].as_bool(), Some(true));
+
+    let notes = fs::read_to_string(cache.join("notes.json")).unwrap();
+    assert!(notes.contains("Speaker note from include."));
+}
+
+#[test]
 fn present_no_serve_writes_presenter_html() {
     let dir = tempdir().unwrap();
     let fixture = Fixture::write(dir.path());

--- a/docs/plans/2026-07-20-slide-include.md
+++ b/docs/plans/2026-07-20-slide-include.md
@@ -1,0 +1,322 @@
+# Slide-level Markdown include
+
+Issue: #330. Author decisions (2026-07-20):
+
+- **Syntax**: page-settings comment `<!-- {"include":"foo.md"} -->`. Reuses
+  the existing `parse_page_comment` seam, its JSON validation, and its
+  line-numbered errors. No new lexical surface. The one wrinkle — the
+  same syntactic shape now describes both "attributes of this slide" and
+  "expand into zero-or-more slides at this location" — is resolved by
+  making `include` mutually exclusive with every other page-settings key
+  and by requiring the include comment to sit on a slide with no body
+  content (see "Include slide shape" below). The include slide is a
+  container, not a real slide.
+- **Frontmatter in included files**: forbidden. If the leading `---` of
+  an included file parses as YAML frontmatter, the include is a
+  line-numbered build error attributed to the included file. Only the
+  top-level deck carries frontmatter, so `time`, `layouts`, `css`,
+  `syntaxes`, `fonts`, `code_images`, `breaks`, `aspect_ratio`, and
+  `resolution` all live in one place and section-total-vs-`time`
+  validation is trivially preserved. This is the most easily-relaxed
+  choice; ban first, revisit if a concrete need appears.
+- **Section markers in included files**: allowed. An included file may
+  contain `{"section":"Name","time":"1m"}` markers on its slides. After
+  the include expansion (which produces a flat ordered slide list),
+  `resolve_deck_sections` runs against the expanded list and the
+  frontmatter-`time`-vs-section-total check applies unchanged. This lets
+  a shared intro/outro carry its own section timing without special
+  cases downstream.
+
+## Non-goals (v1)
+
+- URL / remote includes.
+- Partial-slide fragment includes (splicing headings / lists / code
+  blocks into a slide body).
+- Templating / parameter substitution.
+- Code-file includes into fenced blocks (`{{ include "foo.rs" }}`).
+
+Each of these becomes its own follow-up issue if desired.
+
+## Expansion seam
+
+Include expansion happens **before** `parse_markdown`, **after** the
+top-level file has been read from disk and its frontmatter has been
+consumed by `parse_frontmatter`. The included files are not fed through
+`parse_frontmatter`; instead the include expander splits each included
+file into slide ranges and splices those slides into the top-level
+deck's slide sequence as raw markdown, then hands the resulting single
+combined source string to `parse_markdown` alongside the top-level
+`ParsedFrontmatter`.
+
+Concretely: a new `crates/peitho-core/src/include.rs` module exposes
+
+```rust
+pub fn expand_includes(
+    top_source: &str,
+    top_body_start: usize,
+    top_path: &Path,
+) -> Result<ExpandedSource>;
+```
+
+where
+
+```rust
+pub struct ExpandedSource {
+    pub source: String,               // top frontmatter + spliced body
+    pub body_start: usize,            // unchanged from top_body_start
+    pub line_map: LineMap,            // per-line origin (file path + original line)
+}
+```
+
+`expand_includes` performs one lightweight scan over the top file's
+body to find include comments (see "Detection" below), reads each
+included file (line-numbered `Missing`/`IoError` on failure), recursively
+expands its includes (tracking a visited-paths stack for cycle
+detection), and produces a combined source. The combined source is
+what `parse_markdown` sees.
+
+The CLI (main.rs and asset_resolution.rs) already reads the file
+itself and calls `parse_frontmatter(&markdown)` then
+`parse_deck_and_transform(&markdown, frontmatter, ...)`. The seam
+change: after `parse_frontmatter` returns, call `expand_includes` with
+the top file's body range and canonical path, then pass
+`expanded.source` (not the original `markdown`) into
+`parse_deck_and_transform`. The `ParsedFrontmatter.body_start` is
+unchanged — expansion preserves the byte offset where the body begins
+because the top frontmatter block sits at the very start of the
+combined string, byte-identical to the original.
+
+Callers touched: `crates/peitho/src/main.rs` (cmd_build, cmd_layouts,
+cmd_preview, cmd_present, cmd_export, cmd_publish, cmd_lint's paths
+that read the deck source) and `crates/peitho/src/doctor.rs` and the
+in-crate `code_images::parse_deck_and_transform` call sites in tests.
+The seam is added as a single helper in `main.rs`
+(`load_and_expand_deck_source(path)`) that all commands funnel through
+so the expansion pass is not sprinkled site by site.
+
+## Detection: how includes are recognized before markdown parsing
+
+The include expander does not run pulldown-cmark. It performs a
+line-oriented scan that recognizes an include comment only in
+positions where a page-settings comment is legal today: a
+whole-line HTML comment `<!-- {...} -->` that sits inside a slide
+region (between two `---` slide separators or between the last
+frontmatter `---` and the first following `---`), skipping content
+inside fenced code blocks. This mirrors the way peitho already
+distinguishes legitimate slide `---` splits from fenced-code `---`
+lines.
+
+An include comment is a whole-line `<!-- {"include":"path"} -->`. The
+JSON is parsed with `serde_json`. If the object has any key besides
+`include`, or if `include` is not a non-empty string, or if the
+containing slide region has any non-whitespace / non-comment content,
+the expander emits a line-numbered `BuildError` and never falls back
+to treating the include comment as an ordinary page-settings comment
+(the parser must never see it — see "Include slide shape").
+
+Only a comment discovered by this pre-scan is treated as an include.
+`parse_page_comment` gains a symmetric guard: if it ever sees
+`"include"` in a page-settings JSON, that is a hard error
+("include comment must be the only content of its slide" — the
+expander would already have removed it, so seeing it here means the
+comment was in a position the expander does not recognize, which we
+want to catch loudly rather than silently split-brain).
+
+## Include slide shape
+
+An include comment must be the entire content of its slide region:
+
+```
+---
+<!-- {"include":"shared/intro.md"} -->
+---
+```
+
+Anything else in the slide (headings, body text, other page-settings
+comments, speaker notes) is a line-numbered build error with help
+"place the include comment in its own slide bounded by `---`". This
+keeps the expansion mechanical (delete the include slide, splice the
+included slides in its place) and prevents confusing constructs like a
+title above an include that expands to a title-bearing slide of its
+own.
+
+The rationale for reusing the page-comment shape while forbidding
+sibling content: the alternative (a shape that allows sibling content)
+raises unanswerable design questions — does the sibling content
+survive the expansion? attach to the first spliced slide? the last?
+None of those compose with `draft`/`skip`/`section` on the outer slide.
+The container-only rule sidesteps all of it.
+
+## Nested includes and cycles
+
+Nested includes are allowed. The expander walks includes recursively
+with a visited-paths stack keyed on canonical (`std::fs::canonicalize`)
+paths. If a canonical path is already on the stack, the expander emits
+a line-numbered `Cycle` error naming the include chain
+(`A.md → B.md → A.md`). If canonicalization fails (broken symlink,
+etc.), the expander falls back to the lexically-normalized path for
+the cycle key so we still detect cycles rather than infinite-loop.
+
+The expander enforces `MAX_INCLUDE_DEPTH = 64` as a stack-safety cap
+alongside cycle detection: a legitimate non-cyclic chain deeper than
+64 produces a line-numbered "include chain exceeds max depth of 64"
+error rather than blowing the thread stack.
+
+## Frontmatter in included files: forbidden
+
+After reading an included file, the expander runs the leading-`---`
+detector already implemented in `parse_frontmatter` (via a
+pub(crate) helper it exposes for this purpose) purely to detect the
+presence of frontmatter. If a frontmatter block is present, the
+expander emits:
+
+```
+error: included file has frontmatter, which is not supported
+  --> shared/intro.md:1
+  help: move frontmatter to the top-level deck; included files may only contain slides
+```
+
+Detection is stricter than "the file starts with `---`" — it must
+match the frontmatter grammar so a legitimate first slide starting
+with `---` on its own is not mistaken for frontmatter. In practice
+this means: if the leading `---` opens a YAML block that closes at a
+matching `---` before any real slide content, it is frontmatter.
+
+## Section markers in included files: allowed
+
+Section markers are just page-settings comments. Included slides go
+into the flat slide list, `resolve_deck_sections` runs over the
+expanded list, and the existing
+"if frontmatter `time` is set, section total must equal it"
+invariant applies unchanged. If the top-level deck sets `time: 30m`
+and an included intro contributes a 3m section and the outro
+contributes a 2m section, the deck body slides must account for 25m
+of sections; a mismatch is a line-numbered error attributed to the
+first mismatching marker (existing behavior).
+
+Two markers on the same slide (e.g. an included slide already has a
+marker and someone tries to add another) is already a line-numbered
+error via the "at most one page settings comment per slide" rule.
+Nothing new.
+
+## Interaction with draft / skip / speaker notes
+
+- `draft` on an included slide works exactly as it does on a top-level
+  slide: it is dropped at parse end before `ParsedSlide.index`
+  assignment. Draft dropping happens after include expansion, so it
+  sees the expanded list uniformly.
+- `skip` on an included slide surfaces as `ManifestSlide.skip`
+  unchanged.
+- Speaker notes (non-JSON HTML comments) on included slides ride
+  through to `notes.json` unchanged.
+
+The include slide itself is a container and cannot carry `draft`,
+`skip`, `section`, `layout`, `key`, `page_number`, or notes — all of
+those on the same slide as an `include` are line-numbered errors.
+To skip an entire included file, mark the include slide with
+`draft` at… no: that is disallowed. To conditionally omit an included
+file, the author edits the top file. This is a deliberate v1
+simplification.
+
+## Source-file attribution in errors
+
+`ParsedSlide.source_index` today is a `usize` (the parse-time slide
+number) that error messages surface as "slide N". After include
+expansion, "slide N" alone is ambiguous — is slide 7 in the deck or in
+`shared/intro.md`? The fix is to carry a per-line origin table
+alongside the combined source and to translate `BuildError.line` back
+through it at error-emission time so messages say `foo.md:12` instead
+of a raw combined-source line number.
+
+The origin table (`LineMap`) is a `Vec<LineOrigin>` where index N
+holds `{file: PathBuf, original_line: usize}` for combined-source line
+N+1. Building it is trivial during splicing (each appended chunk
+records its source file and the mapping from its combined-source lines
+to original file lines). Translation is a single method
+`LineMap::translate(line) -> (PathBuf, usize)`.
+
+The seam for translation: `BuildError` gains an
+optional `origin_file: Option<PathBuf>` field (defaulting to the
+top-level deck path). The CLI's error printer (`core()` and the
+miette adapters in `main.rs` / `doctor.rs`) is the one place that
+consults the `LineMap` — parser/mapping/check keep operating on
+combined-source line numbers internally. When an error bubbles out to
+the CLI, `translate` runs once and the message is formatted with the
+per-file line number and the file's display path (relative to the
+top-level deck's directory when possible).
+
+Errors raised inside `expand_includes` itself (missing include target,
+frontmatter in included file, cycle, malformed include comment) are
+attributed directly to the file being expanded and carry
+`origin_file` set at construction time.
+
+## Test surface
+
+Unit tests (`crates/peitho-core/src/include.rs` tests):
+
+1. Missing include target → line-numbered error naming the missing
+   path.
+2. Frontmatter in included file → line-numbered error naming the
+   included file.
+3. Cycle (self-include) → line-numbered error naming the chain.
+4. Cycle (A→B→A) → line-numbered error naming the chain.
+5. Nested include (A→B→C, no cycle) → expanded body concatenates all
+   three files' slides in order.
+6. Include comment with a sibling heading in the same slide → error.
+7. Include comment with a sibling page-settings comment in the same
+   slide → error.
+8. Include JSON with an extra key (`{"include":"x.md","layout":"y"}`)
+   → error.
+9. Include JSON with a non-string include value → error.
+10. Include inside a fenced code block → **not** an include (verbatim
+    code content preserved).
+11. Whole-source integration test: a top file with two includes
+    produces the expected combined slide sequence, and building the
+    combined source with `parse_markdown` yields the expected
+    `Deck<Parsed>`.
+12. `LineMap` translation: an error raised on line X of an included
+    file surfaces as `included/file.md:Y` in the CLI error.
+
+CLI integration tests: build a two-file deck, verify manifest and
+`notes.json` contents.
+
+Snapshot / doctest updates: a new `docs/plans/…` code sample and a
+short `examples/include-decks/` (top deck + shared intro) example
+that the demo build can pick up if desired (out of scope for v1;
+opening an issue for it if the shape lands).
+
+## Rollout order (TDD-friendly, small green steps)
+
+1. Add `include.rs` module with `LineMap`, `LineOrigin`, and a
+   trivial `expand_includes` that returns the input unchanged when no
+   include comment is present. Wire it into the CLI at
+   `load_and_expand_deck_source`. Verify nothing regresses.
+2. Add pre-scan detection of a whole-line include comment inside a
+   slide region (no expansion yet — just detect and error on
+   malformed shape).
+3. Implement single-file (non-nested) expansion: splice one included
+   file's raw slides into the combined source, extend the `LineMap`,
+   splice out the container include slide.
+4. Add included-file frontmatter detection (forbidden).
+5. Add nested include recursion + visited-path cycle detection.
+6. Add `BuildError.origin_file` and the CLI-side `LineMap`
+   translation so error line numbers surface per file.
+7. Extend `parse_page_comment` with the belt-and-braces "include key
+   not allowed here" guard.
+
+Each step is a Red/Green/Refactor cycle with tests added first.
+
+## Alternatives considered and why they lost
+
+- `!include foo.md` line directive: adds a new lexical surface with no
+  reuse of existing infrastructure. Requires a fresh
+  fenced-code-aware scanner. Rejected.
+- `::: {include="foo.md"}` fence: reuses explicit-slot tokens but the
+  semantics are unrelated (slot routing vs deck expansion). Would
+  fork the meaning of `:::`. Rejected.
+- Allowing sibling content on an include slide: raises unanswerable
+  attach-semantics questions with no clean answer. Rejected — the
+  container-only rule is a hard constraint from day one.
+- Allowing frontmatter in included files with a merge policy: adds a
+  merge rule that has to live in author's head forever. Rejected;
+  easier to relax later than to remove.


### PR DESCRIPTION
## Summary

- `<!-- {"include":"path/to/slides.md"} -->` on an otherwise empty slide splices the referenced file's slides in at that position, expanding recursively.
- Same-repo relative paths only; absolute paths, `..` escapes above the deck root, cycles, and chains deeper than 64 are all line-numbered build errors. Included files may not carry frontmatter; section markers inside them ride through the deck's normal `time`-vs-section-total validation.
- Errors from included files surface as `path/to/included.md:LINE` via a per-line origin map bound to the loaded deck source, so every CLI code path attributes correctly. Watch mode observes the whole include tree — edits to any included file trigger a rebuild.

Design: `docs/plans/2026-07-20-slide-include.md`. Closes #330.

## Test plan

- [x] `cargo test --workspace` (green, run 3x for race safety)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/` (no contract changes; pure-Rust addition)
- [x] 5 rounds of self-review; issues found and fixed each round (see commit history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)