### PR TITLE
Pin presenter step mirroring and complete the synthetic slidechange detail

### DIFF
--- a/packages/peitho-present/dist/shell.js
+++ b/packages/peitho-present/dist/shell.js
@@ -2562,7 +2562,9 @@ async function mountPresenterView(options) {
       key: firstSlide.key,
       index: firstSlide.index,
       total: mainShell.manifest?.slideCount ?? 0,
-      previousIndex: null
+      previousIndex: null,
+      step: mainShell.currentStep,
+      stepCount: firstSlide.revealSteps ?? 0
     });
   }
   const buttonCleanups = [];

--- a/packages/peitho-present/src/presenter.ts
+++ b/packages/peitho-present/src/presenter.ts
@@ -399,7 +399,9 @@ export async function mountPresenterView(options: PresenterOptions): Promise<Pre
       key: firstSlide.key,
       index: firstSlide.index,
       total: mainShell.manifest?.slideCount ?? 0,
-      previousIndex: null
+      previousIndex: null,
+      step: mainShell.currentStep,
+      stepCount: firstSlide.revealSteps ?? 0
     });
   }
 

--- a/packages/peitho-present/test/presenter.test.ts
+++ b/packages/peitho-present/test/presenter.test.ts
@@ -478,6 +478,53 @@ it("updates preview and shows end of deck on the last slide", async () => {
   );
 });
 
+it("presenter current pane follows sync step while next pane stays final state", async () => {
+  const responseManifest: Manifest = {
+    ...manifest,
+    slides: [
+      { ...manifest.slides[0], revealSteps: 2 },
+      { ...manifest.slides[1], revealSteps: 1 }
+    ]
+  };
+  const root = document.createElement("main");
+  const { channel, factory } = mockSyncChannelFactory();
+  const view = await mountPresenterView({
+    root,
+    notes,
+    fetcher: vi.fn(async (url: string) => {
+      if (url === "manifest.json") return okJson(responseManifest);
+      if (url === "peitho.css") return okText("");
+      if (url === "slides/000-intro.html") {
+        return okText(
+          '<section><p data-reveal-step="1">A</p><p data-reveal-step="2">B</p></section>'
+        );
+      }
+      if (url === "slides/001-details.html") {
+        return okText('<section><p data-reveal-step="1">Next</p></section>');
+      }
+      return { ok: false, status: 404, text: async () => "" } as Response;
+    }) as typeof fetch,
+    window,
+    now: () => 1000,
+    syncChannelFactory: factory
+  });
+  views.push(view);
+
+  channel.onmessage?.({ data: { index: 0, step: 1 } });
+
+  const currentSlide = root
+    .querySelector<HTMLElement>('[data-peitho-presenter="current"] [data-slide-index="0"]')!
+    .shadowRoot!;
+  const currentFirst = currentSlide.querySelector<HTMLElement>('[data-reveal-step="1"]')!;
+  const currentSecond = currentSlide.querySelector<HTMLElement>('[data-reveal-step="2"]')!;
+  const nextFirst = root
+    .querySelector<HTMLElement>('[data-peitho-presenter="preview"] [data-slide-index="1"]')!
+    .shadowRoot!.querySelector<HTMLElement>('[data-reveal-step="1"]')!;
+  expect(currentFirst.hasAttribute("data-reveal-hidden")).toBe(false);
+  expect(currentSecond.hasAttribute("data-reveal-hidden")).toBe(true);
+  expect(nextFirst.hasAttribute("data-reveal-hidden")).toBe(false);
+});
+
 it("next preview skips skipped slides while counters keep total slide count", async () => {
   const root = document.createElement("main");
   const { factory } = mockSyncChannelFactory();


### PR DESCRIPTION
Closes #351. Part of #290 (design: #341, `docs/plans/2026-07-31-incremental-reveal.md` Task 10).

## Summary

Honest reduction: the Task 10 behaviors — the presenter's current pane mirroring the live reveal step via sync replay, and the next-slide pane landing fully revealed through the shell's direct-jump rule — were already delivered by the merged wiring from #348/#349 (verified by the new test passing before any source change). This PR therefore:

- Pins both pane behaviors with a regression test whose assertions are provably discriminating: review round 1 caught that the plan's own test shape passed even with sync delivery severed (both steps hidden at mount), so the test also asserts step 1 becomes *visible* after the `{index:0, step:1}` replay — red under a severed-sync mutation.
- Completes the synthetic first-slide `updateFromSlide` detail with `step`/`stepCount` (behaviorally inert today; keeps the synthetic detail faithful to real `slidechange` events per the plan).

Notes/agenda/rehearsal/timer consumers read none of the new fields (grep-verified); only `dist/shell.js` rebuilds (presenter is bundled there; preview/remote bundles unchanged, rebuild double-checked deterministic).

## Gates

`cargo test --workspace` ×3 clean · clippy/fmt/bindings clean · `npm test` 325, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
