### PR TITLE
lint: measure min visible text font size with UTF-8-safe transport

### DIFF
--- a/crates/peitho-core/src/lint_measure.js
+++ b/crates/peitho-core/src/lint_measure.js
@@ -86,16 +86,74 @@
     return bounds;
   }
 
+  function truncateSample(sample) {
+    if (Array.from(sample).length > 40) {
+      return Array.from(sample).slice(0, 40).join("") + "…";
+    }
+    return sample;
+  }
+
+  function fontSample(text) {
+    var sample = text.replace(/\s+/g, " ").trim();
+    return truncateSample(sample);
+  }
+
+  function measureTextFont(slide) {
+    var walker = document.createTreeWalker(slide, NodeFilter.SHOW_TEXT);
+    var minFontSizePx = null;
+    var minFontSample = null;
+    var node;
+
+    while ((node = walker.nextNode())) {
+      var sample = fontSample(node.textContent || "");
+      var parent = node.parentElement;
+      if (sample === "" || !parent) {
+        continue;
+      }
+      if (parent.closest(".peitho-footnotes, sup.peitho-footnote-ref")) {
+        continue;
+      }
+
+      var rect = parent.getBoundingClientRect();
+      var style = getComputedStyle(parent);
+      var visibility = style.visibility;
+      if (
+        (rect.width === 0 && rect.height === 0) ||
+        visibility === "hidden" ||
+        visibility === "collapse"
+      ) {
+        continue;
+      }
+
+      var size = parseFloat(style.fontSize);
+      if (!isFinite(size)) {
+        continue;
+      }
+      if (minFontSizePx === null || size < minFontSizePx) {
+        minFontSizePx = size;
+        minFontSample = sample;
+      }
+    }
+
+    return {
+      minFontSizePx: minFontSizePx,
+      minFontSample: minFontSample
+    };
+  }
+
   function measureSlide(slide, index) {
     var slideRect = slide.getBoundingClientRect();
     var bounds = contentBounds(slide, slideRect);
+    var textFont = measureTextFont(slide);
 
     return {
       slide: index + 1,
       contentWidth: Math.max(bounds.maxRight - bounds.minLeft, slide.scrollWidth),
       contentHeight: Math.max(bounds.maxBottom - bounds.minTop, slide.scrollHeight),
       boxWidth: slideRect.width,
-      boxHeight: slideRect.height
+      boxHeight: slideRect.height,
+      minFontSizePx: textFont.minFontSizePx,
+      minFontSample: textFont.minFontSample
     };
   }
 
@@ -106,8 +164,17 @@
     );
   }
 
