### PR TITLE
fix: publish lint measurements before Chrome prints

### DIFF
--- a/crates/peitho-core/src/lint_measure.js
+++ b/crates/peitho-core/src/lint_measure.js
@@ -348,7 +348,13 @@
     return btoa(binary);
   }
 
+  var published = false;
+
   function publish(results) {
+    if (published) {
+      return;
+    }
+    published = true;
     var payload = base64EncodeUtf8(JSON.stringify(results));
     var total = Math.max(1, Math.ceil(payload.length / CHUNK_SIZE));
     for (var index = 0; index < total; index += 1) {
@@ -363,6 +369,16 @@
   // Start every declared face while this parser-blocking inline script is running,
   // before Chrome can consider the lint page complete.
   var declaredFontsReady = requestDeclaredFonts();
+
+  // Chrome prints when it considers the page ready and exits immediately after,
+  // so the readiness chain below is racing that teardown: bounding its waits
+  // shortens the race but never orders it, and losing means no payload at all.
+  // beforeprint runs after layout settles and before the PDF bytes are written,
+  // so it publishes even when a wait never settles. The latch in publish() keeps
+  // whichever path arrives first as the single payload.
+  window.addEventListener("beforeprint", function () {
+    publish(measureSlides());
+  });
 
   waitForWindowLoad()
     .then(waitForImages)

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -3829,6 +3829,35 @@ Paragraph after heading.
     }
 
     #[test]
+    fn lint_measure_script_publishes_before_chrome_prints() {
+        // Regression: bounding the readiness waits only shortens the race
+        // against Chrome's --print-to-pdf teardown, it does not order it, so
+        // the payload could be missing entirely. beforeprint fires after
+        // layout settles but before the PDF bytes are written, which orders
+        // publication by construction even when a wait never settles.
+        assert!(
+            LINT_MEASURE_JS.contains(r#"window.addEventListener("beforeprint""#),
+            "expected a beforeprint listener so publish cannot lose to the print"
+        );
+        assert!(
+            LINT_MEASURE_JS.contains("published"),
+            "expected a latch so the chain and beforeprint cannot both emit a payload"
+        );
+
+        let publish_body = LINT_MEASURE_JS
+            .split_once("function publish(")
+            .unwrap()
+            .1
+            .split_once("\n  }")
+            .unwrap()
+            .0;
+        assert!(
+            publish_body.contains("if (published)"),
+            "expected publish() itself to hold the latch, not each call site"
+        );
+    }
+
+    #[test]
     fn lint_measure_script_does_not_contain_raw_sentinel_strings() {
         assert!(!LINT_MEASURE_JS.contains("PEITHO_LINT_BEGIN"));
         assert!(!LINT_MEASURE_JS.contains("PEITHO_LINT_END"));

--- a/docs/plans/2026-08-04-lint-publish-print-ordering.md
+++ b/docs/plans/2026-08-04-lint-publish-print-ordering.md
@@ -1,0 +1,116 @@
+# Lint publish/print ordering (2026-08-04)
+
+## Problem
+
+`lint_accepts_trivially_small_deck` fails intermittently on Linux CI with:
+
+```
+Chrome completed before one-shot output was ready
+help: expected lint measurement payload before Chrome exited
+```
+
+This is **not** the bug PR #393 fixed. That one truncated output that Chrome had
+already written; this one is Chrome exiting before the payload is written at all.
+
+### Evidence
+
+- In the failing logs (runs 30914999594 / 30912935249 / 30911489043, all the same
+  signature), `PEITHO_LINT_DONE` occurs 0 times **and so does `CONSOLE`**. The
+  drain-window bug leaves a truncated tail with CONSOLE lines present; zero
+  CONSOLE lines means `publish()` was never reached.
+- Chrome's own timestamps bound its whole lifetime at ~370 ms
+  (`134128.226` → `134128.595`), while `lint_measure.js` budgets
+  `WINDOW_LOAD_TIMEOUT_MS = 2000` plus `FONT_READY_TIMEOUT_MS = 2000`. Neither
+  timeout ever expired — the process ended first.
+- The last stderr line is `4322 bytes written to file …/lint.pdf`: the print
+  completed and Chrome tore down while the measurement chain was still pending.
+
+### Root cause
+
+`lint_measure.js` publishes at the end of an asynchronous chain:
+
+```
+waitForWindowLoad → waitForImages → waitForFonts → waitForFrame → publish
+```
+
+Nothing orders that chain against Chrome's `--print-to-pdf` completion. Chrome
+prints when *it* considers the page ready and exits immediately after, so the
+chain is a race against teardown. `--virtual-time-budget=10000` bounds virtual
+time; it does not hold the print back until pending promises settle.
+
+The three prior fixes to this seam (`7554083`, `ca87934`, `d088481`) all added
+*upper bounds to waits*. A bound shortens the race; it never orders it. That is
+why the flake keeps returning under new load conditions.
+
+### Why it never reproduces locally
+
+Measured on macOS Chrome: under `--virtual-time-budget`, both `setTimeout` and
+`document.fonts.ready` resolve against virtual time, so the chain finishes
+early and `PEITHO_LINT_DONE` reliably precedes the PDF write. The ordering only
+inverts where real-time resource work outlives virtual time (Linux headless CI).
+Local runs cannot validate this fix; the Linux `e2e` job is the check.
+
+## Approach
+
+Publish from a **`beforeprint` listener** instead of from the tail of the async
+chain.
+
+`beforeprint` fires synchronously, after layout and font resolution have settled,
+and — measured — strictly *before* the PDF bytes are written. Publishing inside it
+is ordered by construction rather than by timing, which makes "Chrome printed but
+lint published nothing" unrepresentable rather than merely unlikely.
+
+Measured orderings (macOS Chrome, same flags as `lint_chrome_args`):
+
+| Scenario | Result |
+| --- | --- |
+| publish inside `beforeprint` | `BEFOREPRINT` → `DONE` → `bytes written` |
+| async chain that **never settles**, plus `beforeprint` | `PUBLISH_FROM_BEFOREPRINT` → `DONE` → `bytes written` |
+
+The second row is the load-bearing one: even with a permanently pending promise
+— the exact Linux hang class called out in the existing comments — the payload
+still lands before the print. It also subsumes the `image.decode()` hang pitfall
+already recorded in CLAUDE.md.
+
+### Design
+
+Keep the existing readiness chain as the *preferred* trigger, since it publishes
+as soon as fonts and images genuinely settle (the common, correctly-measured
+case). Add `beforeprint` as a second trigger. Guard both with a single
+`published` latch so exactly one payload is ever emitted.
+
+This is one seam, not a guard at each consumer: `publish()` gains the latch, and
+the two triggers both route through it.
+
+Not chosen:
+
+- **Measure synchronously at parse time.** Ordering would be guaranteed, but it
+  measures before fonts and images load, silently changing lint results. Wrong
+  answers on time are worse than a flake.
+- **Raise the timeouts.** Same shape as the three fixes that already failed.
+
+## Tasks
+
+1. `crates/peitho-core/src/lint_measure.js`
+   - Add a module-level `published` latch; make `publish()` a no-op after first call.
+   - Register a `beforeprint` listener that measures and publishes.
+   - Keep the existing chain calling the same `publish()`.
+   - Comment states the invariant (publish must precede print) and why the chain
+     alone cannot guarantee it — not what the next line does.
+2. `crates/peitho-core/src/render.rs` tests
+   - Assert `LINT_MEASURE_JS` registers `beforeprint`, alongside the existing
+     assertions that it contains `console.log(` / `CHUNK_SIZE` and does not
+     contain the literal signal strings.
+3. Verification
+   - Full gate list from CLAUDE.md.
+   - Linux `e2e` job is the real check; confirm `lint_accepts_trivially_small_deck`
+     passes there, and that the lint report still reports real measurements
+     (a payload of zeroes would pass the test while defeating lint).
+
+## Risk
+
+`beforeprint` may fire on a page whose fonts have not settled, producing
+measurements from fallback fonts. That only happens when the chain has not
+already published — i.e. exactly the case that currently produces *no*
+measurement and a hard failure. Degrading from "hard error" to "measured against
+whatever font resolved" matches the tradeoff `waitForFonts` already documents.


### PR DESCRIPTION
## Problem

`lint_accepts_trivially_small_deck` keeps failing intermittently on the Linux `e2e` job with:

```
Chrome completed before one-shot output was ready
help: expected lint measurement payload before Chrome exited
```

This is **not** the bug PR #393 fixed. That one drained output Chrome had already written; this one is Chrome exiting before the payload is written at all. Three failures today share the signature: runs 30914999594, 30912935249, 30911489043.

## Evidence

- In the failing logs, `PEITHO_LINT_DONE` occurs **0 times and so does `CONSOLE`**. The drain bug leaves a truncated tail with CONSOLE lines present; zero CONSOLE lines means `publish()` was never reached.
- Chrome's own timestamps bound its whole lifetime at ~370ms (`134128.226` → `134128.595`), while `lint_measure.js` budgets `WINDOW_LOAD_TIMEOUT_MS = 2000` plus `FONT_READY_TIMEOUT_MS = 2000`. Neither timeout ever expired — the process ended first.
- The last stderr line is `bytes written to file …/lint.pdf`: the print completed and Chrome tore down with the chain still pending.

## Root cause

`lint_measure.js` published at the tail of `waitForWindowLoad → waitForImages → waitForFonts → waitForFrame → publish`. Nothing ordered that chain against `--print-to-pdf` completion, so it raced teardown. `--virtual-time-budget` bounds virtual time; it does not hold the print back until pending promises settle.

The three prior fixes to this seam (`7554083`, `ca87934`, `d088481`) all added **upper bounds to waits**. A bound shortens the race; it never orders it. That is why the flake kept coming back.

## Fix

Publish from a `beforeprint` listener in addition to the existing chain. `beforeprint` fires after layout and fonts settle but **before** the PDF bytes are written, so publication is ordered by construction rather than by timing. A latch inside `publish()` keeps whichever path arrives first as the single payload — one seam, not a guard per call site.

## Verification

Measured against real Chrome with the same flags as `lint_chrome_args`:

| Scenario | Result |
| --- | --- |
| Readiness chain stalled permanently, listener present | payload → `DONE` → `bytes written`, decoding to real measurements (`contentWidth: 740`, `minFontSizePx: 40`) |
| Same page, listener removed | **0** `PEITHO_LINT_DONE`, PDF still written — reproduces the CI signature exactly |

The stalled-chain row is the load-bearing one: it is the exact Linux hang class the existing comments call out, and it also subsumes the `image.decode()` pitfall in CLAUDE.md.

End-to-end `peitho lint` still reports genuine results, not zeroes — a tiny deck passes clean, and an overflowing deck still produces slide overflow, slot overflow, and font-size warnings.

Note that this cannot be reproduced on macOS: under `--virtual-time-budget`, `setTimeout` and `document.fonts.ready` resolve against virtual time, so `DONE` reliably precedes the print locally. The Linux `e2e` job is the real check.

All gates pass: `cargo test --workspace` ×3, clippy, fmt, bindings drift, and the TS build/test/typecheck plus shell/preview/remote bundle drift.

Design record: `docs/plans/2026-08-04-lint-publish-print-ordering.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)