### PR TITLE
fix: give preview Enter and Escape a single direction each

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ enum Phase { Parsed, Mapped, Checked, Rendered }
 
 ![peitho preview prints the URL it is serving on, plus a rebuild line on every save](site/static/guide-shots/cli-preview.png)
 
-Press `o`, `Enter`, or `Esc` to flip between the single-slide view and a tile overview of the whole deck; arrows walk the grid, and clicking (or `Enter`) opens the selected tile:
+Press `o` to flip between the single-slide view and a tile overview of the whole deck, or move one way at a time: `Esc` returns to the overview, `Enter` opens the selected tile. Arrows walk the grid, and clicking a tile opens it too:
 
 ![The preview overview: every slide as a tile in a scrollable grid](site/static/guide-shots/preview-overview.png)
 

--- a/packages/peitho-present/dist/preview.js
+++ b/packages/peitho-present/dist/preview.js
@@ -564,7 +564,7 @@ function installPreviewKeyboard(win = window, bus = win) {
     }
     if (event.key === "Escape") {
       event.preventDefault();
-      dispatchOverviewRequest(bus, "toggle");
+      dispatchOverviewRequest(bus, "enter");
       return;
     }
     if (event.key === "Enter") {
@@ -821,8 +821,7 @@ var PreviewShellController = class {
     this.saveState();
   }
   activateSelection() {
-    if (this.mode === "grid") this.exitGrid();
-    else this.enterGrid();
+    this.exitGrid();
   }
   setIndex(index) {
     const next = this.clampIndex(index);

--- a/packages/peitho-present/src/preview.ts
+++ b/packages/peitho-present/src/preview.ts
@@ -97,7 +97,7 @@ export function installPreviewKeyboard(
     }
     if (event.key === "Escape") {
       event.preventDefault();
-      dispatchOverviewRequest(bus, "toggle");
+      dispatchOverviewRequest(bus, "enter");
       return;
     }
     if (event.key === "Enter") {
@@ -384,8 +384,7 @@ class PreviewShellController implements PreviewShell {
   }
 
   private activateSelection(): void {
-    if (this.mode === "grid") this.exitGrid();
-    else this.enterGrid();
+    this.exitGrid();
   }
 
   private setIndex(index: number): void {

--- a/packages/peitho-present/test/preview.test.ts
+++ b/packages/peitho-present/test/preview.test.ts
@@ -242,7 +242,7 @@ it("preview keyboard emits command requests and ignores chord-modified commands"
     window.dispatchEvent(event);
   }
 
-  expect(requests).toEqual([{ action: "toggle" }, { action: "activate" }]);
+  expect(requests).toEqual([{ action: "enter" }, { action: "activate" }]);
   expect(navigations).toEqual([{ to: "next" }, { to: "up" }, { to: "down" }]);
   expect(bareEscape.defaultPrevented).toBe(true);
   expect(chordEscape.defaultPrevented).toBe(false);
@@ -347,7 +347,7 @@ it("exit overview requests exit grid mode and are a no-op in single mode", async
   expect(shell.mode).toBe("single");
 });
 
-it("Escape toggles between single and grid mode with the current slide selected", async () => {
+it("Escape returns to grid mode with the current slide selected", async () => {
   const bus = new EventTarget();
   const root = document.createElement("main");
   const shell = await mountForTest(root, bus);
@@ -362,16 +362,27 @@ it("Escape toggles between single and grid mode with the current slide selected"
   expect(shell.mode).toBe("grid");
   expect(shell.currentIndex).toBe(2);
   expect(shell.selectedIndex).toBe(2);
-
-  const exitGrid = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
-  window.dispatchEvent(exitGrid);
-
-  expect(exitGrid.defaultPrevented).toBe(true);
-  expect(shell.mode).toBe("single");
-  expect(shell.currentIndex).toBe(2);
 });
 
-it("Enter activate request enters grid from single mode with the current slide selected", async () => {
+it("Escape in grid mode stays in grid mode", async () => {
+  const bus = new EventTarget();
+  const root = document.createElement("main");
+  const shell = await mountForTest(root, bus);
+  cleanups.push(installPreviewKeyboard(window, bus));
+
+  bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 2 } } }));
+  bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "enter" } }));
+  expect(shell.mode).toBe("grid");
+
+  const stayInGrid = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+  window.dispatchEvent(stayInGrid);
+
+  expect(stayInGrid.defaultPrevented).toBe(true);
+  expect(shell.mode).toBe("grid");
+  expect(shell.selectedIndex).toBe(2);
+});
+
+it("Enter activate request in single mode stays in single mode", async () => {
   const bus = new EventTarget();
   const root = document.createElement("main");
   const shell = await mountForTest(root, bus);
@@ -380,7 +391,7 @@ it("Enter activate request enters grid from single mode with the current slide s
   bus.dispatchEvent(new CustomEvent("peitho:navigate", { detail: { to: { index: 2 } } }));
   bus.dispatchEvent(new CustomEvent("peitho:overviewrequest", { detail: { action: "activate" } }));
 
-  expect(shell.mode).toBe("grid");
+  expect(shell.mode).toBe("single");
   expect(shell.currentIndex).toBe(2);
   expect(shell.selectedIndex).toBe(2);
 });

--- a/site/content/guide/getting-started.md
+++ b/site/content/guide/getting-started.md
@@ -77,8 +77,9 @@ and overview mode.
 
 ![peitho preview showing a single slide in the browser](/guide-shots/preview-single.png)
 
-In preview, `o`, Enter, or Esc toggles single-slide and tile overview modes;
-arrows move through slides and overview tiles, and clicking a tile opens it.
+In preview, `o` toggles single-slide and tile overview modes, while Esc returns
+to the overview and Enter opens the selected tile; arrows move through slides
+and overview tiles, and clicking a tile opens it.
 
 ![The overview view: every slide as a tile in a scrollable grid](/guide-shots/preview-overview.png)
 


### PR DESCRIPTION
## Problem

In preview mode, `Enter` and `Escape` both toggled between grid and single-slide mode — `activateSelection()` and `toggleOverview()` had identical bodies. That made the two keys interchangeable and left neither with a direction: `Escape` in single mode *entered* the grid rather than returning to it, and `Enter` in single mode bounced back out to the grid.

## Change

Each key now moves one way only:

| key | grid → single | single → grid |
|---|---|---|
| `Enter` | opens the selected tile | no-op |
| `Escape` | no-op | returns to the overview |
| `o` | toggle | toggle |

The `peitho:overviewrequest` vocabulary already had `enter` and `exit` actions with exactly the right semantics but nothing emitted them, so the change is small: the keyboard emits `enter` for `Escape`, and `activateSelection()` only exits the grid. `enterGrid()`/`exitGrid()` already early-return when the mode is unchanged, so the no-op cases fall out for free rather than needing new guards.

## Note on history

This reverses the `Escape` half of the Issue #181 follow-up (`docs/plans/2026-07-08-issue-181-escape-overview-toggle.md`), which had deliberately turned `Escape` from `exit` into `toggle` citing reveal.js convention. `o` remains the reveal.js-style toggle; `Enter`/`Escape` now follow the decide/cancel convention instead.

## Verification

- `cargo test --workspace` ×3, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — all clean
- `npm run build && npm test && npm run typecheck` — 328 tests pass; only `dist/preview.js` changed (no `shell.js`/`remote.js` drift), `bindings/` clean
- Real-browser E2E against `peitho preview` on Chrome, driving actual keydown events:
  - `grid + Enter → single`, `single + Enter → single` (no-op)
  - `single + Escape → grid`, `grid + Escape → grid` (no-op)
  - `o` still toggles both ways
  - grid arrow selection then `Enter` opens exactly the selected slide, and it renders

Docs updated in `README.md` and `site/content/guide/getting-started.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)