### PR TITLE
Document slide-level include in README + guide, bump to 1.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.14.0"
+version = "1.15.0"
 
 [workspace.dependencies]
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ A slide's page settings are one `<!-- { ... } -->` JSON comment (at most one per
 
 - `layout` — pin a layout by name, e.g. `{"layout":"cover"}`. An unknown name is a build error with a candidate list
 - `section` + `time` — the marked slide starts an agenda section that runs until the next marker. Section budgets must add up to the deck's `time` frontmatter (when present) — mismatches are build errors with line numbers. During the talk, the presenter agenda shows planned vs. actual per section in real time
+- `include` — on an otherwise empty slide, splices the referenced Markdown file's slides in at that position:
+
+  ```markdown
+  ---
+  <!-- {"include":"shared/intro.md"} -->
+  ---
+  ```
+
+  Deck-relative paths only, nested up to 64 levels, cycles/absolute/`..`-escape are build errors. Included files may not carry frontmatter but may declare their own `section`/`time` markers. Watch mode rebuilds when any included file changes.
 
 ### Speaker notes
 

--- a/site/content/guide/writing-decks.md
+++ b/site/content/guide/writing-decks.md
@@ -113,7 +113,7 @@ rendered as plaintext.
 ## Page settings comments
 
 JSON HTML comments carry page settings. The supported settings are `key`,
-`layout`, `section`, `time`, `draft`, and `skip`.
+`layout`, `section`, `time`, `draft`, `skip`, and `include`.
 
 ```markdown
 <!-- {"key":"checks","layout":"agenda","section":"Contracts","time":"3m"} -->
@@ -147,3 +147,34 @@ The marked slide starts a section that runs until the next marker. If any
 section marker exists, the first slide must carry one. When deck frontmatter
 sets `time`, the section totals must equal that deck time; when deck `time` is
 absent, the section total becomes the deck's planned time.
+
+## Splitting a deck across files
+
+An `include` page settings comment on an otherwise empty slide splices the
+referenced Markdown file's slides in at that position. Use it to share a
+common intro or outro across a talk series, or to break a long deck into
+smaller files.
+
+```markdown
+# Deck slide
+
+---
+<!-- {"include":"shared/intro.md"} -->
+---
+# Next deck slide
+```
+
+The include comment must be the only content of its slide, may not combine
+with any other page settings key, and takes only `include` — a string with a
+deck-relative Markdown path. The referenced file may contain any number of
+slides, may nest further `include` comments up to 64 levels deep, and may
+declare `section` and `time` markers that participate in the deck's normal
+section-total-vs-`time` validation. Included files may **not** carry
+frontmatter — the top-level deck is the sole source of deck-wide settings.
+
+Paths are resolved relative to the including file and must stay under the
+top-level deck's directory. Absolute paths, `..` escapes, missing targets,
+cycles, chains exceeding 64 nested includes, empty included files, and any
+of the above malformed shapes are all line-numbered build errors. Watch
+mode observes the entire include tree, so edits to any included file
+trigger a rebuild.


### PR DESCRIPTION
## Summary

- Add slide-level `include` to the README's per-slide settings list, with a compact example and the failure modes (deck-relative only, cycles / absolute / `..`-escape / frontmatter-in-includes / depth-64 all build errors).
- Add a "Splitting a deck across files" section to `site/content/guide/writing-decks.md` covering syntax, section-marker composition, and watch-mode behavior. Also update the earlier "Page settings comments" listing to include the new key.
- Bump the workspace version 1.14.0 → 1.15.0 (new user-facing feature).

Follow-up to #332.

## Test plan

- [x] `cargo test --workspace` (green, 3x)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `zola build` under `site/` after `make docs-sources` — Done in 100ms, 0 orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)