### PR TITLE
Label the incremental-reveal demo link as published output

### DIFF
--- a/site/content/examples/incremental-reveal.md
+++ b/site/content/examples/incremental-reveal.md
@@ -9,6 +9,7 @@ deck = "incremental-reveal"
 demo_path = "/demo/incremental-reveal/"
 source_path = "static/deck-sources/incremental-reveal/deck.md"
 github_path = "examples/incremental-reveal"
+demo_label = "Open published deck (final state)"
 +++
 
 ## What it demonstrates
@@ -22,6 +23,8 @@ numbers continue from the first group.
 Content outside reveal groups stays visible in every presenter state. Published
 output, previews, PDF export, and gallery screenshots render the final state, so
 all reveal steps remain visible outside `peitho present`.
+
+To step through the reveal locally, run `peitho present examples/incremental-reveal/deck.md` and use the arrow keys.
 
 ## What to look at
 

--- a/site/templates/example-page.html
+++ b/site/templates/example-page.html
@@ -19,7 +19,7 @@
 
 {% block docs_content %}
   {% for key, value in page.extra %}
-    {% if key != "demo_path" and key != "source_path" and key != "deck" and key != "github_path" %}
+    {% if key != "demo_path" and key != "source_path" and key != "deck" and key != "github_path" and key != "demo_label" %}
       {{ throw_unknown_example_extra_key }}
     {% endif %}
   {% endfor %}
@@ -52,7 +52,7 @@
     {% endif %}
 
     <p class="example-links">
-      <a href="{{ page.extra.demo_path | safe }}">Open live demo</a>
+      <a href="{{ page.extra.demo_path | safe }}">{{ page.extra.demo_label | default(value="Open live demo") }}</a>
       <span aria-hidden="true"> · </span>
       <a href="{{ config.extra.github_url | safe }}/tree/main/{{ page.extra.github_path | safe }}">View source on GitHub</a>
     </p>


### PR DESCRIPTION
Follow-up to #362 (refs #290), from author feedback: "live demo" is misleading on the incremental-reveal example page — the linked deck is the published build showing the final state; reveal steps only run in `peitho present`.

- `example-page.html`: the demo link label is now overridable via `[extra] demo_label` (default stays "Open live demo"; the unknown-extra-key guard accepts the new key, so typos still fail the build).
- `incremental-reveal.md`: label becomes "Open published deck (final state)" and the body gains a one-line pointer to `peitho present examples/incremental-reveal/deck.md` with arrow keys.

Verified with a local `zola build`: 20 pages, 0 orphans; the incremental-reveal page shows the new label, sibling pages (footnotes) keep "Open live demo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
