### PR TITLE
Bound document.fonts.ready wait in lint_measure.js and pdf_flatten.js

### DIFF
--- a/crates/peitho-core/src/lint_measure.js
+++ b/crates/peitho-core/src/lint_measure.js
@@ -3,6 +3,7 @@
   var DONE = "PEITHO_LINT_" + "DONE";
   // Keep each console payload comfortably below macOS PIPE_BUF after Chrome's log wrapper.
   var CHUNK_SIZE = 300;
+  var FONT_READY_TIMEOUT_MS = 2000; // Below Chrome --virtual-time-budget=10000.
 
   function waitForWindowLoad() {
     if (document.readyState === "complete") {
@@ -31,7 +32,17 @@
     if (!document.fonts || !document.fonts.ready) {
       return Promise.resolve();
     }
-    return document.fonts.ready;
+    // Bound the wait: document.fonts.ready has been observed to hang
+    // indefinitely under Chrome's --virtual-time-budget on Linux headless
+    // (same pitfall class as image decode promises). If fonts don't settle
+    // in time, publish measurements against whatever font resolves at the
+    // next requestAnimationFrame; better than emitting no payload.
+    return Promise.race([
+      document.fonts.ready.then(function () {}, function () {}),
+      new Promise(function (resolve) {
+        setTimeout(resolve, FONT_READY_TIMEOUT_MS);
+      })
+    ]);
   }
 
   function waitForFrame() {

--- a/crates/peitho-core/src/pdf_flatten.js
+++ b/crates/peitho-core/src/pdf_flatten.js
@@ -3,6 +3,7 @@
   var SCALE = 2;
   var MAX_CANVAS_DIMENSION = 16384;
   var MAX_CANVAS_AREA = 268000000;
+  var FONT_READY_TIMEOUT_MS = 2000; // Below Chrome --virtual-time-budget=10000.
   var nextClassId = 0;
   var pseudoStyleElement = null;
   var rasterCache = new Map();
@@ -929,7 +930,12 @@
 
   async function waitForStableLayout() {
     if (document.fonts && document.fonts.ready) {
-      await document.fonts.ready;
+      await Promise.race([
+        document.fonts.ready.then(function () {}, function () {}),
+        new Promise(function (resolve) {
+          setTimeout(resolve, FONT_READY_TIMEOUT_MS);
+        })
+      ]);
     }
     await waitForWindowLoad();
   }

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -2740,6 +2740,15 @@ Paragraph after heading.
     }
 
     #[test]
+    fn pdf_flatten_script_bounds_font_wait_with_a_timeout() {
+        // Same class-of-bug as lint_measure.js: see Issue #337.
+        assert!(PDF_FLATTEN_JS.contains("document.fonts.ready"));
+        assert!(PDF_FLATTEN_JS.contains("FONT_READY_TIMEOUT_MS"));
+        assert!(PDF_FLATTEN_JS.contains("Promise.race"));
+        assert!(PDF_FLATTEN_JS.contains("FONT_READY_TIMEOUT_MS = 2000"));
+    }
+
+    #[test]
     fn pdf_document_uses_four_by_three_resolution_and_scale() {
         let rendered = render_checked_deck("---\naspect_ratio: 4:3\n---\n# Intro");
 
@@ -2815,6 +2824,35 @@ Paragraph after heading.
         assert!(LINT_MEASURE_JS.contains(r#""PEITHO_LINT_" + "CHUNK""#));
         assert!(LINT_MEASURE_JS.contains(r#""PEITHO_LINT_" + "DONE""#));
         assert!(!LINT_MEASURE_JS.contains("document.title"));
+    }
+
+    #[test]
+    fn lint_measure_script_bounds_font_wait_with_a_timeout() {
+        // Regression: document.fonts.ready has been observed to hang under
+        // Chrome's --virtual-time-budget, so the script must bound the wait
+        // instead of awaiting it unconditionally.
+        assert!(
+            LINT_MEASURE_JS.contains("document.fonts.ready"),
+            "expected the script to still reference document.fonts.ready"
+        );
+        assert!(
+            LINT_MEASURE_JS.contains("FONT_READY_TIMEOUT_MS"),
+            "expected a named timeout constant so the bound is discoverable"
+        );
+        assert!(
+            LINT_MEASURE_JS.contains("setTimeout"),
+            "expected a setTimeout so the wait is bounded"
+        );
+        assert!(
+            LINT_MEASURE_JS.contains("Promise.race"),
+            "expected Promise.race around the fonts.ready wait, or the timeout is dead code"
+        );
+        // The named constant must be reasonable - below the virtual-time
+        // budget so publish() still has time to run.
+        assert!(
+            LINT_MEASURE_JS.contains("FONT_READY_TIMEOUT_MS = 2000"),
+            "expected FONT_READY_TIMEOUT_MS to be 2000ms; adjust intentionally if this changes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #337

## Summary

The `e2e` CI job's lint integration tests started failing today (2026-07-21) with `Chrome completed before one-shot output was ready`. Root cause: the in-page `lint_measure.js` awaited `document.fonts.ready` unconditionally, and a recent Chrome upstream change made that promise hang forever under `--virtual-time-budget=10000` on Linux headless. Chrome then exits at the virtual-time deadline with the PDF written but no lint-payload chunks logged to stderr.

This is the same pitfall class as the already-documented `image.decode()` virtual-time hang. Chrome has now expanded that class to include `document.fonts.ready`.

## Fix

Wrap `document.fonts.ready` in `Promise.race` against a 2 s `setTimeout` in both in-page scripts that run under a Chrome one-shot with `--virtual-time-budget`:

- `crates/peitho-core/src/lint_measure.js` — the script that emits the base64 lint payload.
- `crates/peitho-core/src/pdf_flatten.js` — the script that flattens gradients/shadows in the PDF export path.

Both scripts declare `FONT_READY_TIMEOUT_MS = 2000` as a named tuning constant near the top; the comment notes it sits well below `--virtual-time-budget=10000` so the rest of the pipeline (image wait, RAF, publish) still has room.

Only `lint_measure.js` has been observed to fail in the wild today, but per the repo's root-cause rule the fix has to remove the invariant at both consumer sites — `pdf_flatten.js` has the same shape and would regress identically the next time Chrome's virtual-time treatment moves.

Regression tests in `crates/peitho-core/src/render.rs` pin the pattern in both scripts: `Promise.race` present, `FONT_READY_TIMEOUT_MS` named, value 2000.

## Tradeoff

If fonts happen to settle at 2001 ms, `lint` measures against fallback metrics for one frame instead of the real webfont. That's worse than perfect but strictly better than emitting no payload at all (which is what CI has been seeing today). Same tradeoff already made by the CI thumbnail script in the `decks` repo.

## Test plan

- [x] `cargo test --workspace` (3 runs, all green)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --exit-code bindings/`
- [x] `cd packages/peitho-present && npm run build && npm test && npm run typecheck` (309 tests, unaffected)
- [x] `git diff --exit-code packages/peitho-present/dist/{shell,preview,remote}.js`
- [ ] Confirm the Linux e2e job passes on this PR — this is the real test of the fix. The change targets exactly the CI failure signature reported in #337.