### PR TITLE
Wait for document.fonts before mounting slides

### DIFF
--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -210,6 +210,52 @@ function isCssWhitespace(char) {
   return char === " " || char === "\n" || char === "\r" || char === "	" || char === "\f";
 }
 
+// src/fontsReady.ts
+var MAX_FONT_READY_PASSES = 5;
+async function waitForFontsReady(doc, win, options) {
+  const fonts = doc.fonts;
+  if (fonts == null) return;
+  const timeoutMs = options?.timeoutMs ?? 3e3;
+  const deadline = Date.now() + timeoutMs;
+  const kicked = /* @__PURE__ */ new WeakSet();
+  for (let pass = 0; pass < MAX_FONT_READY_PASSES; pass += 1) {
+    const hasNewFace = kickVisibleFontFaces(fonts, kicked);
+    if (!hasNewFace && pass > 0) return;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0 || await raceReadyWithTimeout(fonts, win, remainingMs)) {
+      const log = options?.log ?? console;
+      log.warn(`document.fonts.ready timed out after ${timeoutMs}ms`);
+      return;
+    }
+  }
+}
+function kickVisibleFontFaces(fonts, kicked) {
+  let hasNewFace = false;
+  fonts.forEach((face) => {
+    if (kicked.has(face)) return;
+    kicked.add(face);
+    hasNewFace = true;
+    try {
+      face.load().catch(() => void 0);
+    } catch {
+    }
+  });
+  return hasNewFace;
+}
+async function raceReadyWithTimeout(fonts, win, ms) {
+  let timeoutId;
+  const timeout = new Promise((resolve) => {
+    timeoutId = win.setTimeout(() => resolve("timeout"), ms);
+  });
+  const ready = fonts.ready.then(
+    () => "ready",
+    () => "ready"
+  );
+  const result = await Promise.race([ready, timeout]);
+  if (timeoutId !== void 0) win.clearTimeout(timeoutId);
+  return result === "timeout";
+}
+
 // src/keyboard.ts
 var navigationKeyMap = /* @__PURE__ */ new Map([
   ["ArrowRight", "next"],
@@ -599,7 +645,8 @@ var PreviewShellController = class {
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
-    this.log = options.console ?? console;
+    const log = options.console ?? console;
+    this.log = { error: log.error, warn: log.warn ?? console.warn.bind(console) };
     this.bus = options.bus ?? this.win;
     this.storage = options.storage ?? this.win.sessionStorage;
     this.syncUrl = options.syncUrl ?? "/sync";
@@ -627,6 +674,7 @@ var PreviewShellController = class {
       this.setCanvasRootProperties(this.dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
       this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
+      await waitForFontsReady(this.doc, this.win, { log: this.log });
       const pending = await Promise.all(
         manifest.slides.map(async (slide) => {
           const html = await this.fetchText(slide.src);

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -237,6 +237,52 @@ function isCssWhitespace(char) {
   return char === " " || char === "\n" || char === "\r" || char === "	" || char === "\f";
 }
 
+// src/fontsReady.ts
+var MAX_FONT_READY_PASSES = 5;
+async function waitForFontsReady(doc, win, options) {
+  const fonts = doc.fonts;
+  if (fonts == null) return;
+  const timeoutMs = options?.timeoutMs ?? 3e3;
+  const deadline = Date.now() + timeoutMs;
+  const kicked = /* @__PURE__ */ new WeakSet();
+  for (let pass = 0; pass < MAX_FONT_READY_PASSES; pass += 1) {
+    const hasNewFace = kickVisibleFontFaces(fonts, kicked);
+    if (!hasNewFace && pass > 0) return;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0 || await raceReadyWithTimeout(fonts, win, remainingMs)) {
+      const log = options?.log ?? console;
+      log.warn(`document.fonts.ready timed out after ${timeoutMs}ms`);
+      return;
+    }
+  }
+}
+function kickVisibleFontFaces(fonts, kicked) {
+  let hasNewFace = false;
+  fonts.forEach((face) => {
+    if (kicked.has(face)) return;
+    kicked.add(face);
+    hasNewFace = true;
+    try {
+      face.load().catch(() => void 0);
+    } catch {
+    }
+  });
+  return hasNewFace;
+}
+async function raceReadyWithTimeout(fonts, win, ms) {
+  let timeoutId;
+  const timeout = new Promise((resolve) => {
+    timeoutId = win.setTimeout(() => resolve("timeout"), ms);
+  });
+  const ready = fonts.ready.then(
+    () => "ready",
+    () => "ready"
+  );
+  const result = await Promise.race([ready, timeout]);
+  if (timeoutId !== void 0) win.clearTimeout(timeoutId);
+  return result === "timeout";
+}
+
 // src/skipnav.ts
 function nextNonSkippedIndex(slides, from, direction) {
   let index = from + direction;
@@ -673,7 +719,8 @@ var PresentShellController = class {
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
-    this.log = options.console ?? console;
+    const log = options.console ?? console;
+    this.log = { error: log.error, warn: log.warn ?? console.warn.bind(console) };
     this.bus = options.bus ?? this.win;
     this.now = options.now ?? Date.now;
     this.viewport = options.viewport;
@@ -699,6 +746,7 @@ var PresentShellController = class {
       this.setCanvasRootProperties(dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
       this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
+      await waitForFontsReady(this.doc, this.win, { log: this.log });
       const pending = [];
       for (const slide of manifest.slides) {
         const html = await this.fetchText(slide.src);

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -890,6 +890,52 @@ function isCssWhitespace(char) {
   return char === " " || char === "\n" || char === "\r" || char === "	" || char === "\f";
 }
 
+// src/fontsReady.ts
+var MAX_FONT_READY_PASSES = 5;
+async function waitForFontsReady(doc, win, options) {
+  const fonts = doc.fonts;
+  if (fonts == null) return;
+  const timeoutMs = options?.timeoutMs ?? 3e3;
+  const deadline = Date.now() + timeoutMs;
+  const kicked = /* @__PURE__ */ new WeakSet();
+  for (let pass = 0; pass < MAX_FONT_READY_PASSES; pass += 1) {
+    const hasNewFace = kickVisibleFontFaces(fonts, kicked);
+    if (!hasNewFace && pass > 0) return;
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0 || await raceReadyWithTimeout(fonts, win, remainingMs)) {
+      const log = options?.log ?? console;
+      log.warn(`document.fonts.ready timed out after ${timeoutMs}ms`);
+      return;
+    }
+  }
+}
+function kickVisibleFontFaces(fonts, kicked) {
+  let hasNewFace = false;
+  fonts.forEach((face) => {
+    if (kicked.has(face)) return;
+    kicked.add(face);
+    hasNewFace = true;
+    try {
+      face.load().catch(() => void 0);
+    } catch {
+    }
+  });
+  return hasNewFace;
+}
+async function raceReadyWithTimeout(fonts, win, ms) {
+  let timeoutId;
+  const timeout = new Promise((resolve) => {
+    timeoutId = win.setTimeout(() => resolve("timeout"), ms);
+  });
+  const ready = fonts.ready.then(
+    () => "ready",
+    () => "ready"
+  );
+  const result = await Promise.race([ready, timeout]);
+  if (timeoutId !== void 0) win.clearTimeout(timeoutId);
+  return result === "timeout";
+}
+
 // src/skipnav.ts
 function nextNonSkippedIndex(slides, from, direction) {
   let index = from + direction;
@@ -1326,7 +1372,8 @@ var PresentShellController = class {
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
-    this.log = options.console ?? console;
+    const log = options.console ?? console;
+    this.log = { error: log.error, warn: log.warn ?? console.warn.bind(console) };
     this.bus = options.bus ?? this.win;
     this.now = options.now ?? Date.now;
     this.viewport = options.viewport;
@@ -1352,6 +1399,7 @@ var PresentShellController = class {
       this.setCanvasRootProperties(dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
       this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
+      await waitForFontsReady(this.doc, this.win, { log: this.log });
       const pending = [];
       for (const slide of manifest.slides) {
         const html = await this.fetchText(slide.src);

--- a/packages/peitho-present/src/fontsReady.ts
+++ b/packages/peitho-present/src/fontsReady.ts
@@ -1,0 +1,61 @@
+export interface WaitForFontsReadyOptions {
+  timeoutMs?: number;
+  log?: Pick<Console, "warn">;
+}
+
+const MAX_FONT_READY_PASSES = 5;
+
+export async function waitForFontsReady(
+  doc: Document,
+  win: Window,
+  options?: WaitForFontsReadyOptions
+): Promise<void> {
+  const fonts = doc.fonts;
+  if (fonts == null) return;
+
+  const timeoutMs = options?.timeoutMs ?? 3000;
+  const deadline = Date.now() + timeoutMs;
+  const kicked = new WeakSet<FontFace>();
+
+  for (let pass = 0; pass < MAX_FONT_READY_PASSES; pass += 1) {
+    const hasNewFace = kickVisibleFontFaces(fonts, kicked);
+    if (!hasNewFace && pass > 0) return;
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0 || (await raceReadyWithTimeout(fonts, win, remainingMs))) {
+      const log = options?.log ?? console;
+      log.warn(`document.fonts.ready timed out after ${timeoutMs}ms`);
+      return;
+    }
+  }
+}
+
+function kickVisibleFontFaces(fonts: FontFaceSet, kicked: WeakSet<FontFace>): boolean {
+  let hasNewFace = false;
+  fonts.forEach((face) => {
+    if (kicked.has(face)) return;
+    kicked.add(face);
+    hasNewFace = true;
+    try {
+      face.load().catch(() => undefined);
+    } catch {
+      // Ignore invalid or already-failed faces; one broken font must not abort mounting.
+    }
+  });
+  return hasNewFace;
+}
+
+async function raceReadyWithTimeout(fonts: FontFaceSet, win: Window, ms: number): Promise<boolean> {
+  let timeoutId: number | undefined;
+  const timeout = new Promise<"timeout">((resolve) => {
+    timeoutId = win.setTimeout(() => resolve("timeout"), ms);
+  });
+
+  const ready = fonts.ready.then(
+    () => "ready" as const,
+    () => "ready" as const
+  );
+  const result = await Promise.race([ready, timeout]);
+  if (timeoutId !== undefined) win.clearTimeout(timeoutId);
+  return result === "timeout";
+}

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -3,6 +3,7 @@ import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { calculateCanvasFit, type CanvasViewport } from "./canvas";
 import { createClickNavigationGuard } from "./clickNavigationGuard";
 import { installDocumentFontScope } from "./fontscope";
+import { waitForFontsReady } from "./fontsReady";
 import { hasChordModifier } from "./keyboard";
 import type { NavigateTarget, SlideChangeDetail } from "./shell";
 import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
@@ -35,7 +36,7 @@ export type PreviewShellOptions = {
   fetcher?: typeof fetch;
   window?: Window;
   document?: Document;
-  console?: Pick<Console, "error">;
+  console?: Pick<Console, "error"> & Partial<Pick<Console, "warn">>;
   bus?: EventTarget;
   storage?: Storage;
   syncUrl?: string;
@@ -161,7 +162,7 @@ class PreviewShellController implements PreviewShell {
   private readonly fetcher: typeof fetch;
   private readonly win: Window;
   private readonly doc: Document;
-  private readonly log: Pick<Console, "error">;
+  private readonly log: Pick<Console, "error" | "warn">;
   private readonly bus: EventTarget;
   private readonly storage?: Storage;
   private readonly syncUrl: string;
@@ -198,7 +199,8 @@ class PreviewShellController implements PreviewShell {
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
-    this.log = options.console ?? console;
+    const log = options.console ?? console;
+    this.log = { error: log.error, warn: log.warn ?? console.warn.bind(console) };
     this.bus = options.bus ?? this.win;
     this.storage = options.storage ?? this.win.sessionStorage;
     this.syncUrl = options.syncUrl ?? "/sync";
@@ -227,6 +229,7 @@ class PreviewShellController implements PreviewShell {
       this.setCanvasRootProperties(this.dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
       this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
+      await waitForFontsReady(this.doc, this.win, { log: this.log });
       const pending = await Promise.all(
         manifest.slides.map(async (slide) => {
           const html = await this.fetchText(slide.src);

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -2,6 +2,7 @@ import type { Manifest } from "../../../bindings/Manifest";
 import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { installCanvasScaler, type CanvasViewport } from "./canvas";
 import { installDocumentFontScope } from "./fontscope";
+import { waitForFontsReady } from "./fontsReady";
 import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
 
 export type NavigateTarget =
@@ -44,7 +45,7 @@ export type ShellOptions = {
   fetcher?: typeof fetch;
   window?: Window;
   document?: Document;
-  console?: Pick<Console, "error">;
+  console?: Pick<Console, "error"> & Partial<Pick<Console, "warn">>;
   bus?: EventTarget;
   now?: () => number;
   viewport?: () => CanvasViewport;
@@ -510,7 +511,7 @@ class PresentShellController implements PresentShell {
   private readonly injectedManifest?: Manifest;
   private readonly win: Window;
   private readonly doc: Document;
-  private readonly log: Pick<Console, "error">;
+  private readonly log: Pick<Console, "error" | "warn">;
   private readonly bus: EventTarget;
   private readonly now: () => number;
   private readonly viewport?: () => CanvasViewport;
@@ -545,7 +546,8 @@ class PresentShellController implements PresentShell {
     this.fetcher = options.fetcher ?? fetch.bind(globalThis);
     this.win = options.window ?? window;
     this.doc = options.document ?? document;
-    this.log = options.console ?? console;
+    const log = options.console ?? console;
+    this.log = { error: log.error, warn: log.warn ?? console.warn.bind(console) };
     this.bus = options.bus ?? this.win;
     this.now = options.now ?? Date.now;
     this.viewport = options.viewport;
@@ -572,6 +574,7 @@ class PresentShellController implements PresentShell {
       this.setCanvasRootProperties(dimensions, cssAspect);
       const css = await this.fetchText("peitho.css");
       this.fontScopeCleanup = installDocumentFontScope(this.doc, css);
+      await waitForFontsReady(this.doc, this.win, { log: this.log });
       const pending: SlideView[] = [];
       for (const slide of manifest.slides) {
         const html = await this.fetchText(slide.src);

--- a/packages/peitho-present/test/fontsReady.test.ts
+++ b/packages/peitho-present/test/fontsReady.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { waitForFontsReady } from "../src/fontsReady";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(count = 10): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+type FontFaceStub = {
+  load: () => Promise<unknown>;
+};
+
+function defineFonts(
+  doc: Document,
+  {
+    status,
+    ready,
+    faces = []
+  }: {
+    status: FontFaceSet["status"];
+    ready: Promise<unknown> | (() => Promise<unknown>);
+    faces?: FontFaceStub[] | (() => FontFaceStub[]);
+  }
+): void {
+  Object.defineProperty(doc, "fonts", {
+    configurable: true,
+    value: {
+      status,
+      get ready(): Promise<unknown> {
+        return typeof ready === "function" ? ready() : ready;
+      },
+      forEach: (callback: (face: FontFace) => void) => {
+        const visibleFaces = typeof faces === "function" ? faces() : faces;
+        for (const face of visibleFaces) callback(face as unknown as FontFace);
+      }
+    }
+  });
+}
+
+it("resolves immediately without registering a timer when doc.fonts is undefined", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  Object.defineProperty(doc, "fonts", { configurable: true, value: undefined });
+  const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+
+  await expect(waitForFontsReady(doc, window)).resolves.toBeUndefined();
+
+  expect(setTimeoutSpy).not.toHaveBeenCalled();
+});
+
+it("waits until doc.fonts.ready resolves when fonts are still loading", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  const ready = deferred<void>();
+  defineFonts(doc, { status: "loading", ready: ready.promise });
+  const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+  let resolved = false;
+
+  const waiting = waitForFontsReady(doc, window).then(() => {
+    resolved = true;
+  });
+  await Promise.resolve();
+
+  expect(resolved).toBe(false);
+
+  ready.resolve();
+  await waiting;
+
+  expect(resolved).toBe(true);
+  expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+});
+
+it("resolves after the default timeout and warns when doc.fonts.ready never resolves", async () => {
+  vi.useFakeTimers();
+  const doc = document.implementation.createHTMLDocument("test");
+  defineFonts(doc, { status: "loading", ready: new Promise<void>(() => {}) });
+  const win = {
+    setTimeout: window.setTimeout.bind(window),
+    clearTimeout: window.clearTimeout.bind(window),
+    console: window.console
+  } as unknown as Window;
+  const log = { warn: vi.fn() };
+  let resolved = false;
+
+  const waiting = waitForFontsReady(doc, win, { log }).then(() => {
+    resolved = true;
+  });
+  await Promise.resolve();
+
+  expect(resolved).toBe(false);
+
+  await vi.advanceTimersByTimeAsync(3000);
+  await waiting;
+
+  expect(resolved).toBe(true);
+  expect(log.warn).toHaveBeenCalledTimes(1);
+  expect(log.warn.mock.calls[0]?.[0]).toContain("timed out");
+  expect(log.warn.mock.calls[0]?.[0]).toContain("3000ms");
+});
+
+it("respects a custom timeoutMs", async () => {
+  vi.useFakeTimers();
+  const doc = document.implementation.createHTMLDocument("test");
+  defineFonts(doc, { status: "loading", ready: new Promise<void>(() => {}) });
+  const win = {
+    setTimeout: window.setTimeout.bind(window),
+    clearTimeout: window.clearTimeout.bind(window),
+    console: window.console
+  } as unknown as Window;
+  const log = { warn: vi.fn() };
+  let resolved = false;
+
+  const waiting = waitForFontsReady(doc, win, { timeoutMs: 500, log }).then(() => {
+    resolved = true;
+  });
+  await Promise.resolve();
+
+  await vi.advanceTimersByTimeAsync(400);
+  expect(resolved).toBe(false);
+  expect(log.warn).not.toHaveBeenCalled();
+
+  await vi.advanceTimersByTimeAsync(100);
+  await Promise.resolve();
+
+  expect(resolved).toBe(true);
+  await waiting;
+  expect(log.warn).toHaveBeenCalledTimes(1);
+  expect(log.warn.mock.calls[0]?.[0]).toContain("500ms");
+});
+
+it("kicks .load() on each declared face before awaiting ready", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  const firstFace = { load: vi.fn(async () => undefined) };
+  const secondFace = { load: vi.fn(async () => undefined) };
+  let readyResolved = false;
+  defineFonts(doc, {
+    status: "loading",
+    ready: Promise.resolve().then(() => {
+      readyResolved = true;
+    }),
+    faces: [firstFace, secondFace]
+  });
+
+  const waiting = waitForFontsReady(doc, window);
+
+  expect(firstFace.load).toHaveBeenCalledTimes(1);
+  expect(secondFace.load).toHaveBeenCalledTimes(1);
+  expect(readyResolved).toBe(false);
+
+  await waiting;
+});
+
+it("kicks .load() even when declared faces exist while the set reports loaded", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  const face = { load: vi.fn(async () => undefined) };
+  defineFonts(doc, {
+    status: "loaded",
+    ready: Promise.resolve(),
+    faces: [face]
+  });
+
+  await expect(waitForFontsReady(doc, window)).resolves.toBeUndefined();
+
+  expect(face.load).toHaveBeenCalledTimes(1);
+});
+
+it("swallows synchronous throws from face.load()", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  const face = {
+    load: vi.fn(() => {
+      throw new Error("invalid");
+    })
+  };
+  defineFonts(doc, {
+    status: "loading",
+    ready: Promise.resolve(),
+    faces: [face]
+  });
+
+  await expect(waitForFontsReady(doc, window)).resolves.toBeUndefined();
+
+  expect(face.load).toHaveBeenCalledTimes(1);
+});
+
+it("swallows rejections from face.load()", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  const face = { load: vi.fn(async () => Promise.reject(new Error("net"))) };
+  defineFonts(doc, {
+    status: "loading",
+    ready: Promise.resolve(),
+    faces: [face]
+  });
+
+  await expect(waitForFontsReady(doc, window)).resolves.toBeUndefined();
+
+  expect(face.load).toHaveBeenCalledTimes(1);
+});
+
+it("resolves without warning when fonts are already loaded", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  defineFonts(doc, { status: "loaded", ready: Promise.resolve() });
+  const log = { warn: vi.fn() };
+
+  await expect(waitForFontsReady(doc, window, { log })).resolves.toBeUndefined();
+
+  expect(log.warn).not.toHaveBeenCalled();
+});
+
+it("picks up faces that appear after the first pass", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  const firstReady = deferred<void>();
+  const secondReady = deferred<void>();
+  const firstFace = { load: vi.fn(async () => undefined) };
+  const secondFace = { load: vi.fn(async () => undefined) };
+  const readyPromises = [firstReady.promise, secondReady.promise];
+  let readyAccesses = 0;
+  let forEachCalls = 0;
+  const log = { warn: vi.fn() };
+  defineFonts(doc, {
+    status: "loaded",
+    ready: () => readyPromises[readyAccesses++] ?? Promise.resolve(),
+    faces: () => {
+      forEachCalls += 1;
+      return forEachCalls === 1 ? [] : [firstFace, secondFace];
+    }
+  });
+
+  const waiting = waitForFontsReady(doc, window, { log });
+  await Promise.resolve();
+
+  expect(firstFace.load).not.toHaveBeenCalled();
+  expect(secondFace.load).not.toHaveBeenCalled();
+
+  firstReady.resolve();
+  await flushMicrotasks();
+
+  expect(firstFace.load).toHaveBeenCalledTimes(1);
+  expect(secondFace.load).toHaveBeenCalledTimes(1);
+
+  secondReady.resolve();
+  await waiting;
+
+  expect(readyAccesses).toBe(2);
+  expect(forEachCalls).toBe(3);
+  expect(log.warn).not.toHaveBeenCalled();
+});
+
+it("stops after a post-ready pass with no new faces", async () => {
+  const doc = document.implementation.createHTMLDocument("test");
+  let readyAccesses = 0;
+  let forEachCalls = 0;
+  const log = { warn: vi.fn() };
+  defineFonts(doc, {
+    status: "loaded",
+    ready: () => {
+      readyAccesses += 1;
+      return Promise.resolve();
+    },
+    faces: () => {
+      forEachCalls += 1;
+      return [];
+    }
+  });
+
+  await expect(waitForFontsReady(doc, window, { log })).resolves.toBeUndefined();
+
+  expect(readyAccesses).toBe(1);
+  expect(forEachCalls).toBe(2);
+  expect(log.warn).not.toHaveBeenCalled();
+});

--- a/packages/peitho-present/test/shell-fonts-ready.test.ts
+++ b/packages/peitho-present/test/shell-fonts-ready.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { mountPresentShell } from "../src/index";
+import type { PresentShell } from "../src/index";
+
+function okJson(value: unknown): Response {
+  return { ok: true, status: 200, json: async () => value } as Response;
+}
+
+function okText(value: string): Response {
+  return { ok: true, status: 200, text: async () => value } as Response;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(count = 50): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+const manifest = {
+  version: 1,
+  peithoVersion: "0.1.0",
+  title: "Demo",
+  slideCount: 1,
+  plannedDurationMs: null,
+  aspectRatio: "16:9",
+  canvasWidth: 1280,
+  canvasHeight: 720,
+  sections: [],
+  slides: [
+    {
+      index: 0,
+      key: "intro",
+      src: "slides/000-intro.html",
+      hasNotes: false,
+      skip: false,
+      text: { title: "", body: "", code: "" }
+    }
+  ]
+};
+
+const mountedShells: PresentShell[] = [];
+
+beforeEach(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(
+    (() => null) as HTMLCanvasElement["getContext"]
+  );
+});
+
+afterEach(() => {
+  while (mountedShells.length > 0) {
+    mountedShells.pop()?.destroy();
+  }
+  Reflect.deleteProperty(document, "fonts");
+  vi.restoreAllMocks();
+});
+
+it("waits for document fonts before appending slide hosts", async () => {
+  const root = document.createElement("main");
+  const fontsReady = deferred<void>();
+  const face = { load: vi.fn(async () => undefined) };
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: {
+      status: "loading",
+      ready: fontsReady.promise,
+      forEach: (callback: (face: FontFace) => void) => {
+        callback(face as unknown as FontFace);
+      }
+    }
+  });
+  const fetcher = vi.fn(async (url: string) => {
+    if (url === "manifest.json") return okJson(manifest);
+    if (url === "peitho.css") return okText('@font-face { font-family: "Deck"; src: url("deck.woff2"); }');
+    if (url === "slides/000-intro.html") return okText("<section><h1>Intro</h1></section>");
+    throw new Error(`unexpected ${url}`);
+  });
+
+  const mounting = mountPresentShell({
+    root,
+    fetcher: fetcher as unknown as typeof fetch,
+    window,
+    document
+  });
+  await flushMicrotasks();
+
+  expect(root.children.length).toBe(0);
+  expect(face.load).toHaveBeenCalledTimes(1);
+
+  fontsReady.resolve();
+  const shell = await mounting;
+  mountedShells.push(shell);
+
+  expect(root.children.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Closes #334

## Summary

`Shell.load()` and `Preview.load()` installed `@font-face` rules into `document.head` via `installDocumentFontScope()`, then immediately built and appended slide DOM. With `font-display: swap` (fontsource's default), the browser painted the initial slide in a fallback font and then swapped mid-view to the deck's webfont — the reflow-during-view reported on deployed decks.

Add `waitForFontsReady(doc, win, {timeoutMs, log})` and await it after `installDocumentFontScope()` and before mounting slides in both `Shell.load()` and `Preview.load()`. Same broken invariant lived at both sites; fix removes it at both.

## Design notes

The helper does more than just `await document.fonts.ready`, because a plain wait is a no-op for how peitho actually uses fonts:

1. `installDocumentFontScope` only injects `@font-face` (and leading `@import`) at document scope. Per the CSS Font Loading spec, `@font-face` doesn't trigger a download until layout consumes the family, and peitho only consumes fonts inside per-slide shadow DOM CSS — which happens *after* our wait.
2. So the helper first iterates `document.fonts` and calls `face.load()` on every declared face to kick the downloads proactively.
3. For decks that pull fontsource-variable via `@import`, the imported stylesheet resolves asynchronously and only then registers its `@font-face` rules. The helper handles that by re-iterating after each `ready` settles, kicking any newly-visible face, and awaiting `ready` again — up to a small pass cap.
4. Bounded by a 3 s timeout that warns rather than throws, so a stalled font can't hang mounting.

The `console` field in `ShellOptions` / `PreviewShellOptions` was widened from `Pick<Console, "error">` to include an optional `warn`; existing callers passing just `{ error }` still typecheck, and the constructor falls back to global `console.warn` when `warn` is absent.

## Test plan

- [x] `cargo test --workspace` (run 3 times)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck` (309 tests pass, up from 303)
- [x] Regenerated `dist/{shell,preview,remote}.js` committed
- [ ] E2E verification on decks.gosu.ke: open an uncached browser profile, load a deck, confirm the initial paint uses the deck's webfont (no visible mid-view swap)

The E2E confirmation is what actually validates the fix against the reported symptom — the unit and integration tests pin the mounting-order invariant and the load-kicking behavior, but only a real browser + real webfonts can confirm the swap is gone.