### PR TITLE
Release v1.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.15.0"
+version = "1.15.1"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
## Summary

Patch release covering the font-swap fix from PR #335.

## Changes since v1.15.0

- #335 Wait for `document.fonts` before mounting slides so decks don't flash a fallback font (fixes #334)

## Test plan

- [x] `cargo test --workspace` (3 runs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck`
- [x] `git diff --exit-code packages/peitho-present/dist/{shell,preview,remote}.js`