### PR TITLE
chore: bump version to 1.21.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1922,7 +1922,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.20.1"
+version = "1.21.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Release 1.21.0.

Changes since v1.20.1:
- #410 feat: order PDF printing after flattening via CDP
- #409 fix: require the PDF flatten completion signal before export succeeds

A `feat:` PR is included, so this is a minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)