### PR TITLE
chore: bump version to 1.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.18.0"
+version = "1.19.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Version bump for the v1.19.0 release.

## Included since v1.18.0

**New Features**
- #381 Code line emphasis: point at specific lines, optionally stepping through them
- #386 lint: warn when slide text renders below the recommended 24pt
- #389 lint: detect slot-level overflow

**Bug Fixes**
- #388 lint: decide the font-size warning on the displayed pt value

**Other**
- #384 lint: measure min visible text font size with UTF-8-safe transport
- #383 lint: deserialize minFontSizePx/minFontSample payload fields
- #382 lint: rename SlideOverflow to SlideMeasurement
- #373 lint: font-size check — design and implementation plan

All gates pass locally: `cargo test --workspace` ×3, clippy, fmt, bindings drift, and the TS build/test/typecheck plus shell/preview/remote bundle drift checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)