### PR TITLE
Sync reveal step state atomically across server, shell, and remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packages/peitho-present/dist/*
 site/static/giallo.css
 site/static/deck-sources/
 .zola-examples/
+.worktrees/

--- a/crates/peitho/src/server.rs
+++ b/crates/peitho/src/server.rs
@@ -79,6 +79,7 @@ struct SyncState {
     seq: u64,
     latest: Option<String>,
     index: Option<usize>,
+    step: Option<usize>,
     swapped: bool,
     timer: Option<TimerSyncState>,
     generation: u64,
@@ -91,6 +92,7 @@ impl Default for SyncState {
             seq: 0,
             latest: None,
             index: None,
+            step: None,
             swapped: false,
             timer: None,
             generation: 0,
@@ -117,6 +119,7 @@ struct SyncPoll {
 struct SyncSnapshot {
     seq: u64,
     index: Option<usize>,
+    step: Option<usize>,
     swapped: bool,
     timer: Option<TimerSyncState>,
     generation: u64,
@@ -128,7 +131,10 @@ impl SyncHub {
         let (lock, cvar) = &*self.state;
         let mut state = lock.lock().expect("sync hub mutex");
         match message {
-            SyncMessage::Index(message) => state.index = Some(message.index),
+            SyncMessage::Index(message) => {
+                state.index = Some(message.index);
+                state.step = Some(message.step);
+            }
             SyncMessage::Swap(message) => state.swapped = message.swapped,
             SyncMessage::Timer(message) => {
                 state.timer = Some(TimerSyncState {
@@ -171,6 +177,7 @@ impl SyncHub {
             snapshot: SyncSnapshot {
                 seq: state.seq,
                 index: state.index,
+                step: state.step,
                 swapped: state.swapped,
                 timer: state.timer,
                 generation: state.generation,
@@ -186,6 +193,7 @@ impl SyncHub {
         SyncSnapshot {
             seq: state.seq,
             index: state.index,
+            step: state.step,
             swapped: state.swapped,
             timer: state.timer,
             generation: state.generation,
@@ -840,6 +848,7 @@ enum SyncMessage {
 #[serde(deny_unknown_fields)]
 struct SyncIndexMessage {
     index: usize,
+    step: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -991,6 +1000,7 @@ fn sync_response_body(snapshot: SyncSnapshot, message: Option<&str>) -> String {
         seq: u64,
         message: Option<Value>,
         index: Option<usize>,
+        step: Option<usize>,
         swapped: bool,
         generation: u64,
         session: String,
@@ -1004,6 +1014,7 @@ fn sync_response_body(snapshot: SyncSnapshot, message: Option<&str>) -> String {
         seq: snapshot.seq,
         message,
         index: snapshot.index,
+        step: snapshot.step,
         swapped: snapshot.swapped,
         generation: snapshot.generation,
         session: snapshot.session,
@@ -1464,7 +1475,7 @@ mod tests {
         let hub = SyncHub::default();
         let session = hub.snapshot().session;
 
-        let message = SyncMessage::Index(SyncIndexMessage { index: 2 });
+        let message = SyncMessage::Index(SyncIndexMessage { index: 2, step: 0 });
         let seq = hub.broadcast_sync_message(&message);
 
         assert_eq!(seq, 1);
@@ -1474,15 +1485,42 @@ mod tests {
                 snapshot: SyncSnapshot {
                     seq: 1,
                     index: Some(2),
+                    step: Some(0),
                     swapped: false,
                     timer: None,
                     generation: 0,
                     session
                 },
-                message: Some(r#"{"index":2}"#.to_owned())
+                message: Some(r#"{"index":2,"step":0}"#.to_owned())
             }
         );
         assert!(hub.wait_after(1, Duration::from_millis(1)).is_none());
+    }
+
+    #[test]
+    fn sync_hub_stores_index_and_step_atomically() {
+        let hub = SyncHub::default();
+        let session = hub.snapshot().session;
+
+        let message = SyncMessage::Index(SyncIndexMessage { index: 2, step: 3 });
+        let seq = hub.broadcast_sync_message(&message);
+
+        assert_eq!(seq, 1);
+        assert_eq!(
+            hub.wait_after(0, Duration::from_secs(1)).unwrap(),
+            SyncPoll {
+                snapshot: SyncSnapshot {
+                    seq: 1,
+                    index: Some(2),
+                    step: Some(3),
+                    swapped: false,
+                    timer: None,
+                    generation: 0,
+                    session
+                },
+                message: Some(r#"{"index":2,"step":3}"#.to_owned())
+            }
+        );
     }
 
     #[test]
@@ -1563,6 +1601,7 @@ mod tests {
                 snapshot: SyncSnapshot {
                     seq: 1,
                     index: None,
+                    step: None,
                     swapped: false,
                     timer: None,
                     generation: 1,
@@ -1576,6 +1615,7 @@ mod tests {
             SyncSnapshot {
                 seq: 1,
                 index: None,
+                step: None,
                 swapped: false,
                 timer: None,
                 generation: 1,
@@ -1589,7 +1629,7 @@ mod tests {
         let hub = SyncHub::default();
         let session = hub.snapshot().session;
 
-        hub.broadcast_sync_message(&SyncMessage::Index(SyncIndexMessage { index: 1 }));
+        hub.broadcast_sync_message(&SyncMessage::Index(SyncIndexMessage { index: 1, step: 0 }));
         let poll = hub.wait_after(0, Duration::from_secs(1)).unwrap();
 
         assert_eq!(poll.snapshot.session, session);
@@ -1704,6 +1744,7 @@ mod tests {
             SyncSnapshot {
                 seq: 4,
                 index: Some(2),
+                step: Some(1),
                 swapped: true,
                 timer: Some(TimerSyncState {
                     running: true,
@@ -1721,6 +1762,7 @@ mod tests {
         assert!(body.contains(r#""session":"session-a""#));
         assert!(body.contains(r#""message":null"#));
         assert!(body.contains(r#""index":2"#));
+        assert!(body.contains(r#""step":1"#));
         assert!(body.contains(r#""swapped":true"#));
         assert_eq!(json["timer"]["running"], true);
         assert_eq!(json["timer"]["elapsedMs"], 12_000);
@@ -1729,11 +1771,32 @@ mod tests {
     }
 
     #[test]
+    fn sync_response_body_includes_step() {
+        let body = sync_response_body(
+            SyncSnapshot {
+                seq: 4,
+                index: Some(2),
+                step: Some(1),
+                swapped: false,
+                timer: None,
+                generation: 0,
+                session: "session-a".to_owned(),
+            },
+            None,
+        );
+
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["index"], 2);
+        assert_eq!(json["step"], 1);
+    }
+
+    #[test]
     fn sync_response_body_includes_session() {
         let body = sync_response_body(
             SyncSnapshot {
                 seq: 4,
                 index: None,
+                step: None,
                 swapped: false,
                 timer: None,
                 generation: 0,
@@ -1752,6 +1815,7 @@ mod tests {
             SyncSnapshot {
                 seq: 7,
                 index: Some(2),
+                step: Some(0),
                 swapped: false,
                 timer: None,
                 generation: 0,
@@ -1807,6 +1871,11 @@ mod tests {
     #[test]
     fn reload_is_not_accepted_as_a_posted_sync_message() {
         assert!(serde_json::from_str::<SyncMessage>(r#"{"reload":true}"#).is_err());
+    }
+
+    #[test]
+    fn bare_index_sync_messages_are_rejected() {
+        assert!(serde_json::from_str::<SyncMessage>(r#"{"index":2}"#).is_err());
     }
 
     #[test]
@@ -2104,7 +2173,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let server = PresentServer::bind(dir.path().to_path_buf(), 0, "present.html").unwrap();
 
-        let post = http_request(&server, "POST", "/sync", r#"{"index":2}"#);
+        let post = http_request(&server, "POST", "/sync", r#"{"index":2,"step":0}"#);
         let get = http_request(&server, "GET", "/sync", "");
 
         assert_eq!(post.status, 200);
@@ -2114,6 +2183,34 @@ mod tests {
             serde_json::from_str::<Value>(&get.body).unwrap()["index"],
             2
         );
+        assert_eq!(serde_json::from_str::<Value>(&get.body).unwrap()["step"], 0);
+    }
+
+    #[test]
+    fn sync_endpoint_accepts_index_step_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = PresentServer::bind(dir.path().to_path_buf(), 0, "present.html").unwrap();
+
+        let post = http_request(&server, "POST", "/sync", r#"{"index":2,"step":1}"#);
+        let get = http_request(&server, "GET", "/sync", "");
+
+        assert_eq!(post.status, 200);
+        assert_eq!(
+            serde_json::from_str::<Value>(&get.body).unwrap()["index"],
+            2
+        );
+        assert_eq!(serde_json::from_str::<Value>(&get.body).unwrap()["step"], 1);
+    }
+
+    #[test]
+    fn sync_endpoint_rejects_bare_index_body() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = PresentServer::bind(dir.path().to_path_buf(), 0, "present.html").unwrap();
+
+        let response = http_request(&server, "POST", "/sync", r#"{"index":2}"#);
+
+        assert_eq!(response.status, 400);
+        assert_eq!(response.body, "invalid sync body\n");
     }
 
     #[derive(Debug)]

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -419,15 +419,16 @@ fn present_server_relays_sync_post_to_long_poll_subscriber() {
     poll.write_all(b"GET /sync?seq=0 HTTP/1.1\r\nHost: localhost\r\n\r\n")
         .unwrap();
 
-    let post_response = post_sync(addr, r#"{"index":1}"#);
+    let post_response = post_sync(addr, r#"{"index":1,"step":4}"#);
     assert_sync_post_ack(&post_response, 1);
 
     let event = read_until_contains(&mut poll, r#""swapped":false"#);
     assert!(event.contains("200 OK"));
     assert!(event.contains("application/json"));
     assert!(event.contains(r#""seq":1"#));
-    assert!(event.contains(r#""message":{"index":1}"#));
+    assert!(event.contains(r#""message":{"index":1,"step":4}"#));
     assert!(event.contains(r#""index":1"#));
+    assert!(event.contains(r#""step":4"#));
     assert!(event.contains(r#""swapped":false"#));
     assert!(event.contains(r#""generation":0"#));
 
@@ -454,15 +455,16 @@ fn present_server_poll_response_includes_current_replay_state() {
     poll.write_all(b"GET /sync?seq=1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
         .unwrap();
 
-    let index_response = post_sync(addr, r#"{"index":3}"#);
+    let index_response = post_sync(addr, r#"{"index":3,"step":2}"#);
     assert_sync_post_ack(&index_response, 2);
 
     let event = read_until_contains(&mut poll, r#""swapped":true"#);
     assert!(event.contains("200 OK"));
     assert!(event.contains("application/json"));
     assert!(event.contains(r#""seq":2"#));
-    assert!(event.contains(r#""message":{"index":3}"#));
+    assert!(event.contains(r#""message":{"index":3,"step":2}"#));
     assert!(event.contains(r#""index":3"#));
+    assert!(event.contains(r#""step":2"#));
     assert!(event.contains(r#""swapped":true"#));
     assert!(event.contains(r#""generation":0"#));
 
@@ -495,6 +497,7 @@ fn present_server_relays_swap_sync_post_to_long_poll_subscriber() {
     assert!(event.contains(r#""seq":1"#));
     assert!(event.contains(r#""message":{"swapped":true}"#));
     assert!(event.contains(r#""index":null"#));
+    assert!(event.contains(r#""step":null"#));
     assert!(event.contains(r#""swapped":true"#));
     assert!(event.contains(r#""generation":0"#));
 
@@ -525,6 +528,7 @@ fn present_server_relays_close_sync_post_to_long_poll_subscriber() {
     assert!(event.contains("200 OK"));
     assert!(event.contains(r#""seq":1"#));
     assert!(event.contains(r#""message":{"close":true}"#));
+    assert!(event.contains(r#""step":null"#));
     assert!(event.contains(r#""generation":0"#));
 
     drop(poll);
@@ -551,6 +555,7 @@ fn present_server_broadcast_reload_reaches_long_poll_subscriber() {
     assert_eq!(body["seq"], 1);
     assert!(body["message"].is_null());
     assert!(body["index"].is_null());
+    assert!(body["step"].is_null());
     assert_eq!(body["swapped"], false);
     assert_eq!(body["generation"], 1);
     handle.join().unwrap();
@@ -575,6 +580,7 @@ fn present_server_reload_does_not_change_handshake_replay_state() {
     assert_eq!(body["seq"], 1);
     assert!(body["message"].is_null());
     assert!(body["index"].is_null());
+    assert!(body["step"].is_null());
     assert_eq!(body["swapped"], false);
     assert_eq!(body["generation"], 1);
     handle.join().unwrap();
@@ -635,6 +641,7 @@ fn present_server_sync_handshake_returns_current_seq_without_replaying_latest_me
     assert!(response.contains(r#""seq":1"#));
     assert!(response.contains(r#""message":null"#));
     assert!(response.contains(r#""index":null"#));
+    assert!(response.contains(r#""step":null"#));
     assert!(response.contains(r#""swapped":false"#));
     assert!(response.contains(r#""generation":0"#));
     assert!(!response.contains(r#""close":true"#));
@@ -658,6 +665,7 @@ fn present_server_sync_initial_handshake_returns_replay_state_defaults() {
     assert_eq!(body["seq"], 0);
     assert!(body["message"].is_null());
     assert!(body["index"].is_null());
+    assert!(body["step"].is_null());
     assert_eq!(body["swapped"], false);
     assert_eq!(body["generation"], 0);
     handle.join().unwrap();
@@ -678,7 +686,7 @@ fn present_server_sync_handshake_replays_index_and_swapped_after_broadcasts() {
         server.handle_one();
     });
 
-    let index_response = post_sync(addr, r#"{"index":2}"#);
+    let index_response = post_sync(addr, r#"{"index":2,"step":5}"#);
     assert_sync_post_ack(&index_response, 1);
     let swap_response = post_sync(addr, r#"{"swapped":true}"#);
     assert_sync_post_ack(&swap_response, 2);
@@ -688,6 +696,7 @@ fn present_server_sync_handshake_replays_index_and_swapped_after_broadcasts() {
     assert_eq!(body["seq"], 2);
     assert!(body["message"].is_null());
     assert_eq!(body["index"], 2);
+    assert_eq!(body["step"], 5);
     assert_eq!(body["swapped"], true);
     assert_eq!(body["generation"], 0);
     handle.join().unwrap();
@@ -709,7 +718,7 @@ fn present_server_sync_close_does_not_clobber_replay_state() {
         server.handle_one();
     });
 
-    let index_response = post_sync(addr, r#"{"index":2}"#);
+    let index_response = post_sync(addr, r#"{"index":2,"step":6}"#);
     assert_sync_post_ack(&index_response, 1);
     let swap_response = post_sync(addr, r#"{"swapped":true}"#);
     assert_sync_post_ack(&swap_response, 2);
@@ -721,6 +730,7 @@ fn present_server_sync_close_does_not_clobber_replay_state() {
     assert_eq!(body["seq"], 3);
     assert!(body["message"].is_null());
     assert_eq!(body["index"], 2);
+    assert_eq!(body["step"], 6);
     assert_eq!(body["swapped"], true);
     assert_eq!(body["generation"], 0);
     handle.join().unwrap();
@@ -805,7 +815,7 @@ fn present_server_rejects_mixed_sync_post_body() {
     let addr = server.addr();
     let handle = thread::spawn(move || server.handle_one());
 
-    let response = post_sync(addr, r#"{"index":1,"close":true}"#);
+    let response = post_sync(addr, r#"{"index":1,"step":0,"close":true}"#);
 
     assert!(response.contains("400 Bad Request"));
     handle.join().unwrap();

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -298,8 +298,11 @@ var SWAP_ROUTES = Object.freeze({
 function isRecord(value) {
   return typeof value === "object" && value !== null;
 }
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
 function isIndexSyncMessage(value) {
-  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
+  return isRecord(value) && isFiniteNumber(value.index) && isFiniteNumber(value.step);
 }
 function isSwappedSyncMessage(value) {
   return isRecord(value) && typeof value.swapped === "boolean";
@@ -318,6 +321,13 @@ function isTimerReplaySyncMessage(value) {
 }
 function isGenerationSyncMessage(value) {
   return isRecord(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
+}
+function serverIndexReplayMessage(value) {
+  if (!isFiniteNumber(value.index)) return null;
+  return {
+    index: value.index,
+    step: isFiniteNumber(value.step) ? value.step : 0
+  };
 }
 function serverSyncChannelFactory(options = {}) {
   const url = options.url ?? "/sync";
@@ -360,8 +370,9 @@ function serverSyncChannelFactory(options = {}) {
           onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
         }
       }
-      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
-        onmessage?.({ data: { index: body.index } });
+      const indexReplay = serverIndexReplayMessage(body);
+      if (!skipAbsoluteState && indexReplay !== null) {
+        onmessage?.({ data: indexReplay });
       }
       if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
@@ -444,11 +455,12 @@ function serverSyncChannelFactory(options = {}) {
             continue;
           }
           seq = body.seq;
-          if (body.message != null) {
+          const skipAbsoluteState = body.seq < highestAckedPostSeq;
+          if (body.message != null && !(skipAbsoluteState && isIndexSyncMessage(body.message))) {
             onmessage?.({ data: body.message });
           }
           deliverReplayState(body, {
-            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            skipAbsoluteState,
             deferTimerReplay: pendingTimerPosts > 0
           });
         } catch (error) {

--- a/packages/peitho-present/dist/remote.js
+++ b/packages/peitho-present/dist/remote.js
@@ -297,12 +297,39 @@ function initialSlideIndex(slides) {
   return nextNonSkippedIndex(slides, -1, 1) ?? 0;
 }
 
+// src/stepnav.ts
+function revealStepCount(slide) {
+  const value = slide?.revealSteps;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+function clampStep(step, stepCount) {
+  if (!Number.isFinite(step)) return 0;
+  return Math.max(0, Math.min(Math.floor(step), stepCount));
+}
+function resolveStepTarget(slides, position, direction) {
+  if (direction === 1) {
+    const stepCount = revealStepCount(slides[position.index]);
+    if (position.step < stepCount) {
+      return { index: position.index, step: position.step + 1 };
+    }
+    const index2 = nextNonSkippedIndex(slides, position.index, 1);
+    return index2 === null ? null : { index: index2, step: 0 };
+  }
+  if (position.step > 0) {
+    return { index: position.index, step: position.step - 1 };
+  }
+  const index = nextNonSkippedIndex(slides, position.index, -1);
+  return index === null ? null : { index, step: revealStepCount(slides[index]) };
+}
+
 // src/shell.ts
 var DEFAULT_POINTER_BASE_COLOR = "#38bdf8";
 var DEFAULT_POINTER_CORE_COLOR = "#e0f2fe";
 var POINTER_TRAIL_DURATION_MS = 500;
 var POINTER_TRAIL_CAP = 64;
 var POINTER_CORE_MIX_TO_WHITE = 0.65;
+var REVEAL_HIDDEN_CSS = "[data-reveal-hidden]{visibility:hidden}";
 var CSS_NAMED_COLORS = {
   aliceblue: "#f0f8ff",
   antiquewhite: "#faebd7",
@@ -679,6 +706,7 @@ function installPointerOverlay(options) {
 var PresentShellController = class {
   manifest = null;
   currentIndex = -1;
+  currentStep = 0;
   slides = [];
   root;
   fetcher;
@@ -758,7 +786,7 @@ var PresentShellController = class {
         this.root.appendChild(view.host);
         this.slides.push(view);
       }
-      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0, 0);
       this.mountPointerOverlay();
     } catch (error) {
       this.clearCanvasRootProperties();
@@ -767,9 +795,9 @@ var PresentShellController = class {
     }
   }
   navigate(to) {
-    const index = this.resolveTarget(to);
-    if (index === null) return;
-    this.show(index);
+    const target = this.resolveTarget(to);
+    if (target === null) return;
+    this.show(target.index, target.step);
   }
   elapsedMs() {
     if (this.startedAtValue === null) return 0;
@@ -858,6 +886,9 @@ var PresentShellController = class {
     const style = this.doc.createElement("style");
     style.textContent = css;
     shadow.appendChild(style);
+    const revealStyle = this.doc.createElement("style");
+    revealStyle.textContent = REVEAL_HIDDEN_CSS;
+    shadow.appendChild(revealStyle);
     const template = this.doc.createElement("template");
     template.innerHTML = html;
     shadow.appendChild(template.content.cloneNode(true));
@@ -885,8 +916,8 @@ var PresentShellController = class {
     });
   }
   resolveTarget(to) {
-    if (to === "first") return 0;
-    if (to === "last") return this.slides.length - 1;
+    if (to === "first") return this.resolveDirectIndex(0);
+    if (to === "last") return this.resolveDirectIndex(this.slides.length - 1);
     if (to === "next") return this.resolveSequentialTarget(1);
     if (to === "prev") return this.resolveSequentialTarget(-1);
     if ("index" in to) {
@@ -894,44 +925,86 @@ var PresentShellController = class {
         this.log.error(`Unknown slide index: ${to.index}`);
         return null;
       }
-      return to.index;
+      return this.resolveDirectIndex(to.index, to.step);
     }
     const index = this.slides.findIndex((slide) => slide.meta.key === to.key);
     if (index < 0) {
       this.log.error(`Unknown slide key: ${to.key}`);
       return null;
     }
-    return index;
+    return this.resolveDirectIndex(index);
+  }
+  resolveDirectIndex(index, step) {
+    if (index < 0 || index >= this.slides.length) return null;
+    const stepCount = this.stepCountFor(index);
+    return {
+      index,
+      step: step === void 0 ? stepCount : clampStep(step, stepCount)
+    };
   }
   resolveSequentialTarget(direction) {
-    return nextNonSkippedIndex(
+    return resolveStepTarget(
       this.slides.map((slide) => slide.meta),
-      this.currentIndex,
+      { index: this.currentIndex, step: this.currentStep },
       direction
     );
   }
-  show(index) {
+  stepCountFor(index) {
+    return revealStepCount(this.slides[index]?.meta);
+  }
+  show(index, step) {
     if (index < 0 || index >= this.slides.length) {
       this.log.error(`Unknown slide target: ${index}`);
       return;
     }
-    if (index === this.currentIndex) return;
+    const stepCount = this.stepCountFor(index);
+    const nextStep = clampStep(step, stepCount);
+    const indexChanged = index !== this.currentIndex;
+    const stepChanged = nextStep !== this.currentStep;
+    if (!indexChanged && !stepChanged) return;
     this.slides.forEach((slide2, slideIndex) => {
       slide2.host.hidden = slideIndex !== index;
     });
     const previousIndex = this.currentIndex < 0 ? null : this.currentIndex;
     this.currentIndex = index;
+    this.currentStep = nextStep;
     const slide = this.slides[index];
+    this.applyRevealState(slide.host, nextStep);
+    if (indexChanged) {
+      this.bus.dispatchEvent(
+        new CustomEvent("peitho:slidechange", {
+          detail: {
+            key: slide.meta.key,
+            index: slide.meta.index,
+            total: this.slides.length,
+            previousIndex,
+            step: nextStep,
+            stepCount
+          }
+        })
+      );
+      return;
+    }
     this.bus.dispatchEvent(
-      new CustomEvent("peitho:slidechange", {
+      new CustomEvent("peitho:stepchange", {
         detail: {
-          key: slide.meta.key,
           index: slide.meta.index,
-          total: this.slides.length,
-          previousIndex
+          step: nextStep,
+          stepCount
         }
       })
     );
+  }
+  applyRevealState(host, step) {
+    const markers = host.shadowRoot?.querySelectorAll("[data-reveal-step]");
+    if (markers == null) return;
+    for (const marker of markers) {
+      const revealStep = Number(marker.dataset.revealStep);
+      marker.toggleAttribute(
+        "data-reveal-hidden",
+        Number.isFinite(revealStep) && revealStep > step
+      );
+    }
   }
   startPresentation() {
     if (this.startedAtValue !== null) return;
@@ -1114,8 +1187,11 @@ function isRecord2(value) {
 function isCloseSyncMessage(value) {
   return isRecord2(value) && value.close === true;
 }
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
 function isIndexSyncMessage(value) {
-  return isRecord2(value) && typeof value.index === "number" && Number.isFinite(value.index);
+  return isRecord2(value) && isFiniteNumber(value.index) && isFiniteNumber(value.step);
 }
 function isSwappedSyncMessage(value) {
   return isRecord2(value) && typeof value.swapped === "boolean";
@@ -1137,6 +1213,13 @@ function isTimerReplaySyncMessage(value) {
 }
 function isGenerationSyncMessage(value) {
   return isRecord2(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
+}
+function serverIndexReplayMessage(value) {
+  if (!isFiniteNumber(value.index)) return null;
+  return {
+    index: value.index,
+    step: isFiniteNumber(value.step) ? value.step : 0
+  };
 }
 function serverSyncChannelFactory(options = {}) {
   const url = options.url ?? "/sync";
@@ -1179,8 +1262,9 @@ function serverSyncChannelFactory(options = {}) {
           onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
         }
       }
-      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
-        onmessage?.({ data: { index: body.index } });
+      const indexReplay = serverIndexReplayMessage(body);
+      if (!skipAbsoluteState && indexReplay !== null) {
+        onmessage?.({ data: indexReplay });
       }
       if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
@@ -1263,11 +1347,12 @@ function serverSyncChannelFactory(options = {}) {
             continue;
           }
           seq = body.seq;
-          if (body.message != null) {
+          const skipAbsoluteState = body.seq < highestAckedPostSeq;
+          if (body.message != null && !(skipAbsoluteState && isIndexSyncMessage(body.message))) {
             onmessage?.({ data: body.message });
           }
           deliverReplayState(body, {
-            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            skipAbsoluteState,
             deferTimerReplay: pendingTimerPosts > 0
           });
         } catch (error) {
@@ -1685,10 +1770,10 @@ function installRemoteSyncBridge(options) {
     if (!synced) return;
     const to = event.detail?.to;
     if (to !== "next" && to !== "prev") return;
-    const target = resolveRemoteTarget(options.slides, options.getCurrentIndex(), to);
+    const target = resolveRemoteTarget(options.slides, options.getCurrentPosition(), to);
     if (target === null) return;
-    channel.postMessage({ index: target });
-    options.setCurrentIndex(target);
+    channel.postMessage(target);
+    options.setCurrentPosition(target);
   };
   const onTimerControl = (event) => {
     if (!synced) return;
@@ -1716,7 +1801,7 @@ function installRemoteSyncBridge(options) {
       return;
     }
     if (isIndexSyncMessage(data)) {
-      options.setCurrentIndex(data.index);
+      options.setCurrentPosition({ index: data.index, step: data.step });
       return;
     }
     if (isTimerReplaySyncMessage(data)) {
@@ -1748,7 +1833,6 @@ function installRemoteSyncBridge(options) {
 }
 var RemoteController = class {
   manifest = null;
-  currentIndex = null;
   root;
   manifestUrl;
   notesUrl;
@@ -1766,6 +1850,7 @@ var RemoteController = class {
   notes = { version: 1, notes: {} };
   renderedNotesValue = null;
   slides = [];
+  currentPosition = null;
   timerState = null;
   controlsCleanup = null;
   syncCleanup = null;
@@ -1786,6 +1871,9 @@ var RemoteController = class {
     this.now = options.now ?? Date.now;
     this.reload = options.reload ?? (() => this.win.location.reload());
   }
+  get currentIndex() {
+    return this.currentPosition?.index ?? null;
+  }
   async load() {
     try {
       const manifest = await this.fetchJson(this.manifestUrl);
@@ -1794,9 +1882,10 @@ var RemoteController = class {
       this.slides = manifest.slides.map((slide) => ({
         key: slide.key,
         skip: slide.skip === true,
-        title: slide.text.title
+        title: slide.text.title,
+        revealSteps: revealStepCount(slide)
       }));
-      this.currentIndex = initialSlideIndex(this.slides);
+      this.currentPosition = initialRemotePosition(this.slides);
       this.controlsCleanup = installRemoteControls({
         root: this.root,
         document: this.doc,
@@ -1829,8 +1918,8 @@ var RemoteController = class {
         channelFactory: this.channelFactory,
         bus: this.bus,
         now: this.now,
-        getCurrentIndex: () => this.currentIndex,
-        setCurrentIndex: (index) => this.setCurrentIndex(index),
+        getCurrentPosition: () => this.currentPosition,
+        setCurrentPosition: (position) => this.setCurrentPosition(position),
         getTimerState: () => this.timerState,
         setTimerState: (state) => this.setTimerState(state),
         setSynced: () => this.setSynced(),
@@ -1868,8 +1957,8 @@ var RemoteController = class {
       return { version: 1, notes: {} };
     }
   }
-  setCurrentIndex(index) {
-    this.currentIndex = clampIndex(index, this.slides.length);
+  setCurrentPosition(position) {
+    this.currentPosition = clampRemotePosition(position, this.slides);
     this.render();
   }
   setTimerState(state) {
@@ -1896,7 +1985,8 @@ var RemoteController = class {
     const container = this.root.querySelector(".peitho-remote");
     if (container == null) return;
     container.dataset.peithoEnded = isReadOnly(this.state) ? "true" : "false";
-    const currentIndex = this.currentIndex;
+    const currentPosition = this.currentPosition;
+    const currentIndex = currentPosition?.index ?? null;
     const slide = currentIndex == null ? null : manifest.slides[currentIndex];
     const total = this.slides.length;
     setText(this.root, "title", slideTitle(slide?.text.title));
@@ -1906,8 +1996,8 @@ var RemoteController = class {
     this.renderTimeDependentChrome(manifest, currentIndex);
     this.renderSection(manifest, currentIndex);
     this.renderNotes(slide?.key);
-    this.renderButtons(currentIndex);
-    this.syncPreview(currentIndex);
+    this.renderButtons(currentPosition);
+    this.syncPreview(currentPosition);
     this.updateTimerInterval();
   }
   renderChase(manifest, currentIndex) {
@@ -2037,17 +2127,19 @@ var RemoteController = class {
     notes.textContent = value;
     this.renderedNotesValue = value;
   }
-  renderButtons(currentIndex) {
+  renderButtons(currentPosition) {
     const prev = this.root.querySelector('[data-peitho-action="prev"]');
     const next = this.root.querySelector('[data-peitho-action="next"]');
     if (prev == null || next == null) return;
-    prev.disabled = !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
-    next.disabled = !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
+    prev.disabled = !canInteract(this.state) || resolveRemoteTarget(this.slides, currentPosition, "prev") === null;
+    next.disabled = !canInteract(this.state) || resolveRemoteTarget(this.slides, currentPosition, "next") === null;
   }
-  syncPreview(currentIndex) {
-    if (currentIndex == null) return;
+  syncPreview(position) {
+    if (position == null) return;
     this.previewBus.dispatchEvent(
-      new CustomEvent("peitho:navigate", { detail: { to: { index: currentIndex } } })
+      new CustomEvent("peitho:navigate", {
+        detail: { to: { index: position.index, step: position.step } }
+      })
     );
   }
   currentElapsedMs() {
@@ -2122,10 +2214,20 @@ function isPointerMoveDetail(value) {
 function isUnitCoordinate2(value) {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
 }
-function resolveRemoteTarget(slides, currentIndex, to) {
-  const base = currentIndex ?? initialSlideIndex(slides);
-  if (base === null) return null;
-  return nextNonSkippedIndex(slides, base, to === "next" ? 1 : -1);
+function resolveRemoteTarget(slides, currentPosition, to) {
+  const current = clampRemotePosition(currentPosition ?? initialRemotePosition(slides), slides);
+  if (current === null) return null;
+  return resolveStepTarget(slides, current, to === "next" ? 1 : -1);
+}
+function initialRemotePosition(slides) {
+  const index = initialSlideIndex(slides);
+  return index === null ? null : { index, step: 0 };
+}
+function clampRemotePosition(position, slides) {
+  if (position === null) return null;
+  const index = clampIndex(position.index, slides.length);
+  if (index === null) return null;
+  return { index, step: clampStep(position.step, revealStepCount(slides[index])) };
 }
 function clampIndex(index, total) {
   if (total === 0) return null;

--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -950,12 +950,39 @@ function initialSlideIndex(slides) {
   return nextNonSkippedIndex(slides, -1, 1) ?? 0;
 }
 
+// src/stepnav.ts
+function revealStepCount(slide) {
+  const value = slide?.revealSteps;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+function clampStep(step, stepCount) {
+  if (!Number.isFinite(step)) return 0;
+  return Math.max(0, Math.min(Math.floor(step), stepCount));
+}
+function resolveStepTarget(slides, position, direction) {
+  if (direction === 1) {
+    const stepCount = revealStepCount(slides[position.index]);
+    if (position.step < stepCount) {
+      return { index: position.index, step: position.step + 1 };
+    }
+    const index2 = nextNonSkippedIndex(slides, position.index, 1);
+    return index2 === null ? null : { index: index2, step: 0 };
+  }
+  if (position.step > 0) {
+    return { index: position.index, step: position.step - 1 };
+  }
+  const index = nextNonSkippedIndex(slides, position.index, -1);
+  return index === null ? null : { index, step: revealStepCount(slides[index]) };
+}
+
 // src/shell.ts
 var DEFAULT_POINTER_BASE_COLOR = "#38bdf8";
 var DEFAULT_POINTER_CORE_COLOR = "#e0f2fe";
 var POINTER_TRAIL_DURATION_MS = 500;
 var POINTER_TRAIL_CAP = 64;
 var POINTER_CORE_MIX_TO_WHITE = 0.65;
+var REVEAL_HIDDEN_CSS = "[data-reveal-hidden]{visibility:hidden}";
 var CSS_NAMED_COLORS = {
   aliceblue: "#f0f8ff",
   antiquewhite: "#faebd7",
@@ -1332,6 +1359,7 @@ function installPointerOverlay(options) {
 var PresentShellController = class {
   manifest = null;
   currentIndex = -1;
+  currentStep = 0;
   slides = [];
   root;
   fetcher;
@@ -1411,7 +1439,7 @@ var PresentShellController = class {
         this.root.appendChild(view.host);
         this.slides.push(view);
       }
-      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0, 0);
       this.mountPointerOverlay();
     } catch (error) {
       this.clearCanvasRootProperties();
@@ -1420,9 +1448,9 @@ var PresentShellController = class {
     }
   }
   navigate(to) {
-    const index = this.resolveTarget(to);
-    if (index === null) return;
-    this.show(index);
+    const target = this.resolveTarget(to);
+    if (target === null) return;
+    this.show(target.index, target.step);
   }
   elapsedMs() {
     if (this.startedAtValue === null) return 0;
@@ -1511,6 +1539,9 @@ var PresentShellController = class {
     const style = this.doc.createElement("style");
     style.textContent = css;
     shadow.appendChild(style);
+    const revealStyle = this.doc.createElement("style");
+    revealStyle.textContent = REVEAL_HIDDEN_CSS;
+    shadow.appendChild(revealStyle);
     const template = this.doc.createElement("template");
     template.innerHTML = html;
     shadow.appendChild(template.content.cloneNode(true));
@@ -1538,8 +1569,8 @@ var PresentShellController = class {
     });
   }
   resolveTarget(to) {
-    if (to === "first") return 0;
-    if (to === "last") return this.slides.length - 1;
+    if (to === "first") return this.resolveDirectIndex(0);
+    if (to === "last") return this.resolveDirectIndex(this.slides.length - 1);
     if (to === "next") return this.resolveSequentialTarget(1);
     if (to === "prev") return this.resolveSequentialTarget(-1);
     if ("index" in to) {
@@ -1547,44 +1578,86 @@ var PresentShellController = class {
         this.log.error(`Unknown slide index: ${to.index}`);
         return null;
       }
-      return to.index;
+      return this.resolveDirectIndex(to.index, to.step);
     }
     const index = this.slides.findIndex((slide) => slide.meta.key === to.key);
     if (index < 0) {
       this.log.error(`Unknown slide key: ${to.key}`);
       return null;
     }
-    return index;
+    return this.resolveDirectIndex(index);
+  }
+  resolveDirectIndex(index, step) {
+    if (index < 0 || index >= this.slides.length) return null;
+    const stepCount = this.stepCountFor(index);
+    return {
+      index,
+      step: step === void 0 ? stepCount : clampStep(step, stepCount)
+    };
   }
   resolveSequentialTarget(direction) {
-    return nextNonSkippedIndex(
+    return resolveStepTarget(
       this.slides.map((slide) => slide.meta),
-      this.currentIndex,
+      { index: this.currentIndex, step: this.currentStep },
       direction
     );
   }
-  show(index) {
+  stepCountFor(index) {
+    return revealStepCount(this.slides[index]?.meta);
+  }
+  show(index, step) {
     if (index < 0 || index >= this.slides.length) {
       this.log.error(`Unknown slide target: ${index}`);
       return;
     }
-    if (index === this.currentIndex) return;
+    const stepCount = this.stepCountFor(index);
+    const nextStep = clampStep(step, stepCount);
+    const indexChanged = index !== this.currentIndex;
+    const stepChanged = nextStep !== this.currentStep;
+    if (!indexChanged && !stepChanged) return;
     this.slides.forEach((slide2, slideIndex) => {
       slide2.host.hidden = slideIndex !== index;
     });
     const previousIndex = this.currentIndex < 0 ? null : this.currentIndex;
     this.currentIndex = index;
+    this.currentStep = nextStep;
     const slide = this.slides[index];
+    this.applyRevealState(slide.host, nextStep);
+    if (indexChanged) {
+      this.bus.dispatchEvent(
+        new CustomEvent("peitho:slidechange", {
+          detail: {
+            key: slide.meta.key,
+            index: slide.meta.index,
+            total: this.slides.length,
+            previousIndex,
+            step: nextStep,
+            stepCount
+          }
+        })
+      );
+      return;
+    }
     this.bus.dispatchEvent(
-      new CustomEvent("peitho:slidechange", {
+      new CustomEvent("peitho:stepchange", {
         detail: {
-          key: slide.meta.key,
           index: slide.meta.index,
-          total: this.slides.length,
-          previousIndex
+          step: nextStep,
+          stepCount
         }
       })
     );
+  }
+  applyRevealState(host, step) {
+    const markers = host.shadowRoot?.querySelectorAll("[data-reveal-step]");
+    if (markers == null) return;
+    for (const marker of markers) {
+      const revealStep = Number(marker.dataset.revealStep);
+      marker.toggleAttribute(
+        "data-reveal-hidden",
+        Number.isFinite(revealStep) && revealStep > step
+      );
+    }
   }
   startPresentation() {
     if (this.startedAtValue !== null) return;
@@ -1781,8 +1854,11 @@ function isRecord2(value) {
 function isCloseSyncMessage(value) {
   return isRecord2(value) && value.close === true;
 }
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
 function isIndexSyncMessage(value) {
-  return isRecord2(value) && typeof value.index === "number" && Number.isFinite(value.index);
+  return isRecord2(value) && isFiniteNumber(value.index) && isFiniteNumber(value.step);
 }
 function isSwappedSyncMessage(value) {
   return isRecord2(value) && typeof value.swapped === "boolean";
@@ -1804,6 +1880,13 @@ function isTimerReplaySyncMessage(value) {
 }
 function isGenerationSyncMessage(value) {
   return isRecord2(value) && typeof value.generation === "number" && Number.isFinite(value.generation);
+}
+function serverIndexReplayMessage(value) {
+  if (!isFiniteNumber(value.index)) return null;
+  return {
+    index: value.index,
+    step: isFiniteNumber(value.step) ? value.step : 0
+  };
 }
 function defaultChannelFactory(name) {
   const channel = new BroadcastChannel(name);
@@ -1875,8 +1958,9 @@ function serverSyncChannelFactory(options = {}) {
           onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
         }
       }
-      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
-        onmessage?.({ data: { index: body.index } });
+      const indexReplay = serverIndexReplayMessage(body);
+      if (!skipAbsoluteState && indexReplay !== null) {
+        onmessage?.({ data: indexReplay });
       }
       if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
@@ -1959,11 +2043,12 @@ function serverSyncChannelFactory(options = {}) {
             continue;
           }
           seq = body.seq;
-          if (body.message != null) {
+          const skipAbsoluteState = body.seq < highestAckedPostSeq;
+          if (body.message != null && !(skipAbsoluteState && isIndexSyncMessage(body.message))) {
             onmessage?.({ data: body.message });
           }
           deliverReplayState(body, {
-            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            skipAbsoluteState,
             deferTimerReplay: pendingTimerPosts > 0
           });
         } catch (error) {
@@ -2039,10 +2124,19 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
   const pathname = hooks.pathname ?? (() => win.location.pathname);
   const navigate = hooks.navigate ?? ((url) => win.location.replace(url));
   let synced = false;
-  const onSlideChange = (event) => {
-    const detail = event.detail;
-    if (typeof detail?.index !== "number") return;
-    channel.postMessage({ index: detail.index });
+  const navigationStateMessage = (detail) => {
+    if (!isRecord2(detail) || !isFiniteNumber(detail.index) || !isFiniteNumber(detail.step)) {
+      return null;
+    }
+    return { index: detail.index, step: detail.step };
+  };
+  const onNavigationStateChange = (event) => {
+    const message = navigationStateMessage(event.detail);
+    if (message === null) {
+      console.error("Invalid peitho navigation state event");
+      return;
+    }
+    channel.postMessage(message);
   };
   const onCloseRequest = () => {
     channel.postMessage({ close: true });
@@ -2078,7 +2172,9 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
     }
     if (isIndexSyncMessage(data)) {
       bus.dispatchEvent(
-        new CustomEvent("peitho:navigate", { detail: { to: { index: data.index } } })
+        new CustomEvent("peitho:navigate", {
+          detail: { to: { index: data.index, step: data.step } }
+        })
       );
       return;
     }
@@ -2110,12 +2206,14 @@ function installSyncBridge(win = window, channelFactory = defaultChannelFactory,
     }
     console.error("Invalid peitho sync message");
   };
-  bus.addEventListener("peitho:slidechange", onSlideChange);
+  bus.addEventListener("peitho:slidechange", onNavigationStateChange);
+  bus.addEventListener("peitho:stepchange", onNavigationStateChange);
   bus.addEventListener("peitho:closerequest", onCloseRequest);
   bus.addEventListener("peitho:swaprequest", onSwapRequest);
   bus.addEventListener("peitho:timerchange", onTimerChange);
   return () => {
-    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    bus.removeEventListener("peitho:slidechange", onNavigationStateChange);
+    bus.removeEventListener("peitho:stepchange", onNavigationStateChange);
     bus.removeEventListener("peitho:closerequest", onCloseRequest);
     bus.removeEventListener("peitho:swaprequest", onSwapRequest);
     bus.removeEventListener("peitho:timerchange", onTimerChange);

--- a/packages/peitho-present/src/index.ts
+++ b/packages/peitho-present/src/index.ts
@@ -52,6 +52,7 @@ export type {
   PresentationStartDetail,
   ShellOptions,
   SlideChangeDetail,
+  StepChangeDetail,
   TimerAdoptDetail,
   TimerControlDetail,
   TimerStateDetail

--- a/packages/peitho-present/src/remote.ts
+++ b/packages/peitho-present/src/remote.ts
@@ -8,7 +8,8 @@ import {
   type ShellOptions,
   type TimerControlDetail
 } from "./shell";
-import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
+import { initialSlideIndex } from "./skipnav";
+import { clampStep, resolveStepTarget, revealStepCount } from "./stepnav";
 import {
   isCloseSyncMessage,
   isGenerationSyncMessage,
@@ -30,7 +31,10 @@ type RemoteSlide = {
   key: string;
   skip: boolean;
   title: string;
+  revealSteps: number;
 };
+
+type RemotePosition = { index: number; step: number };
 
 type RemoteTimerAnchor = {
   running: boolean;
@@ -96,8 +100,8 @@ export type RemoteSyncBridgeOptions = {
   channelFactory?: SyncChannelFactory;
   bus?: EventTarget;
   now?: () => number;
-  getCurrentIndex(): number | null;
-  setCurrentIndex(index: number): void;
+  getCurrentPosition(): RemotePosition | null;
+  setCurrentPosition(position: RemotePosition): void;
   getTimerState(): RemoteTimerAnchor | null;
   setTimerState(state: RemoteTimerAnchor): void;
   setSynced(): void;
@@ -507,10 +511,10 @@ export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () =>
     if (!synced) return;
     const to = (event as CustomEvent<{ to?: unknown }>).detail?.to;
     if (to !== "next" && to !== "prev") return;
-    const target = resolveRemoteTarget(options.slides, options.getCurrentIndex(), to);
+    const target = resolveRemoteTarget(options.slides, options.getCurrentPosition(), to);
     if (target === null) return;
-    channel.postMessage({ index: target });
-    options.setCurrentIndex(target);
+    channel.postMessage(target);
+    options.setCurrentPosition(target);
   };
 
   const onTimerControl = (event: Event): void => {
@@ -540,7 +544,7 @@ export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () =>
       return;
     }
     if (isIndexSyncMessage(data)) {
-      options.setCurrentIndex(data.index);
+      options.setCurrentPosition({ index: data.index, step: data.step });
       return;
     }
     if (isTimerReplaySyncMessage(data)) {
@@ -578,7 +582,6 @@ export function installRemoteSyncBridge(options: RemoteSyncBridgeOptions): () =>
 
 class RemoteController implements RemoteView {
   manifest: Manifest | null = null;
-  currentIndex: number | null = null;
   private readonly root: HTMLElement;
   private readonly manifestUrl: string;
   private readonly notesUrl: string;
@@ -596,6 +599,7 @@ class RemoteController implements RemoteView {
   private notes: Notes = { version: 1, notes: {} };
   private renderedNotesValue: string | null = null;
   private slides: RemoteSlide[] = [];
+  private currentPosition: RemotePosition | null = null;
   private timerState: RemoteTimerAnchor | null = null;
   private controlsCleanup: (() => void) | null = null;
   private syncCleanup: (() => void) | null = null;
@@ -618,6 +622,10 @@ class RemoteController implements RemoteView {
     this.reload = options.reload ?? (() => this.win.location.reload());
   }
 
+  get currentIndex(): number | null {
+    return this.currentPosition?.index ?? null;
+  }
+
   async load(): Promise<void> {
     try {
       const manifest = await this.fetchJson<Manifest>(this.manifestUrl);
@@ -626,9 +634,10 @@ class RemoteController implements RemoteView {
       this.slides = manifest.slides.map((slide) => ({
         key: slide.key,
         skip: slide.skip === true,
-        title: slide.text.title
+        title: slide.text.title,
+        revealSteps: revealStepCount(slide)
       }));
-      this.currentIndex = initialSlideIndex(this.slides);
+      this.currentPosition = initialRemotePosition(this.slides);
       this.controlsCleanup = installRemoteControls({
         root: this.root,
         document: this.doc,
@@ -661,8 +670,8 @@ class RemoteController implements RemoteView {
         channelFactory: this.channelFactory,
         bus: this.bus,
         now: this.now,
-        getCurrentIndex: () => this.currentIndex,
-        setCurrentIndex: (index) => this.setCurrentIndex(index),
+        getCurrentPosition: () => this.currentPosition,
+        setCurrentPosition: (position) => this.setCurrentPosition(position),
         getTimerState: () => this.timerState,
         setTimerState: (state) => this.setTimerState(state),
         setSynced: () => this.setSynced(),
@@ -704,8 +713,8 @@ class RemoteController implements RemoteView {
     }
   }
 
-  private setCurrentIndex(index: number): void {
-    this.currentIndex = clampIndex(index, this.slides.length);
+  private setCurrentPosition(position: RemotePosition): void {
+    this.currentPosition = clampRemotePosition(position, this.slides);
     this.render();
   }
 
@@ -736,7 +745,8 @@ class RemoteController implements RemoteView {
     const container = this.root.querySelector<HTMLElement>(".peitho-remote");
     if (container == null) return;
     container.dataset.peithoEnded = isReadOnly(this.state) ? "true" : "false";
-    const currentIndex = this.currentIndex;
+    const currentPosition = this.currentPosition;
+    const currentIndex = currentPosition?.index ?? null;
     const slide = currentIndex == null ? null : manifest.slides[currentIndex];
     const total = this.slides.length;
 
@@ -748,8 +758,8 @@ class RemoteController implements RemoteView {
     this.renderTimeDependentChrome(manifest, currentIndex);
     this.renderSection(manifest, currentIndex);
     this.renderNotes(slide?.key);
-    this.renderButtons(currentIndex);
-    this.syncPreview(currentIndex);
+    this.renderButtons(currentPosition);
+    this.syncPreview(currentPosition);
     this.updateTimerInterval();
   }
 
@@ -898,20 +908,24 @@ class RemoteController implements RemoteView {
     this.renderedNotesValue = value;
   }
 
-  private renderButtons(currentIndex: number | null): void {
+  private renderButtons(currentPosition: RemotePosition | null): void {
     const prev = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="prev"]');
     const next = this.root.querySelector<HTMLButtonElement>('[data-peitho-action="next"]');
     if (prev == null || next == null) return;
     prev.disabled =
-      !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "prev") === null;
+      !canInteract(this.state) ||
+      resolveRemoteTarget(this.slides, currentPosition, "prev") === null;
     next.disabled =
-      !canInteract(this.state) || resolveRemoteTarget(this.slides, currentIndex, "next") === null;
+      !canInteract(this.state) ||
+      resolveRemoteTarget(this.slides, currentPosition, "next") === null;
   }
 
-  private syncPreview(currentIndex: number | null): void {
-    if (currentIndex == null) return;
+  private syncPreview(position: RemotePosition | null): void {
+    if (position == null) return;
     this.previewBus.dispatchEvent(
-      new CustomEvent("peitho:navigate", { detail: { to: { index: currentIndex } } })
+      new CustomEvent("peitho:navigate", {
+        detail: { to: { index: position.index, step: position.step } }
+      })
     );
   }
 
@@ -1001,12 +1015,27 @@ function isUnitCoordinate(value: unknown): value is number {
 
 function resolveRemoteTarget(
   slides: ReadonlyArray<RemoteSlide>,
-  currentIndex: number | null,
+  currentPosition: RemotePosition | null,
   to: "prev" | "next"
-): number | null {
-  const base = currentIndex ?? initialSlideIndex(slides);
-  if (base === null) return null;
-  return nextNonSkippedIndex(slides, base, to === "next" ? 1 : -1);
+): RemotePosition | null {
+  const current = clampRemotePosition(currentPosition ?? initialRemotePosition(slides), slides);
+  if (current === null) return null;
+  return resolveStepTarget(slides, current, to === "next" ? 1 : -1);
+}
+
+function initialRemotePosition(slides: ReadonlyArray<RemoteSlide>): RemotePosition | null {
+  const index = initialSlideIndex(slides);
+  return index === null ? null : { index, step: 0 };
+}
+
+function clampRemotePosition(
+  position: RemotePosition | null,
+  slides: ReadonlyArray<RemoteSlide>
+): RemotePosition | null {
+  if (position === null) return null;
+  const index = clampIndex(position.index, slides.length);
+  if (index === null) return null;
+  return { index, step: clampStep(position.step, revealStepCount(slides[index])) };
 }
 
 function clampIndex(index: number, total: number): number | null {

--- a/packages/peitho-present/src/shell.ts
+++ b/packages/peitho-present/src/shell.ts
@@ -3,7 +3,8 @@ import type { ManifestSlide } from "../../../bindings/ManifestSlide";
 import { installCanvasScaler, type CanvasViewport } from "./canvas";
 import { installDocumentFontScope } from "./fontscope";
 import { waitForFontsReady } from "./fontsReady";
-import { initialSlideIndex, nextNonSkippedIndex } from "./skipnav";
+import { initialSlideIndex } from "./skipnav";
+import { clampStep, resolveStepTarget, revealStepCount } from "./stepnav";
 
 export type NavigateTarget =
   | "next"
@@ -11,7 +12,7 @@ export type NavigateTarget =
   | "first"
   | "last"
   | { key: string }
-  | { index: number };
+  | { index: number; step?: number };
 
 export type NavigateDetail = { to: NavigateTarget };
 
@@ -20,8 +21,11 @@ export type SlideChangeDetail = {
   index: number;
   total: number;
   previousIndex: number | null;
+  step?: number;
+  stepCount?: number;
 };
 
+export type StepChangeDetail = { index: number; step: number; stepCount: number };
 export type PresentationStartDetail = { total: number; startedAt: number };
 export type PresentationEndDetail = { endedAt: number; elapsedMs: number };
 export type TimerStateDetail = { running: boolean; elapsedMs: number };
@@ -31,6 +35,7 @@ export type TimerControlDetail = { action: "start" | "pause" | "resume" | "reset
 export type PresentShell = {
   manifest: Manifest | null;
   currentIndex: number;
+  currentStep: number;
   navigate(to: NavigateTarget): void;
   elapsedMs(): number;
   isPaused(): boolean;
@@ -97,6 +102,7 @@ const DEFAULT_POINTER_CORE_COLOR = "#e0f2fe";
 const POINTER_TRAIL_DURATION_MS = 500;
 const POINTER_TRAIL_CAP = 64;
 const POINTER_CORE_MIX_TO_WHITE = 0.65;
+const REVEAL_HIDDEN_CSS = "[data-reveal-hidden]{visibility:hidden}";
 
 const CSS_NAMED_COLORS: Record<string, string> = {
   aliceblue: "#f0f8ff",
@@ -253,6 +259,8 @@ export type SlideView = {
   meta: ManifestSlide;
   host: HTMLElement;
 };
+
+type ResolvedNavigateTarget = { index: number; step: number };
 
 export async function mountPresentShell(options: ShellOptions): Promise<PresentShell> {
   const shell = new PresentShellController(options);
@@ -505,6 +513,7 @@ export function installPointerOverlay(options: PointerOverlayOptions): () => voi
 class PresentShellController implements PresentShell {
   manifest: Manifest | null = null;
   currentIndex = -1;
+  currentStep = 0;
   private readonly slides: SlideView[] = [];
   private readonly root: HTMLElement;
   private readonly fetcher: typeof fetch;
@@ -586,7 +595,7 @@ class PresentShellController implements PresentShell {
         this.root.appendChild(view.host);
         this.slides.push(view);
       }
-      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0);
+      this.show(initialSlideIndex(pending.map((view) => view.meta)) ?? 0, 0);
       this.mountPointerOverlay();
     } catch (error) {
       this.clearCanvasRootProperties();
@@ -596,9 +605,9 @@ class PresentShellController implements PresentShell {
   }
 
   navigate(to: NavigateTarget): void {
-    const index = this.resolveTarget(to);
-    if (index === null) return;
-    this.show(index);
+    const target = this.resolveTarget(to);
+    if (target === null) return;
+    this.show(target.index, target.step);
   }
 
   elapsedMs(): number {
@@ -703,6 +712,9 @@ class PresentShellController implements PresentShell {
     const style = this.doc.createElement("style");
     style.textContent = css;
     shadow.appendChild(style);
+    const revealStyle = this.doc.createElement("style");
+    revealStyle.textContent = REVEAL_HIDDEN_CSS;
+    shadow.appendChild(revealStyle);
     const template = this.doc.createElement("template");
     template.innerHTML = html;
     shadow.appendChild(template.content.cloneNode(true));
@@ -731,9 +743,9 @@ class PresentShellController implements PresentShell {
     });
   }
 
-  private resolveTarget(to: NavigateTarget): number | null {
-    if (to === "first") return 0;
-    if (to === "last") return this.slides.length - 1;
+  private resolveTarget(to: NavigateTarget): ResolvedNavigateTarget | null {
+    if (to === "first") return this.resolveDirectIndex(0);
+    if (to === "last") return this.resolveDirectIndex(this.slides.length - 1);
     if (to === "next") return this.resolveSequentialTarget(1);
     if (to === "prev") return this.resolveSequentialTarget(-1);
     if ("index" in to) {
@@ -741,47 +753,92 @@ class PresentShellController implements PresentShell {
         this.log.error(`Unknown slide index: ${to.index}`);
         return null;
       }
-      return to.index;
+      return this.resolveDirectIndex(to.index, to.step);
     }
     const index = this.slides.findIndex((slide) => slide.meta.key === to.key);
     if (index < 0) {
       this.log.error(`Unknown slide key: ${to.key}`);
       return null;
     }
-    return index;
+    return this.resolveDirectIndex(index);
   }
 
-  private resolveSequentialTarget(direction: 1 | -1): number | null {
-    return nextNonSkippedIndex(
+  private resolveDirectIndex(index: number, step?: number): ResolvedNavigateTarget | null {
+    if (index < 0 || index >= this.slides.length) return null;
+    const stepCount = this.stepCountFor(index);
+    return {
+      index,
+      step: step === undefined ? stepCount : clampStep(step, stepCount)
+    };
+  }
+
+  private resolveSequentialTarget(direction: 1 | -1): ResolvedNavigateTarget | null {
+    return resolveStepTarget(
       this.slides.map((slide) => slide.meta),
-      this.currentIndex,
+      { index: this.currentIndex, step: this.currentStep },
       direction
     );
   }
 
-  private show(index: number): void {
+  private stepCountFor(index: number): number {
+    return revealStepCount(this.slides[index]?.meta);
+  }
+
+  private show(index: number, step: number): void {
     if (index < 0 || index >= this.slides.length) {
       this.log.error(`Unknown slide target: ${index}`);
       return;
     }
-    if (index === this.currentIndex) return;
+    const stepCount = this.stepCountFor(index);
+    const nextStep = clampStep(step, stepCount);
+    const indexChanged = index !== this.currentIndex;
+    const stepChanged = nextStep !== this.currentStep;
+    if (!indexChanged && !stepChanged) return;
 
     this.slides.forEach((slide, slideIndex) => {
       slide.host.hidden = slideIndex !== index;
     });
     const previousIndex = this.currentIndex < 0 ? null : this.currentIndex;
     this.currentIndex = index;
+    this.currentStep = nextStep;
     const slide = this.slides[index];
+    this.applyRevealState(slide.host, nextStep);
+    if (indexChanged) {
+      this.bus.dispatchEvent(
+        new CustomEvent<SlideChangeDetail>("peitho:slidechange", {
+          detail: {
+            key: slide.meta.key,
+            index: slide.meta.index,
+            total: this.slides.length,
+            previousIndex,
+            step: nextStep,
+            stepCount
+          }
+        })
+      );
+      return;
+    }
     this.bus.dispatchEvent(
-      new CustomEvent<SlideChangeDetail>("peitho:slidechange", {
+      new CustomEvent<StepChangeDetail>("peitho:stepchange", {
         detail: {
-          key: slide.meta.key,
           index: slide.meta.index,
-          total: this.slides.length,
-          previousIndex
+          step: nextStep,
+          stepCount
         }
       })
     );
+  }
+
+  private applyRevealState(host: HTMLElement, step: number): void {
+    const markers = host.shadowRoot?.querySelectorAll<HTMLElement>("[data-reveal-step]");
+    if (markers == null) return;
+    for (const marker of markers) {
+      const revealStep = Number(marker.dataset.revealStep);
+      marker.toggleAttribute(
+        "data-reveal-hidden",
+        Number.isFinite(revealStep) && revealStep > step
+      );
+    }
   }
 
   private startPresentation(): void {

--- a/packages/peitho-present/src/skipnav.ts
+++ b/packages/peitho-present/src/skipnav.ts
@@ -1,5 +1,5 @@
 export function nextNonSkippedIndex(
-  slides: ReadonlyArray<{ skip: boolean }>,
+  slides: ReadonlyArray<{ skip?: boolean }>,
   from: number,
   direction: 1 | -1
 ): number | null {
@@ -11,7 +11,7 @@ export function nextNonSkippedIndex(
   return null;
 }
 
-export function initialSlideIndex(slides: ReadonlyArray<{ skip: boolean }>): number | null {
+export function initialSlideIndex(slides: ReadonlyArray<{ skip?: boolean }>): number | null {
   if (slides.length === 0) return null;
   return nextNonSkippedIndex(slides, -1, 1) ?? 0;
 }

--- a/packages/peitho-present/src/stepnav.ts
+++ b/packages/peitho-present/src/stepnav.ts
@@ -1,0 +1,35 @@
+import { nextNonSkippedIndex } from "./skipnav";
+
+export type StepNavigationSlide = { skip?: boolean; revealSteps?: unknown };
+export type StepPosition = { index: number; step: number };
+
+export function revealStepCount(slide: StepNavigationSlide | undefined): number {
+  const value = slide?.revealSteps;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+
+export function clampStep(step: number, stepCount: number): number {
+  if (!Number.isFinite(step)) return 0;
+  return Math.max(0, Math.min(Math.floor(step), stepCount));
+}
+
+export function resolveStepTarget(
+  slides: ReadonlyArray<StepNavigationSlide>,
+  position: StepPosition,
+  direction: 1 | -1
+): StepPosition | null {
+  if (direction === 1) {
+    const stepCount = revealStepCount(slides[position.index]);
+    if (position.step < stepCount) {
+      return { index: position.index, step: position.step + 1 };
+    }
+    const index = nextNonSkippedIndex(slides, position.index, 1);
+    return index === null ? null : { index, step: 0 };
+  }
+  if (position.step > 0) {
+    return { index: position.index, step: position.step - 1 };
+  }
+  const index = nextNonSkippedIndex(slides, position.index, -1);
+  return index === null ? null : { index, step: revealStepCount(slides[index]) };
+}

--- a/packages/peitho-present/src/sync.ts
+++ b/packages/peitho-present/src/sync.ts
@@ -6,9 +6,10 @@ export type TimerSyncMessage = { timer: TimerSyncState };
 export type TimerReplaySyncMessage = { timer: TimerSyncSnapshot; nowMs: number };
 export type SyncedSyncMessage = { synced: true };
 export type SessionChangedSyncMessage = { sessionChanged: true };
+type IndexSyncMessage = { index: number; step: number };
 
 export type SyncMessage =
-  | { index: number }
+  | IndexSyncMessage
   | { swapped: boolean }
   | TimerSyncMessage
   | { close: true };
@@ -41,6 +42,7 @@ type ServerSyncPollResponse = {
   seq: number;
   message: unknown;
   index?: unknown;
+  step?: unknown;
   swapped?: unknown;
   generation?: unknown;
   session?: unknown;
@@ -61,8 +63,12 @@ export function isCloseSyncMessage(value: unknown): value is { close: true } {
   return isRecord(value) && value.close === true;
 }
 
-export function isIndexSyncMessage(value: unknown): value is { index: number } {
-  return isRecord(value) && typeof value.index === "number" && Number.isFinite(value.index);
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function isIndexSyncMessage(value: unknown): value is IndexSyncMessage {
+  return isRecord(value) && isFiniteNumber(value.index) && isFiniteNumber(value.step);
 }
 
 export function isSwappedSyncMessage(value: unknown): value is { swapped: boolean } {
@@ -107,6 +113,16 @@ export function isGenerationSyncMessage(value: unknown): value is { generation: 
     typeof value.generation === "number" &&
     Number.isFinite(value.generation)
   );
+}
+
+function serverIndexReplayMessage(
+  value: Partial<ServerSyncPollResponse>
+): IndexSyncMessage | null {
+  if (!isFiniteNumber(value.index)) return null;
+  return {
+    index: value.index,
+    step: isFiniteNumber(value.step) ? value.step : 0
+  };
 }
 
 function defaultChannelFactory(name: string): SyncChannel {
@@ -186,8 +202,9 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
           onmessage?.({ data: { timer: body.timer, nowMs: body.nowMs } });
         }
       }
-      if (!skipAbsoluteState && isIndexSyncMessage(body)) {
-        onmessage?.({ data: { index: body.index } });
+      const indexReplay = serverIndexReplayMessage(body);
+      if (!skipAbsoluteState && indexReplay !== null) {
+        onmessage?.({ data: indexReplay });
       }
       if (!skipAbsoluteState && isSwappedSyncMessage(body)) {
         onmessage?.({ data: { swapped: body.swapped } });
@@ -274,11 +291,12 @@ export function serverSyncChannelFactory(options: ServerSyncOptions = {}): SyncC
             continue;
           }
           seq = body.seq;
-          if (body.message != null) {
+          const skipAbsoluteState = body.seq < highestAckedPostSeq;
+          if (body.message != null && !(skipAbsoluteState && isIndexSyncMessage(body.message))) {
             onmessage?.({ data: body.message });
           }
           deliverReplayState(body, {
-            skipAbsoluteState: body.seq < highestAckedPostSeq,
+            skipAbsoluteState,
             deferTimerReplay: pendingTimerPosts > 0
           });
         } catch (error: unknown) {
@@ -365,10 +383,19 @@ export function installSyncBridge(
   const pathname = hooks.pathname ?? (() => win.location.pathname);
   const navigate = hooks.navigate ?? ((url) => win.location.replace(url));
   let synced = false;
-  const onSlideChange = (event: Event): void => {
-    const detail = (event as CustomEvent<{ index: number }>).detail;
-    if (typeof detail?.index !== "number") return;
-    channel.postMessage({ index: detail.index });
+  const navigationStateMessage = (detail: unknown): IndexSyncMessage | null => {
+    if (!isRecord(detail) || !isFiniteNumber(detail.index) || !isFiniteNumber(detail.step)) {
+      return null;
+    }
+    return { index: detail.index, step: detail.step };
+  };
+  const onNavigationStateChange = (event: Event): void => {
+    const message = navigationStateMessage((event as CustomEvent).detail);
+    if (message === null) {
+      console.error("Invalid peitho navigation state event");
+      return;
+    }
+    channel.postMessage(message);
   };
   const onCloseRequest = (): void => {
     channel.postMessage({ close: true });
@@ -407,7 +434,9 @@ export function installSyncBridge(
     }
     if (isIndexSyncMessage(data)) {
       bus.dispatchEvent(
-        new CustomEvent("peitho:navigate", { detail: { to: { index: data.index } } })
+        new CustomEvent("peitho:navigate", {
+          detail: { to: { index: data.index, step: data.step } }
+        })
       );
       return;
     }
@@ -441,12 +470,14 @@ export function installSyncBridge(
     }
     console.error("Invalid peitho sync message");
   };
-  bus.addEventListener("peitho:slidechange", onSlideChange);
+  bus.addEventListener("peitho:slidechange", onNavigationStateChange);
+  bus.addEventListener("peitho:stepchange", onNavigationStateChange);
   bus.addEventListener("peitho:closerequest", onCloseRequest);
   bus.addEventListener("peitho:swaprequest", onSwapRequest);
   bus.addEventListener("peitho:timerchange", onTimerChange);
   return () => {
-    bus.removeEventListener("peitho:slidechange", onSlideChange);
+    bus.removeEventListener("peitho:slidechange", onNavigationStateChange);
+    bus.removeEventListener("peitho:stepchange", onNavigationStateChange);
     bus.removeEventListener("peitho:closerequest", onCloseRequest);
     bus.removeEventListener("peitho:swaprequest", onSwapRequest);
     bus.removeEventListener("peitho:timerchange", onTimerChange);

--- a/packages/peitho-present/test/generated.test.ts
+++ b/packages/peitho-present/test/generated.test.ts
@@ -22,6 +22,7 @@ import type {
   PresenterOptions,
   ServerSyncOptions,
   ShellOptions,
+  StepChangeDetail,
   TimerControlDetail
 } from "../src/index";
 
@@ -57,6 +58,7 @@ describe("generated manifest contract", () => {
     expect(manifest.aspectRatio).toBe("16:9");
     expect(manifest.canvasWidth).toBe(1280);
     expect(manifest.canvasHeight).toBe(720);
+    expect(manifest.slides[0].revealSteps).toBe(0);
     expect(options.root.tagName).toBe("MAIN");
   });
 
@@ -97,6 +99,7 @@ describe("generated manifest contract", () => {
 
   it("exports presenter and presentation event types", () => {
     const start: PresentationStartDetail = { total: 3, startedAt: 1000 };
+    const step: StepChangeDetail = { index: 0, step: 1, stepCount: 3 };
     const end: PresentationEndDetail = { endedAt: 2000, elapsedMs: 1000 };
     const control: TimerControlDetail = { action: "pause" };
     const options: Pick<PresenterOptions, "root" | "notes"> = {
@@ -105,6 +108,7 @@ describe("generated manifest contract", () => {
     };
 
     expect(start.total).toBe(3);
+    expect(step.step).toBe(1);
     expect(end.elapsedMs).toBe(1000);
     expect(control.action).toBe("pause");
     expect(options.notes.version).toBe(1);

--- a/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
+++ b/packages/peitho-present/test/loads-handles-navigates-invalid-previousIndex-keyboard-fetch.test.ts
@@ -97,7 +97,9 @@ function standardFetch(responseManifest = manifest, css = cssText): typeof fetch
   }) as unknown as typeof fetch;
 }
 
-function manifestWithSlides(slides: Array<{ key: string; skip?: boolean }>): typeof manifest {
+function manifestWithSlides(
+  slides: Array<{ key: string; skip?: boolean; revealSteps?: number }>
+): typeof manifest {
   return {
     ...manifest,
     slideCount: slides.length,
@@ -107,7 +109,7 @@ function manifestWithSlides(slides: Array<{ key: string; skip?: boolean }>): typ
       src: `slides/${String(index).padStart(3, "0")}-${slide.key}.html`,
       hasNotes: false,
       skip: slide.skip ?? false,
-      revealSteps: 0,
+      revealSteps: slide.revealSteps ?? 0,
       text: { title: "", body: "", code: "" }
     }))
   };
@@ -360,8 +362,8 @@ it("emits slidechange with previousIndex after navigation", async () => {
   window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
 
   expect(changes).toEqual([
-    { key: "intro", index: 0, total: 2, previousIndex: null },
-    { key: "arch-1", index: 1, total: 2, previousIndex: 0 }
+    { key: "intro", index: 0, total: 2, previousIndex: null, step: 0, stepCount: 0 },
+    { key: "arch-1", index: 1, total: 2, previousIndex: 0, step: 0, stepCount: 0 }
   ]);
 });
 
@@ -378,6 +380,133 @@ it("does not emit slidechange when next at the last slide is a no-op", async () 
 
   expect(shell.currentIndex).toBe(1);
   expect(changes.map((change) => change.index)).toEqual([0, 1]);
+});
+
+it("walks reveal steps before changing slides and hides future step elements", async () => {
+  const responseManifest = manifestWithSlides([
+    { key: "intro", revealSteps: 2 },
+    { key: "end" }
+  ]);
+  const root = document.createElement("main");
+  const changes: unknown[] = [];
+  const steps: unknown[] = [];
+  listenWindow("peitho:slidechange", (event) => changes.push((event as CustomEvent).detail));
+  listenWindow("peitho:stepchange", (event) => steps.push((event as CustomEvent).detail));
+
+  const shell = await mountForTest({
+    root,
+    fetcher: vi.fn(async (url: string) => {
+      if (url === "manifest.json") return okJson(responseManifest);
+      if (url === "peitho.css") return okText("");
+      if (url.includes("intro")) {
+        return okText(
+          '<section><p data-reveal-step="1">A</p><p data-reveal-step="2">B</p></section>'
+        );
+      }
+      if (url.includes("end")) return okText("<section>End</section>");
+      return { ok: false, status: 404, text: async () => "" } as Response;
+    }) as unknown as typeof fetch,
+    window
+  });
+  const intro = root.querySelector<HTMLElement>('[data-slide-index="0"]')!;
+  const markers = intro.shadowRoot!.querySelectorAll<HTMLElement>("[data-reveal-step]");
+
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(0);
+  expect([...markers].map((el) => el.hasAttribute("data-reveal-hidden"))).toEqual([true, true]);
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(1);
+  expect([...markers].map((el) => el.hasAttribute("data-reveal-hidden"))).toEqual([false, true]);
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+  expect(shell.currentIndex).toBe(1);
+  expect(shell.currentStep).toBe(0);
+  expect(changes).toEqual([
+    { key: "intro", index: 0, total: 2, previousIndex: null, step: 0, stepCount: 2 },
+    { key: "end", index: 1, total: 2, previousIndex: 0, step: 0, stepCount: 0 }
+  ]);
+  expect(steps).toEqual([
+    { index: 0, step: 1, stepCount: 2 },
+    { index: 0, step: 2, stepCount: 2 }
+  ]);
+});
+
+it("direct navigation lands fully revealed and prev enters previous slide fully revealed", async () => {
+  const responseManifest = manifestWithSlides([
+    { key: "intro", revealSteps: 2 },
+    { key: "skip", skip: true, revealSteps: 3 },
+    { key: "end", revealSteps: 1 }
+  ]);
+  const root = document.createElement("main");
+  const shell = await mountForTest({ root, fetcher: fetchForManifest(responseManifest), window });
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { key: "intro" } } }));
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(2);
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 2, step: 0 } } }));
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(2);
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 2, step: 0 } } }));
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "first" } }));
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(2);
+});
+
+it("next is a no-op at the last slide's last reveal step", async () => {
+  const responseManifest = manifestWithSlides([
+    { key: "intro" },
+    { key: "end", revealSteps: 1 }
+  ]);
+  const root = document.createElement("main");
+  const changes: unknown[] = [];
+  const steps: unknown[] = [];
+  listenWindow("peitho:slidechange", (event) => changes.push((event as CustomEvent).detail));
+  listenWindow("peitho:stepchange", (event) => steps.push((event as CustomEvent).detail));
+
+  const shell = await mountForTest({ root, fetcher: fetchForManifest(responseManifest), window });
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "last" } }));
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
+
+  expect(shell.currentIndex).toBe(1);
+  expect(shell.currentStep).toBe(1);
+  expect(changes).toEqual([
+    { key: "intro", index: 0, total: 2, previousIndex: null, step: 0, stepCount: 0 },
+    { key: "end", index: 1, total: 2, previousIndex: 0, step: 1, stepCount: 1 }
+  ]);
+  expect(steps).toEqual([]);
+});
+
+it("treats invalid revealSteps values as zero", async () => {
+  const responseManifest = manifestWithSlides([
+    { key: "negative", revealSteps: -3 },
+    { key: "stringy", revealSteps: "x" as unknown as number }
+  ]);
+  const root = document.createElement("main");
+  const changes: unknown[] = [];
+  listenWindow("peitho:slidechange", (event) => changes.push((event as CustomEvent).detail));
+  const shell = await mountForTest({ root, fetcher: fetchForManifest(responseManifest), window });
+
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(0);
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 1, step: 5 } } }));
+  expect(shell.currentIndex).toBe(1);
+  expect(shell.currentStep).toBe(0);
+
+  window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "prev" } }));
+  expect(shell.currentIndex).toBe(0);
+  expect(shell.currentStep).toBe(0);
+  expect(changes).toEqual([
+    { key: "negative", index: 0, total: 2, previousIndex: null, step: 0, stepCount: 0 },
+    { key: "stringy", index: 1, total: 2, previousIndex: 0, step: 0, stepCount: 0 },
+    { key: "negative", index: 0, total: 2, previousIndex: 1, step: 0, stepCount: 0 }
+  ]);
 });
 
 it("next skips one or more skipped slides in the present shell", async () => {
@@ -472,7 +601,9 @@ it("opens on the first non-skipped slide in the present shell", async () => {
   const hosts = [...root.querySelectorAll<HTMLElement>(".peitho-slide")];
 
   expect(shell.currentIndex).toBe(1);
-  expect(changes).toEqual([{ key: "main", index: 1, total: 3, previousIndex: null }]);
+  expect(changes).toEqual([
+    { key: "main", index: 1, total: 3, previousIndex: null, step: 0, stepCount: 0 }
+  ]);
   expect(hosts.map((host) => host.hidden)).toEqual([true, false, true]);
 });
 

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -648,7 +648,7 @@ it("buttons emit navigate timercontrol and close requests", async () => {
   expect(closeRequests).toEqual([null]);
   expect(swapRequests).toEqual([null]);
   expect(channel.sent).toEqual([
-    { index: 1 },
+    { index: 1, step: 0 },
     { timer: { running: true, elapsedMs: 0 } },
     { timer: { running: false, elapsedMs: 0 } },
     { timer: { running: true, elapsedMs: 0 } },

--- a/packages/peitho-present/test/remote.test.ts
+++ b/packages/peitho-present/test/remote.test.ts
@@ -27,7 +27,7 @@ function fail(status: number): Response {
 }
 
 function manifestWithSlides(
-  slides: Array<{ key: string; skip?: boolean; title?: string }>,
+  slides: Array<{ key: string; skip?: boolean; title?: string; revealSteps?: number }>,
   overrides: Partial<Manifest> = {}
 ): Manifest {
   return {
@@ -46,7 +46,7 @@ function manifestWithSlides(
       src: `slides/${String(index).padStart(3, "0")}-${slide.key}.html`,
       hasNotes: false,
       skip: slide.skip ?? false,
-      revealSteps: 0,
+      revealSteps: slide.revealSteps ?? 0,
       text: { title: slide.title ?? "", body: "", code: "" }
     })),
     images: [],
@@ -140,6 +140,7 @@ function mockMountPresentShell(navigations: unknown[] = []): (options: ShellOpti
     return {
       manifest: null,
       currentIndex: 0,
+      currentStep: 0,
       navigate: vi.fn(),
       elapsedMs: () => 0,
       isPaused: () => false,
@@ -241,10 +242,66 @@ it("remote controller resolves next and prev across skipped slides and posts abs
   );
 
   button(root, "next").click();
-  channel.deliver({ index: 2 });
+  channel.deliver({ index: 2, step: 0 });
   button(root, "prev").click();
 
-  expect(channel.sent).toEqual([{ index: 2 }, { index: 0 }]);
+  expect(channel.sent).toEqual([
+    { index: 2, step: 0 },
+    { index: 0, step: 0 }
+  ]);
+});
+
+it("remote resolves reveal steps locally and posts absolute index step targets", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([
+      { key: "intro", revealSteps: 2 },
+      { key: "skip", skip: true, revealSteps: 4 },
+      { key: "end", revealSteps: 1 }
+    ])
+  );
+
+  button(root, "next").click();
+  button(root, "next").click();
+  button(root, "next").click();
+  channel.deliver({ index: 2, step: 0 });
+  button(root, "prev").click();
+
+  expect(channel.sent).toEqual([
+    { index: 0, step: 1 },
+    { index: 0, step: 2 },
+    { index: 2, step: 0 },
+    { index: 0, step: 2 }
+  ]);
+});
+
+it("remote preview mirrors the current reveal step", async () => {
+  const previewNavigations: unknown[] = [];
+  const { channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro", revealSteps: 2 }]),
+    mockChannel(),
+    { mountPresentShell: mockMountPresentShell(previewNavigations) }
+  );
+
+  channel.deliver({ index: 0, step: 1 });
+
+  expect(previewNavigations.at(-1)).toEqual({ to: { index: 0, step: 1 } });
+});
+
+it("remote disables previous and next at reveal-step boundaries", async () => {
+  const { root, channel } = await mountRemoteForTest(
+    manifestWithSlides([{ key: "intro", revealSteps: 2 }, { key: "end", revealSteps: 1 }])
+  );
+
+  expect(button(root, "prev").disabled).toBe(true);
+  expect(button(root, "next").disabled).toBe(false);
+
+  channel.deliver({ index: 1, step: 0 });
+  expect(button(root, "prev").disabled).toBe(false);
+  expect(button(root, "next").disabled).toBe(false);
+
+  channel.deliver({ index: 1, step: 1 });
+  expect(button(root, "prev").disabled).toBe(false);
+  expect(button(root, "next").disabled).toBe(true);
 });
 
 it("remote controls are disabled and silent before the initial sync snapshot is applied", async () => {
@@ -295,7 +352,7 @@ it("remote controls enable after synced replay is reported", async () => {
     root.querySelector<HTMLButtonElement>('[data-peitho-action="timer-reset"]')?.disabled
   ).toBe(true);
   button(root, "next").click();
-  expect(channel.sent).toEqual([{ index: 1 }]);
+  expect(channel.sent).toEqual([{ index: 1, step: 0 }]);
 });
 
 it("remote controller transitions from loading to active to read-only ended", async () => {
@@ -348,7 +405,10 @@ it("remote controller advances optimistically across rapid taps", async () => {
   button(root, "next").click();
   button(root, "next").click();
 
-  expect(channel.sent).toEqual([{ index: 1 }, { index: 2 }]);
+  expect(channel.sent).toEqual([
+    { index: 1, step: 0 },
+    { index: 2, step: 0 }
+  ]);
 });
 
 it("remote controller treats a null replay index as the first non-skipped slide", async () => {
@@ -359,7 +419,7 @@ it("remote controller treats a null replay index as the first non-skipped slide"
   expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("2 / 3");
   button(root, "next").click();
 
-  expect(channel.sent).toEqual([{ index: 2 }]);
+  expect(channel.sent).toEqual([{ index: 2, step: 0 }]);
 });
 
 it("remote renders preview title section notes and section-aware chase chrome", async () => {
@@ -385,14 +445,14 @@ it("remote renders preview title section notes and section-aware chase chrome", 
     mountPresentShell: mockMountPresentShell(previewNavigations)
   });
 
-  channel.deliver({ index: 1 });
+  channel.deliver({ index: 1, step: 0 });
   channel.deliver({
     timer: { running: true, elapsedMs: 20_000, atMs: 1_000_000 },
     nowMs: 1_005_000
   });
 
   expect(root.querySelector('[data-preview-shell="mounted"]')).not.toBeNull();
-  expect(previewNavigations.at(-1)).toEqual({ to: { index: 1 } });
+  expect(previewNavigations.at(-1)).toEqual({ to: { index: 1, step: 0 } });
   expect(root.querySelector('[data-peitho-remote="title"]')?.textContent).toBe("Architecture");
   expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("2 / 3");
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="chase-fill"]')?.style.width).toBe(
@@ -438,7 +498,7 @@ it("remote removes the section line when the current slide is outside every sect
     "Intro · slide 1 / 1 in section"
   );
 
-  channel.deliver({ index: 1 });
+  channel.deliver({ index: 1, step: 0 });
 
   expect(root.querySelector('[data-peitho-remote="section"]')).toBeNull();
 });
@@ -482,7 +542,7 @@ it("remote mounts with empty notes placeholders when notes fetch fails", async (
     "true"
   );
 
-  channel.deliver({ index: 1 });
+  channel.deliver({ index: 1, step: 0 });
 
   expect(root.querySelector('[data-peitho-remote="title"]')?.textContent).toBe("Details");
   expect(root.querySelector('[data-peitho-remote="notes"]')?.textContent).toBe(
@@ -496,7 +556,7 @@ it("remote omits planned rows when the deck has no time", async () => {
   const { root, channel } = await mountRemoteForTest(
     manifestWithSlides([{ key: "intro", title: "Intro" }, { key: "end", title: "End" }])
   );
-  channel.deliver({ index: 1 });
+  channel.deliver({ index: 1, step: 0 });
 
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="planned"]')?.hidden).toBe(true);
   expect(root.querySelector<HTMLElement>('[data-peitho-remote="pace-delta"]')?.hidden).toBe(true);
@@ -526,7 +586,7 @@ it("remote disables previous and next based on first and last non-skipped slides
   expect(button(root, "prev").disabled).toBe(true);
   expect(button(root, "next").disabled).toBe(false);
 
-  channel.deliver({ index: 2 });
+  channel.deliver({ index: 2, step: 0 });
   expect(button(root, "prev").disabled).toBe(false);
   expect(button(root, "next").disabled).toBe(true);
 });
@@ -657,7 +717,7 @@ it("remote chase renders on-pace behind and overrun states", async () => {
     )
   );
 
-  channel.deliver({ index: 1 });
+  channel.deliver({ index: 1, step: 0 });
   channel.deliver({
     timer: { running: true, elapsedMs: 25_000, atMs: 10_000 },
     nowMs: 10_000
@@ -811,7 +871,7 @@ it("remote chase keeps presenter-exact marker semantics on uneven sections", asy
   );
   const { root, channel } = await mountRemoteForTest(manifest);
 
-  channel.deliver({ index: 5 });
+  channel.deliver({ index: 5, step: 0 });
   channel.deliver({
     timer: { running: true, elapsedMs: 8 * 60_000, atMs: 10_000 },
     nowMs: 10_000
@@ -842,7 +902,7 @@ it("remote chase puts the last-slide rabbit at the slide goal", async () => {
     )
   );
 
-  channel.deliver({ index: 2 });
+  channel.deliver({ index: 2, step: 0 });
   channel.deliver({
     timer: { running: true, elapsedMs: 60_000, atMs: 10_000 },
     nowMs: 10_000
@@ -884,9 +944,9 @@ it("remote controller no-ops at the ends", async () => {
     manifestWithSlides([{ key: "intro" }, { key: "middle" }, { key: "end" }])
   );
 
-  channel.deliver({ index: 2 });
+  channel.deliver({ index: 2, step: 0 });
   button(root, "next").click();
-  channel.deliver({ index: 0 });
+  channel.deliver({ index: 0, step: 0 });
   button(root, "prev").click();
 
   expect(channel.sent).toEqual([]);
@@ -897,10 +957,10 @@ it("remote controller replays and clamps out-of-range indexes into the counter",
     manifestWithSlides([{ key: "intro" }, { key: "middle" }, { key: "end" }])
   );
 
-  channel.deliver({ index: 99 });
+  channel.deliver({ index: 99, step: 0 });
   expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("3 / 3");
 
-  channel.deliver({ index: -10 });
+  channel.deliver({ index: -10, step: 0 });
   expect(root.querySelector('[data-peitho-remote="counter"]')?.textContent).toBe("1 / 3");
 });
 
@@ -990,7 +1050,7 @@ it("remote controller does not reload on ordinary sync messages", async () => {
     { reload }
   );
 
-  channel.deliver({ index: 1 });
+  channel.deliver({ index: 1, step: 0 });
   channel.deliver({ swapped: true });
   channel.deliver({ generation: 2 });
   channel.deliver({

--- a/packages/peitho-present/test/stepnav.test.ts
+++ b/packages/peitho-present/test/stepnav.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "vitest";
+import { clampStep, resolveStepTarget, revealStepCount } from "../src/stepnav";
+
+it("walks reveal steps before advancing and stops at the deck boundary", () => {
+  const slides = [{ revealSteps: 2 }, { revealSteps: 1 }];
+
+  expect(resolveStepTarget(slides, { index: 0, step: 0 }, 1)).toEqual({ index: 0, step: 1 });
+  expect(resolveStepTarget(slides, { index: 0, step: 1 }, 1)).toEqual({ index: 0, step: 2 });
+  expect(resolveStepTarget(slides, { index: 0, step: 2 }, 1)).toEqual({ index: 1, step: 0 });
+  expect(resolveStepTarget(slides, { index: 1, step: 1 }, 1)).toBeNull();
+});
+
+it("walks backward through steps and enters previous non-skipped slides fully revealed", () => {
+  const slides = [{ revealSteps: 2 }, { skip: true, revealSteps: 4 }, { revealSteps: 1 }];
+
+  expect(resolveStepTarget(slides, { index: 2, step: 1 }, -1)).toEqual({ index: 2, step: 0 });
+  expect(resolveStepTarget(slides, { index: 2, step: 0 }, -1)).toEqual({ index: 0, step: 2 });
+  expect(resolveStepTarget(slides, { index: 0, step: 2 }, 1)).toEqual({ index: 2, step: 0 });
+  expect(resolveStepTarget(slides, { index: 0, step: 0 }, -1)).toBeNull();
+});
+
+it("normalizes reveal step counts and clamps explicit steps", () => {
+  expect(revealStepCount({ revealSteps: -3 })).toBe(0);
+  expect(revealStepCount({ revealSteps: Number.NaN })).toBe(0);
+  expect(revealStepCount({ revealSteps: "x" })).toBe(0);
+  expect(revealStepCount({ revealSteps: 2.9 })).toBe(2);
+
+  expect(clampStep(Number.NaN, 2)).toBe(0);
+  expect(clampStep(-1, 2)).toBe(0);
+  expect(clampStep(1.9, 2)).toBe(1);
+  expect(clampStep(5, 2)).toBe(2);
+});

--- a/packages/peitho-present/test/sync.test.ts
+++ b/packages/peitho-present/test/sync.test.ts
@@ -88,9 +88,11 @@ it("exports strict sync message guards", () => {
   expect(isCloseSyncMessage({ close: true })).toBe(true);
   expect(isCloseSyncMessage({ close: false })).toBe(false);
 
-  expect(isIndexSyncMessage({ index: 1 })).toBe(true);
-  expect(isIndexSyncMessage({ index: Number.NaN })).toBe(false);
-  expect(isIndexSyncMessage({ index: Number.POSITIVE_INFINITY })).toBe(false);
+  expect(isIndexSyncMessage({ index: 1, step: 0 })).toBe(true);
+  expect(isIndexSyncMessage({ index: 1 })).toBe(false);
+  expect(isIndexSyncMessage({ index: Number.NaN, step: 0 })).toBe(false);
+  expect(isIndexSyncMessage({ index: Number.POSITIVE_INFINITY, step: 0 })).toBe(false);
+  expect(isIndexSyncMessage({ index: 1, step: Number.NaN })).toBe(false);
 
   expect(isSwappedSyncMessage({ swapped: true })).toBe(true);
   expect(isSwappedSyncMessage({ swapped: "true" })).toBe(false);
@@ -140,13 +142,13 @@ it("server sync channel posts local messages to /sync", async () => {
   });
   const channel = factory("peitho-sync");
 
-  channel.postMessage({ index: 2 });
+  channel.postMessage({ index: 2, step: 0 });
   await Promise.resolve();
 
   expect(fetcher).toHaveBeenCalledWith("/sync", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ index: 2 }),
+    body: JSON.stringify({ index: 2, step: 0 }),
     keepalive: true
   });
   channel.close();
@@ -157,7 +159,7 @@ it("server sync channel polls and forwards long-poll messages", async () => {
     if (init?.method === "POST") return Promise.resolve({ ok: true, status: 204 } as Response);
     if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
     if (url === "/sync?seq=5") {
-      return Promise.resolve(okJson({ seq: 6, message: { index: 1 } }));
+      return Promise.resolve(okJson({ seq: 6, message: { index: 1, step: 0 } }));
     }
     return new Promise<Response>(() => undefined);
   }) as typeof fetch;
@@ -168,7 +170,7 @@ it("server sync channel polls and forwards long-poll messages", async () => {
   const received: unknown[] = [];
   channel.onmessage = (event) => received.push(event.data);
 
-  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1, step: 0 }]));
 
   expect(fetcher).toHaveBeenCalledWith("/sync");
   expect(fetcher).toHaveBeenCalledWith("/sync?seq=5", expect.objectContaining({ signal: expect.any(AbortSignal) }));
@@ -181,7 +183,9 @@ it("server sync channel replays poll response state after the poll message", asy
     if (init?.method === "POST") return Promise.resolve({ ok: true, status: 204 } as Response);
     if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
     if (url === "/sync?seq=5") {
-      return Promise.resolve(okJson({ seq: 6, message: { index: 1 }, index: 2, swapped: true }));
+      return Promise.resolve(
+        okJson({ seq: 6, message: { index: 1, step: 0 }, index: 2, step: 3, swapped: true })
+      );
     }
     return new Promise<Response>(() => undefined);
   }) as typeof fetch;
@@ -192,8 +196,8 @@ it("server sync channel replays poll response state after the poll message", asy
   await vi.waitFor(() =>
     expect(received).toEqual([
       { synced: true },
-      { index: 1 },
-      { index: 2 },
+      { index: 1, step: 0 },
+      { index: 2, step: 3 },
       { swapped: true }
     ])
   );
@@ -257,6 +261,7 @@ it("server sync channel delivers handshake replay timer before index and synced 
           seq: 4,
           message: null,
           index: 2,
+          step: 1,
           swapped: true,
           timer: { running: true, elapsedMs: 600_000, atMs: 10_000 },
           nowMs: 11_000
@@ -276,7 +281,7 @@ it("server sync channel delivers handshake replay timer before index and synced 
         timer: { running: true, elapsedMs: 600_000, atMs: 10_000 },
         nowMs: 11_000
       },
-      { index: 2 },
+      { index: 2, step: 1 },
       { swapped: true },
       { synced: true }
     ])
@@ -307,7 +312,7 @@ it("server sync channel does not replay backlog close messages after handshake",
 it("server sync channel replays handshake index then swapped through onmessage", async () => {
   const fetcher = vi.fn((url: string) => {
     if (url === "/sync") {
-      return Promise.resolve(okJson({ seq: 4, message: null, index: 2, swapped: true }));
+      return Promise.resolve(okJson({ seq: 4, message: null, index: 2, step: 1, swapped: true }));
     }
     if (url === "/sync?seq=4") return new Promise<Response>(() => undefined);
     throw new Error(`unexpected sync url: ${url}`);
@@ -317,13 +322,50 @@ it("server sync channel replays handshake index then swapped through onmessage",
   channel.onmessage = (event) => received.push(event.data);
 
   await vi.waitFor(() =>
-    expect(received).toEqual([{ index: 2 }, { swapped: true }, { synced: true }])
+    expect(received).toEqual([{ index: 2, step: 1 }, { swapped: true }, { synced: true }])
   );
 
   expect(fetcher).toHaveBeenCalledWith("/sync");
   expect(fetcher).toHaveBeenCalledWith(
     "/sync?seq=4",
     expect.objectContaining({ signal: expect.any(AbortSignal) })
+  );
+  channel.close();
+});
+
+it("server sync channel replays handshake index and step together", async () => {
+  const fetcher = vi.fn((url: string) => {
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 4, message: null, index: 2, step: 1 }));
+    if (url === "/sync?seq=4") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ index: 2, step: 1 }, { synced: true }]));
+  channel.close();
+});
+
+it("server sync channel treats missing replay step as zero", async () => {
+  const fetcher = vi.fn((url: string) => {
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 4, message: null, index: 2 }));
+    if (url === "/sync?seq=4") {
+      return Promise.resolve(okJson({ seq: 5, message: null, index: 3, step: null }));
+    }
+    if (url === "/sync?seq=5") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() =>
+    expect(received).toEqual([
+      { index: 2, step: 0 },
+      { synced: true },
+      { index: 3, step: 0 }
+    ])
   );
   channel.close();
 });
@@ -523,7 +565,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("posts local slidechange index to peitho-sync", async () => {
+it("posts local slidechange index step to peitho-sync", async () => {
   const channel = mockChannel();
   const root = document.createElement("main");
   const shell = await mountPresentShell({ root, fetcher: standardFetch(), window });
@@ -532,7 +574,39 @@ it("posts local slidechange index to peitho-sync", async () => {
 
   window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
 
-  expect(channel.sent).toEqual([{ index: 1 }]);
+  expect(channel.sent).toEqual([{ index: 1, step: 0 }]);
+});
+
+it("posts local slidechange and stepchange index step to peitho-sync", () => {
+  const channel = mockChannel();
+  const bus = new EventTarget();
+  const cleanup = installSyncBridge(window, () => channel, bus);
+  cleanups.push(cleanup);
+
+  bus.dispatchEvent(new CustomEvent("peitho:slidechange", { detail: { index: 1, step: 0 } }));
+  bus.dispatchEvent(new CustomEvent("peitho:stepchange", { detail: { index: 1, step: 2 } }));
+
+  expect(channel.sent).toEqual([
+    { index: 1, step: 0 },
+    { index: 1, step: 2 }
+  ]);
+});
+
+it("rejects invalid navigation state sync events", () => {
+  const channel = mockChannel();
+  const bus = new EventTarget();
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const cleanup = installSyncBridge(window, () => channel, bus);
+  cleanups.push(cleanup);
+
+  bus.dispatchEvent(new CustomEvent("peitho:slidechange", { detail: { index: 1 } }));
+  bus.dispatchEvent(
+    new CustomEvent("peitho:stepchange", { detail: { index: 1, step: Number.NaN } })
+  );
+
+  expect(channel.sent).toEqual([]);
+  expect(error).toHaveBeenCalledTimes(2);
+  expect(error).toHaveBeenCalledWith("Invalid peitho navigation state event");
 });
 
 it("dispatches closerequest from Escape", () => {
@@ -613,7 +687,7 @@ it("does not repost an auto-start timerchange caused by pre-synced index replay"
   shells.push(shell);
   cleanups.push(installSyncBridge(window, () => channel));
 
-  channel.onmessage?.({ data: { index: 1 } });
+  channel.onmessage?.({ data: { index: 1, step: 0 } });
   window.dispatchEvent(
     new CustomEvent("peitho:timerchange", {
       detail: { running: true, elapsedMs: 0 }
@@ -651,12 +725,54 @@ it("skips stale poll replay state older than the highest acknowledged post seq",
       timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
       nowMs: 1000,
       index: 1,
+      step: 0,
       swapped: true
     })
   );
   await vi.waitFor(() => expect(fetcher).toHaveBeenCalledWith("/sync?seq=7", expect.anything()));
 
   expect(received).toEqual([{ synced: true }]);
+  channel.close();
+});
+
+it("skips stale raw index poll messages older than the highest acknowledged post seq", async () => {
+  let resolvePost!: (response: Response) => void;
+  let resolvePoll!: (response: Response) => void;
+  const fetcher = vi.fn((url: string, init?: RequestInit) => {
+    if (init?.method === "POST") {
+      return new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      });
+    }
+    if (url === "/sync") return Promise.resolve(okJson({ seq: 5, message: null }));
+    if (url === "/sync?seq=5") {
+      return new Promise<Response>((resolve) => {
+        resolvePoll = resolve;
+      });
+    }
+    if (url === "/sync?seq=7") {
+      return Promise.resolve(okJson({ seq: 8, message: { index: 0, step: 2 } }));
+    }
+    if (url === "/sync?seq=8") return new Promise<Response>(() => undefined);
+    throw new Error(`unexpected sync url: ${url}`);
+  }) as typeof fetch;
+  const channel = serverSyncChannelFactory({ fetcher })("peitho-sync");
+  const received: unknown[] = [];
+  channel.onmessage = (event) => received.push(event.data);
+
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }]));
+  await vi.waitFor(() => expect(resolvePoll).toBeTypeOf("function"));
+  channel.postMessage({ index: 0, step: 2 });
+  await vi.waitFor(() => expect(resolvePost).toBeTypeOf("function"));
+  resolvePost(okJson({ seq: 8 }));
+  await flushPromises();
+
+  resolvePoll(okJson({ seq: 7, message: { index: 0, step: 1 }, index: 0, step: 2 }));
+
+  await vi.waitFor(() => expect(fetcher).toHaveBeenCalledWith("/sync?seq=7", expect.anything()));
+  await vi.waitFor(() =>
+    expect(received).toEqual([{ synced: true }, { index: 0, step: 2 }])
+  );
   channel.close();
 });
 
@@ -733,17 +849,18 @@ it("buffers newer timer replay while a timer post is awaiting ack and delivers i
       message: null,
       timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
       nowMs: 2000,
-      index: 1
+      index: 1,
+      step: 0
     })
   );
 
-  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1, step: 0 }]));
   resolvePost(okJson({ seq: 7 }));
 
   await vi.waitFor(() =>
     expect(received).toEqual([
       { synced: true },
-      { index: 1 },
+      { index: 1, step: 0 },
       {
         timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
         nowMs: 2000
@@ -753,7 +870,7 @@ it("buffers newer timer replay while a timer post is awaiting ack and delivers i
   await flushPromises();
   expect(received).toEqual([
     { synced: true },
-    { index: 1 },
+    { index: 1, step: 0 },
     {
       timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
       nowMs: 2000
@@ -782,7 +899,8 @@ it("buffers re-handshake timer replay while a timer post is awaiting ack", async
           message: null,
           timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
           nowMs: 2000,
-          index: 1
+          index: 1,
+          step: 0
         })
       );
     }
@@ -804,14 +922,14 @@ it("buffers re-handshake timer replay while a timer post is awaiting ack", async
   await vi.waitFor(() => expect(resolvePost).toBeTypeOf("function"));
   rejectPoll(new Error("poll lost"));
 
-  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1, step: 0 }]));
   expect(error).toHaveBeenCalledWith("Failed to poll sync message: Error: poll lost");
   resolvePost(okJson({ seq: 7 }));
 
   await vi.waitFor(() =>
     expect(received).toEqual([
       { synced: true },
-      { index: 1 },
+      { index: 1, step: 0 },
       {
         timer: { running: true, elapsedMs: 30_000, atMs: 2000 },
         nowMs: 2000
@@ -853,15 +971,16 @@ it("discards buffered timer replay older than the acknowledged timer post", asyn
       message: null,
       timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
       nowMs: 1000,
-      index: 1
+      index: 1,
+      step: 0
     })
   );
 
-  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1, step: 0 }]));
   resolvePost(okJson({ seq: 7 }));
   await flushPromises();
 
-  expect(received).toEqual([{ synced: true }, { index: 1 }]);
+  expect(received).toEqual([{ synced: true }, { index: 1, step: 0 }]);
   channel.close();
 });
 
@@ -898,18 +1017,19 @@ it("delivers buffered timer replay after a pending timer post fails", async () =
       message: null,
       timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
       nowMs: 1000,
-      index: 1
+      index: 1,
+      step: 0
     })
   );
 
-  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1 }]));
+  await vi.waitFor(() => expect(received).toEqual([{ synced: true }, { index: 1, step: 0 }]));
   rejectPost(new Error("offline"));
   await vi.waitFor(() => expect(error).toHaveBeenCalledWith("Failed to post sync message: Error: offline"));
 
   await vi.waitFor(() =>
     expect(received).toEqual([
       { synced: true },
-      { index: 1 },
+      { index: 1, step: 0 },
       {
         timer: { running: true, elapsedMs: 10_000, atMs: 1000 },
         nowMs: 1000
@@ -977,7 +1097,7 @@ it("closes the window when a remote close sync message arrives", () => {
   expect(closeWindow).toHaveBeenCalledTimes(1);
 });
 
-it("turns remote index messages into navigate requests", () => {
+it("dispatches sync replay as one navigate target with index and step", () => {
   const channel = mockChannel();
   const requests: unknown[] = [];
   const onNavigate = (event: Event) => requests.push((event as CustomEvent).detail);
@@ -985,9 +1105,9 @@ it("turns remote index messages into navigate requests", () => {
   cleanups.push(() => window.removeEventListener("peitho:navigate", onNavigate));
   cleanups.push(installSyncBridge(window, () => channel));
 
-  channel.onmessage?.({ data: { index: 1 } });
+  channel.onmessage?.({ data: { index: 1, step: 0 } });
 
-  expect(requests).toEqual([{ to: { index: 1 } }]);
+  expect(requests).toEqual([{ to: { index: 1, step: 0 } }]);
 });
 
 it("adopts replayed timer sync state through the injected callback", () => {
@@ -1126,7 +1246,7 @@ it("does not navigate on swapped messages received on unknown routes", () => {
 it("does not navigate when replayed swapped state equals the current route", async () => {
   const fetcher = vi.fn((url: string) => {
     if (url === "/sync") {
-      return Promise.resolve(okJson({ seq: 7, message: null, index: 1, swapped: false }));
+      return Promise.resolve(okJson({ seq: 7, message: null, index: 1, step: 0, swapped: false }));
     }
     if (url === "/sync?seq=7") return new Promise<Response>(() => undefined);
     throw new Error(`unexpected sync url: ${url}`);
@@ -1149,7 +1269,7 @@ it("does not navigate when replayed swapped state equals the current route", asy
   );
   cleanups.push(cleanup);
 
-  await vi.waitFor(() => expect(requests).toEqual([{ to: { index: 1 } }]));
+  await vi.waitFor(() => expect(requests).toEqual([{ to: { index: 1, step: 0 } }]));
 
   expect(navigate).not.toHaveBeenCalled();
 });
@@ -1157,10 +1277,12 @@ it("does not navigate when replayed swapped state equals the current route", asy
 it("converges from poll response swapped state when the poll message is unrelated", async () => {
   const fetcher = vi.fn((url: string) => {
     if (url === "/sync") {
-      return Promise.resolve(okJson({ seq: 7, message: null, index: 0, swapped: false }));
+      return Promise.resolve(okJson({ seq: 7, message: null, index: 0, step: 0, swapped: false }));
     }
     if (url === "/sync?seq=7") {
-      return Promise.resolve(okJson({ seq: 8, message: { index: 1 }, index: 1, swapped: true }));
+      return Promise.resolve(
+        okJson({ seq: 8, message: { index: 1, step: 0 }, index: 1, step: 0, swapped: true })
+      );
     }
     if (url === "/sync?seq=8") return new Promise<Response>(() => undefined);
     throw new Error(`unexpected sync url: ${url}`);
@@ -1192,9 +1314,9 @@ it("dispatches remote sync navigation to the injected bus", () => {
 
   const cleanup = installSyncBridge(window, () => channel, bus);
   cleanups.push(cleanup);
-  channel.onmessage?.({ data: { index: 1 } });
+  channel.onmessage?.({ data: { index: 1, step: 0 } });
 
-  expect(requests).toEqual([{ to: { index: 1 } }]);
+  expect(requests).toEqual([{ to: { index: 1, step: 0 } }]);
 });
 
 it("does not echo forever when remote index equals current slide", async () => {
@@ -1205,9 +1327,9 @@ it("does not echo forever when remote index equals current slide", async () => {
   cleanups.push(installSyncBridge(window, () => channel));
 
   window.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: "next" } }));
-  expect(channel.sent).toEqual([{ index: 1 }]);
-  channel.onmessage?.({ data: { index: 1 } });
+  expect(channel.sent).toEqual([{ index: 1, step: 0 }]);
+  channel.onmessage?.({ data: { index: 1, step: 0 } });
 
   expect(shell.currentIndex).toBe(1);
-  expect(channel.sent).toEqual([{ index: 1 }]);
+  expect(channel.sent).toEqual([{ index: 1, step: 0 }]);
 });


### PR DESCRIPTION
Closes #347. Closes #348. Closes #349. Closes #350. Part of #290 (design: #341, `docs/plans/2026-07-31-incremental-reveal.md` Tasks 6-9).

## Why one PR

The `/sync` index-message contract (`{"index":N,"step":M}`, bare index rejected) and the embedded clients (shell/remote bundles) ship in one binary: landing either side alone produces a peitho that breaks its own present sync. Tasks 6-9 are one atomic unit, same as the Tasks 3+4 fold in #356.

## Summary

- **Server**: `SyncIndexMessage` requires `step` (`deny_unknown_fields`); index+step fold atomically under one seq; every GET (handshake and poll) replays `step` in the absolute state.
- **Shell**: `currentStep` state; next/prev walk steps before slides; prev enters the previous slide fully revealed; direct jumps (`{index}`/`{key}`/first/last) land fully revealed; `(index, step)` identity guard; shell-owned `[data-reveal-hidden]{visibility:hidden}` toggling; `peitho:slidechange` detail gains `step`/`stepCount`, new `peitho:stepchange` for step-only transitions. No keyboard changes (§16 intact).
- **Sync bridge**: posts the atomic pair from both events; replay dispatches one `{index, step}` navigate per response; absent/null replay step is treated as 0, never dropped. **Root-cause fix from review**: stale raw index messages (response seq < acked post seq) are now gated — a pre-existing race could echo an older index/step after a rapid double-post and converge every window backwards; step frequency would have amplified it (regression-tested).
- **Remote**: computes prev/next locally from manifest `revealSteps`+`skip`, posts absolute pairs, step-aware button enablement, preview mirrors the live step.
- **stepnav.ts**: the step walk exists once (skipnav precedent), consumed by both shell and remote — review round 4 caught the two hand-maintained copies.
- `.worktrees/` is now gitignored (guards against a stray `git add -A` from the primary worktree — this bit during this PR's preparation; the mistaken local-main commit was reverted before any push of main).

## Review & E2E

5 rounds with mutation testing per surface (server 3/3, shell 8/8 after 2 test-gap fixes, remote 3/3 killed; sync scenario probes for coalescing/echo/stale/legacy). **Real-Chrome E2E performed** (fixed `--port`, `curl POST /sync`, DOM inspection): late-join handshake converges to the live step; step 0/1/2/3 toggle `data-reveal-hidden` correctly with layout preserved; bare `{"index":0}` returns 400; ArrowRight advances a step and syncs it back to the server.

## Gates (inside the worktree)

- `cargo test --workspace` ×3: 0 failed · clippy `-D warnings` clean · fmt clean · bindings drift clean
- `npm run build && npm test && npm run typecheck`: 324 tests, clean; dist bundles rebuilt deterministically (double-build sha-stable) — the bundle diffs are this unit's intended payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)