+  function base64EncodeUtf8(text) {
+    var bytes = new TextEncoder().encode(text);
+    var binary = "";
+    for (var index = 0; index < bytes.length; index += 1) {
+      binary += String.fromCharCode(bytes[index]);
+    }
+    return btoa(binary);
+  }
+
   function publish(results) {
-    var payload = btoa(JSON.stringify(results));
+    var payload = base64EncodeUtf8(JSON.stringify(results));
     var total = Math.max(1, Math.ceil(payload.length / CHUNK_SIZE));
     for (var index = 0; index < total; index += 1) {
       console.log(

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -3574,13 +3574,28 @@ Paragraph after heading.
         assert!(LINT_MEASURE_JS.contains("function walkDescendants"));
         assert!(LINT_MEASURE_JS.contains("Array.prototype.forEach.call(element.children"));
         assert!(!LINT_MEASURE_JS.contains(r#"querySelectorAll("*")"#));
-        assert!(!LINT_MEASURE_JS.contains("getComputedStyle"));
         assert!(!LINT_MEASURE_JS.contains(r#"position === "fixed""#));
         assert!(LINT_MEASURE_JS.contains("rect.width === 0 && rect.height === 0"));
         assert!(LINT_MEASURE_JS.contains("bounds.maxRight - bounds.minLeft"));
         assert!(LINT_MEASURE_JS.contains("slide.scrollWidth"));
         assert!(LINT_MEASURE_JS.contains("contentWidth"));
         assert!(LINT_MEASURE_JS.contains("boxWidth"));
+    }
+
+    #[test]
+    fn lint_measure_script_measures_utf8_safe_min_visible_text_font_size() {
+        assert!(LINT_MEASURE_JS.contains("NodeFilter.SHOW_TEXT"));
+        assert!(LINT_MEASURE_JS.contains("createTreeWalker"));
+        assert!(LINT_MEASURE_JS.contains(r#".peitho-footnotes, sup.peitho-footnote-ref"#));
+        assert!(LINT_MEASURE_JS.contains("getComputedStyle"));
+        assert!(LINT_MEASURE_JS.contains(r#"visibility === "hidden""#));
+        assert!(LINT_MEASURE_JS.contains(r#"visibility === "collapse""#));
+        assert!(LINT_MEASURE_JS.contains("TextEncoder"));
+        assert!(LINT_MEASURE_JS.contains("base64EncodeUtf8"));
+        assert!(!LINT_MEASURE_JS.contains("btoa(JSON.stringify(results))"));
+        assert!(LINT_MEASURE_JS.contains("minFontSizePx"));
+        assert!(LINT_MEASURE_JS.contains("minFontSample"));
+        assert!(LINT_MEASURE_JS.contains(r#"Array.from(sample).slice(0, 40).join("") + "…""#));
     }
 
     fn render_checked_deck(markdown: &str) -> Deck<Rendered> {

--- a/crates/peitho/src/lint.rs
+++ b/crates/peitho/src/lint.rs
@@ -489,6 +489,20 @@ mod tests {
     }
 
     #[test]
+    fn lint_measurement_payload_accepts_utf8_min_font_sample() {
+        let payload = encoded(
+            r#"[{"slide":1,"contentWidth":1280.0,"contentHeight":720.0,"boxWidth":1280.0,"boxHeight":720.0,"minFontSizePx":24.0,"minFontSample":"日本語の小さい文字🙂"}]"#,
+        );
+
+        let measurements = parse_lint_measurements(&console_chunk(1, 1, &payload), 1).unwrap();
+
+        assert_eq!(
+            measurements[0].min_font_sample.as_deref(),
+            Some("日本語の小さい文字🙂")
+        );
+    }
+
+    #[test]
     fn lint_measurement_chunk_errors_are_distinct_and_actionable() {
         let missing = assert_parse_error_mentions(
             "Chrome stderr without lint chunks",


### PR DESCRIPTION
Closes #375

Task 3/7 of the lint font-size plan (`docs/plans/2026-08-01-lint-font-size.md`):

- `lint_measure.js` gains `measureTextFont`: a TreeWalker over each slide's text nodes, skipping whitespace-only nodes, `.peitho-footnotes` / `sup.peitho-footnote-ref` subtrees, unrendered parents (zero-size rect, `visibility: hidden`/`collapse`), and non-finite computed sizes. Per-slide payload gains `minFontSizePx` / `minFontSample` (sample whitespace-collapsed, truncated code-point-safely to 40 chars + `…`).
- **Transport fix**: `publish()` no longer uses `btoa(JSON.stringify(results))` — `btoa` throws on code points > 255 and the sample carries deck text (Japanese decks). Now base64 over `TextEncoder` UTF-8 bytes; chunking unchanged. Rust side needs no change (`STANDARD` decode + `serde_json::from_slice` handles UTF-8), proven by a `日本語…🙂` fixture test.
- Marker test `lint_measure_script_measures_utf8_safe_min_visible_text_font_size` pins the new script shape and bans the old `btoa` form; the now-stale negative `getComputedStyle` assertion is removed from the rect-union marker test.

Verification: `cargo test --workspace` ×3, clippy `-D warnings`, `fmt --check`, bindings drift, `node --check` on the script — all green. Real-Chrome E2E follows in #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNJBDVa1ki822zSeVgotz
