### PR TITLE
chore: bump version to 1.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.19.0"
+version = "1.19.1"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.19.0"
+version = "1.19.1"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Release preparation for v1.19.1.

## Changes since v1.19.0

### Bug Fixes
- #391 fix: give preview Enter and Escape a single direction each
- #393 fix: drain Chrome's remaining output until the completion signal arrives

## Gates

- `cargo test --workspace` ×3 — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `git diff --exit-code bindings/` — no drift
- `npm install && npm run build && npm test && npm run typecheck` — 328 tests pass, typecheck clean
- `dist/shell.js`, `dist/preview.js`, `dist/remote.js` — no drift

`Cargo.toml` and `Cargo.lock` both updated (the release workflow builds with `--locked`).

Rebased onto `main` after #393 merged, so this branch carries the e2e fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)