### PR TITLE
chore: bump version to 1.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.19.1"
+version = "1.20.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.19.1"
+version = "1.20.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.19.1"
+version = "1.20.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Release v1.20.0.

New features since v1.19.1:
- #401: build-time tweet embeds via Chrome screenshot of the official widget (Issue #395)
- #403: opt-in oEmbed card mode for tweet embeds — ```embed mode=card``` (Issue #398)
- #404: generic oEmbed providers for embed blocks — discovery + thumbnail/text cards (Issue #399)

Fixes:
- #396: publish lint measurements before Chrome prints

🤖 Generated with [Claude Code](https://claude.com/claude-code)