### PR TITLE
lint: warn when slide text renders below the recommended 24pt

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,9 +298,11 @@ peitho completions zsh
 ```
 
 `peitho lint` renders each slide in headless Chrome and warns when layout
-content exceeds the slide box by more than 1px on either axis. It exits 1
-when any overflow warning is found and 0 when the deck is clean; it uses the
-same Chrome discovery as `peitho export pdf`.
+content exceeds the slide box by more than 1px on either axis. It also warns
+once per slide when non-footnote text renders below the recommended 24pt,
+reporting the smallest size in pt and a short excerpt. It exits 1 when any
+warning is found and 0 when the deck is clean; it uses the same Chrome
+discovery as `peitho export pdf`.
 
 Layouts, themes, and the presentation shell use defaults embedded in the binary, so a single deck file works in any directory. Point at your own assets from the deck's frontmatter (`layouts:`, `css:`, `syntaxes:`, `fonts:`) or drop `layouts/`, `css/`, `syntaxes/`, and `fonts/` next to the deck for zero-config pickup. Only `--shell` remains as a CLI-side dev/debug swap for the presentation shell bundle itself.
 

--- a/crates/peitho/src/lint.rs
+++ b/crates/peitho/src/lint.rs
@@ -11,8 +11,11 @@ use serde::Deserialize;
 
 pub(crate) const PEITHO_LINT_DONE: &str = "PEITHO_LINT_DONE";
 const PEITHO_LINT_CHUNK: &str = "PEITHO_LINT_CHUNK";
+const MIN_FONT_SIZE_PX: f64 = 32.0;
 const OVERFLOW_TOLERANCE_PX: i64 = 1;
 const OVERFLOW_HELP: &str = "shrink or split the slide content, or adjust the layout CSS";
+const FONT_SIZE_HELP: &str =
+    "raise the font size in the layout CSS, or move content to another slide instead of shrinking it";
 const LINT_PARSE_HELP: &str =
     "rerun lint and inspect lint.html and chrome-stderr.log in the kept workspace";
 
@@ -55,6 +58,13 @@ struct OverflowWarning {
     overflow_px: i64,
     content_px: i64,
     box_px: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct FontSizeWarning {
+    slide: usize,
+    font_size_px: f64,
+    sample: String,
 }
 
 pub(crate) fn run(input: PathBuf, stdout: &mut dyn Write) -> miette::Result<i32> {
@@ -363,12 +373,40 @@ fn round_px(value: f64) -> i64 {
     value.round() as i64
 }
 
+fn round_font_px(value: f64) -> f64 {
+    (value * 100.0).round() / 100.0
+}
+
+fn collect_font_size_warnings(measurements: &[SlideMeasurement]) -> Vec<FontSizeWarning> {
+    measurements
+        .iter()
+        .filter_map(|measurement| {
+            let font_size_px = round_font_px(measurement.min_font_size_px?);
+            (font_size_px < MIN_FONT_SIZE_PX).then(|| FontSizeWarning {
+                slide: measurement.slide,
+                font_size_px,
+                sample: measurement.min_font_sample.clone().unwrap_or_default(),
+            })
+        })
+        .collect()
+}
+
+fn format_font_size_pt(px: f64) -> String {
+    let pt = (px * 0.75 * 10.0).round() / 10.0;
+    if pt.fract() == 0.0 {
+        format!("{pt:.0}pt")
+    } else {
+        format!("{pt:.1}pt")
+    }
+}
+
 fn write_lint_report(
     measurements: &[SlideMeasurement],
     stdout: &mut dyn Write,
 ) -> miette::Result<i32> {
-    let warnings = collect_overflow_warnings(measurements);
-    for warning in &warnings {
+    let overflow_warnings = collect_overflow_warnings(measurements);
+    let font_size_warnings = collect_font_size_warnings(measurements);
+    for warning in &overflow_warnings {
         writeln!(
             stdout,
             "warning: slide {} content overflows the slide box {} by {}px (content {}px, box {}px)",
@@ -381,10 +419,23 @@ fn write_lint_report(
         .into_diagnostic()?;
         writeln!(stdout, "  help: {OVERFLOW_HELP}").into_diagnostic()?;
     }
-    if warnings.is_empty() {
+    for warning in &font_size_warnings {
         writeln!(
             stdout,
-            "checked {} slide(s): no overflow",
+            "warning: slide {} has text at {}, below the recommended 24pt: \"{}\"",
+            warning.slide,
+            format_font_size_pt(warning.font_size_px),
+            warning.sample
+        )
+        .into_diagnostic()?;
+        writeln!(stdout, "  help: {FONT_SIZE_HELP}").into_diagnostic()?;
+    }
+
+    let warning_count = overflow_warnings.len() + font_size_warnings.len();
+    if warning_count == 0 {
+        writeln!(
+            stdout,
+            "checked {} slide(s): no warnings",
             measurements.len()
         )
         .into_diagnostic()?;
@@ -392,9 +443,9 @@ fn write_lint_report(
     } else {
         writeln!(
             stdout,
-            "checked {} slide(s): {} overflow warning(s)",
+            "checked {} slide(s): {} warning(s)",
             measurements.len(),
-            warnings.len()
+            warning_count
         )
         .into_diagnostic()?;
         Ok(1)
@@ -427,6 +478,18 @@ mod tests {
             console_chunk(2, 2, second),
             console_chunk(1, 2, first)
         )
+    }
+
+    fn measurement(slide: usize, px: Option<f64>, sample: Option<&str>) -> SlideMeasurement {
+        SlideMeasurement {
+            slide,
+            content_width: 800.0,
+            content_height: 600.0,
+            box_width: 800.0,
+            box_height: 600.0,
+            min_font_size_px: px,
+            min_font_sample: sample.map(str::to_owned),
+        }
     }
 
     fn assert_parse_error_mentions(
@@ -604,6 +667,20 @@ mod tests {
     }
 
     #[test]
+    fn font_size_warning_collection_rounds_before_comparing() {
+        let warnings = collect_font_size_warnings(&[
+            measurement(1, Some(31.999), Some("rounds clean")),
+            measurement(2, Some(31.994), Some("Tiny caption")),
+            measurement(3, None, None),
+        ]);
+
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0].slide, 2);
+        assert!((warnings[0].font_size_px - 31.99).abs() < f64::EPSILON);
+        assert_eq!(warnings[0].sample, "Tiny caption");
+    }
+
+    #[test]
     fn overflow_warning_collection_applies_strict_one_pixel_tolerance_per_axis() {
         let measurements = vec![
             SlideMeasurement {
@@ -691,8 +768,8 @@ mod tests {
             content_height: 642.4,
             box_width: 900.0,
             box_height: 600.2,
-            min_font_size_px: None,
-            min_font_sample: None,
+            min_font_size_px: Some(24.0),
+            min_font_sample: Some("excerpt…".to_owned()),
         }];
         let mut stdout = Vec::new();
 
@@ -706,27 +783,30 @@ mod tests {
         assert!(
             output.contains("  help: shrink or split the slide content, or adjust the layout CSS")
         );
-        assert!(output.contains("checked 1 slide(s): 1 overflow warning(s)"));
+        assert!(output.contains(
+            "warning: slide 3 has text at 18pt, below the recommended 24pt: \"excerpt…\""
+        ));
+        assert!(output.contains(
+            "  help: raise the font size in the layout CSS, or move content to another slide instead of shrinking it"
+        ));
+        assert!(output.contains("checked 1 slide(s): 2 warning(s)"));
+        assert_eq!(format_font_size_pt(23.1), "17.3pt");
+        assert_eq!(format_font_size_pt(32.0), "24pt");
 
         let mut clean_stdout = Vec::new();
-        let clean_exit = write_lint_report(
-            &[SlideMeasurement {
-                slide: 1,
-                content_width: 800.0,
-                content_height: 601.4,
-                box_width: 800.0,
-                box_height: 600.0,
-                min_font_size_px: None,
-                min_font_sample: None,
-            }],
-            &mut clean_stdout,
-        )
-        .unwrap();
-
-        assert_eq!(clean_exit, 0);
+        let clean = SlideMeasurement {
+            slide: 1,
+            content_width: 800.0,
+            content_height: 600.0,
+            box_width: 800.0,
+            box_height: 600.0,
+            min_font_size_px: None,
+            min_font_sample: None,
+        };
+        assert_eq!(write_lint_report(&[clean], &mut clean_stdout).unwrap(), 0);
         assert_eq!(
             String::from_utf8(clean_stdout).unwrap(),
-            "checked 1 slide(s): no overflow\n"
+            "checked 1 slide(s): no warnings\n"
         );
     }
 

--- a/crates/peitho/tests/lint.rs
+++ b/crates/peitho/tests/lint.rs
@@ -57,8 +57,9 @@ fn lint_reports_slide_vertical_overflow() {
         .stdout(predicate::str::contains("vertically"))
         .stdout(predicate::str::contains("px"))
         .stdout(predicate::str::contains(
-            "checked 1 slide(s): 1 overflow warning(s)",
-        ));
+            "has text at 22.5pt, below the recommended 24pt:",
+        ))
+        .stdout(predicate::str::contains("checked 1 slide(s): 2 warning(s)"));
 }
 
 #[test]
@@ -79,5 +80,5 @@ fn lint_accepts_trivially_small_deck() {
         .arg(&deck)
         .assert()
         .success()
-        .stdout(predicate::str::contains("checked 1 slide(s): no overflow"));
+        .stdout(predicate::str::contains("checked 1 slide(s): no warnings"));
 }

--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -42,16 +42,18 @@ preserving the current slide and overview state.
 ## `peitho lint`
 
 Lint renders every slide in headless Chrome and warns when layout content
-overflows the slide box by more than 1px horizontally or vertically.
+overflows the slide box by more than 1px horizontally or vertically. It also
+warns when non-footnote text renders below the recommended 24pt.
 
 ```sh
 peitho lint
 ```
 
-Warnings include the slide number, axis, and overflow delta in pixels. The
-command exits 1 when any overflow is found and 0 when the deck is clean. It
-requires Chrome or Chromium, using the same discovery rules as PDF export and
-`PEITHO_CHROME_PATH`.
+Overflow warnings include the slide number, axis, and overflow delta in pixels.
+Font-size warnings appear once per slide and report the smallest size in pt
+with a short excerpt. The command exits 1 when either warning kind is found and
+0 when the deck is clean. It requires Chrome or Chromium, using the same
+discovery rules as PDF export and `PEITHO_CHROME_PATH`.
 
 ## `peitho present`
 


### PR DESCRIPTION
Closes #376
Closes #377

Tasks 4+5/7 of the lint font-size plan (`docs/plans/2026-08-01-lint-font-size.md`), combined into one PR so the collector never lands as dead code:

- `collect_font_size_warnings`: one `FontSizeWarning` per slide when `minFontSizePx` rounded to 0.01px is below 32.0 (= 24pt); `None` (no measurable text) never warns; boundary behavior pinned by test (31.999 → clean, 31.994 → warns).
- `write_lint_report` prints font warnings after overflow warnings (`warning: slide N has text at Xpt, below the recommended 24pt: "excerpt"` + help line), formats pt at most one decimal (`18pt` / `17.3pt`), and unifies the summary to `checked N slide(s): M warning(s)` / `no warnings`. Exit code unchanged: any warning → 1.
- Review round 1 caught that the `#[ignore]`d real-Chrome integration tests (run by the CI e2e job) still expected the old summary — and that the overflow deck now also emits a 22.5pt font warning (default theme body is 30px). Expectations updated and **both tests pass locally against real Chrome**.
- README + `site/content/guide/cli.md` lint sections updated to describe both warning kinds (flagged in review round 2).

Known display nuance (deliberately left as designed, for author judgment): measured sizes in the narrow 31.94–31.99px window warn but display as `24pt` (comparison at 0.01px vs display at 0.1pt granularity), producing a "24pt below the recommended 24pt" message in that window.

Verification: `cargo test --workspace` ×3, clippy `-D warnings`, `fmt --check`, bindings drift, and the two ignored real-Chrome lint tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNJBDVa1ki822zSeVgotz
