### PR TITLE
chore: bump version to 1.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.17.1"
+version = "1.18.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.17.1"
+version = "1.18.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.17.1"
+version = "1.18.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Bump version to 1.18.0 for release.

## Included since v1.17.1

- #370 Open preview in grid mode by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNJBDVa1ki822zSeVgotz