### PR TITLE
fix: render swallowed diagnostics through miette's reporter

### DIFF
--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -1017,7 +1017,7 @@ fn cmd_layouts(input: PathBuf, explain: Option<String>, json: bool) -> miette::R
             message,
             format!("known keys: {}", known_keys.join(", ")),
         );
-        eprintln!("{err}");
+        eprintln!("{}", render_diagnostic(&miette::miette!("{err}")));
         std::process::exit(2);
     };
     let trace = peitho_core::explain_dispatch(slide, &layouts);
@@ -1360,6 +1360,23 @@ fn keep_workspace_for_error(tmp: tempfile::TempDir, err: impl std::fmt::Display)
     miette::miette!("{err}\nhelp: workspace kept at {}", kept.display())
 }
 
+/// Render a diagnostic the way miette's own reporter would for a `main`-returned
+/// error, so error paths that must swallow the `Report` (watch loops, preview)
+/// stay visually identical to the ones that propagate.
+///
+/// `Display` on a `Report` emits only the flat message, dropping colors, source
+/// snippets, and width-aware wrapping. Every terminal-facing site that consumes
+/// a diagnostic instead of returning it must go through this function; HTML
+/// sinks such as the preview error page must keep using `Display`, because this
+/// output can carry ANSI escapes.
+fn render_diagnostic(err: &miette::Report) -> String {
+    // `Report`'s `Debug` dispatches to the installed miette handler, which is the
+    // same path a `main`-returned error takes. Going through it (rather than
+    // building a handler here) keeps terminal-width detection, color support, and
+    // `NO_COLOR` handling identical to `peitho build` without duplicating them.
+    format!("{err:?}")
+}
+
 fn rebuild_once_for_watch(
     options: &BuildOptions,
     stdout: &mut dyn Write,
@@ -1378,12 +1395,12 @@ fn rebuild_once_for_watch(
                 stdout.flush().into_diagnostic()?;
             }
             Err(err) => {
-                writeln!(stderr, "build failed: {err}").into_diagnostic()?;
+                writeln!(stderr, "build failed: {}", render_diagnostic(&err)).into_diagnostic()?;
                 stderr.flush().into_diagnostic()?;
             }
         },
         Err(err) => {
-            writeln!(stderr, "build failed: {err}").into_diagnostic()?;
+            writeln!(stderr, "build failed: {}", render_diagnostic(&err)).into_diagnostic()?;
             stderr.flush().into_diagnostic()?;
         }
     }
@@ -4163,7 +4180,7 @@ fn emit_initial_preview_root(
             Ok(root)
         }
         Err(err) => {
-            writeln!(stderr, "build failed: {err}").into_diagnostic()?;
+            writeln!(stderr, "build failed: {}", render_diagnostic(&err)).into_diagnostic()?;
             stderr.flush().into_diagnostic()?;
             let root = emit_preview_error_page(cache, 0, &err.to_string())?;
             prune_preview_cache_generations(cache, 0)?;
@@ -4198,7 +4215,7 @@ fn rebuild_preview_once_for_watch(
             stdout.flush().into_diagnostic()?;
         }
         Err(err) => {
-            writeln!(stderr, "build failed: {err}").into_diagnostic()?;
+            writeln!(stderr, "build failed: {}", render_diagnostic(&err)).into_diagnostic()?;
             stderr.flush().into_diagnostic()?;
         }
     }
@@ -9190,6 +9207,44 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             stderr.contains("slot 'code' got 2 item(s)"),
             "actual stderr: {stderr}"
         );
+    }
+
+    #[test]
+    fn render_diagnostic_formats_help_like_miettes_reporter() {
+        let build_error = peitho_core::BuildError::new(
+            peitho_core::error::ErrorKind::Parse,
+            None,
+            "deck.md:3: broken deck".to_owned(),
+            "fix the frontmatter".to_owned(),
+        );
+        let err = miette::miette!("{build_error}");
+
+        let rendered = render_diagnostic(&err);
+
+        // The graphical handler lays the diagnostic out over multiple lines with a
+        // help section; plain `Display` would collapse it into the message alone.
+        assert!(rendered.contains("broken deck"), "actual: {rendered}");
+        assert!(
+            rendered.contains("help: fix the frontmatter"),
+            "actual: {rendered}"
+        );
+        assert!(rendered.lines().count() > 1, "actual: {rendered}");
+    }
+
+    #[test]
+    fn preview_error_page_keeps_ansi_escapes_out_of_html() {
+        let fixture =
+            WatchFixture::new("# Intro\n\n```rust\nfn a() {}\n```\n\n```rust\nfn b() {}\n```");
+        let cache = fixture._dir.path().join(".peitho/preview-cache");
+        let mut stderr = Vec::new();
+
+        emit_initial_preview_root(&fixture.options.input, &cache, &mut stderr).unwrap();
+
+        // The terminal sink renders the full diagnostic, but the HTML sink must
+        // receive the flat message so escape codes never reach the browser.
+        let html =
+            fs::read_to_string(preview_generation_dir(&cache, 0).join("index.html")).unwrap();
+        assert!(!html.contains('\u{1b}'), "actual html: {html}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`peitho preview` printed build errors without color or miette's formatting, unlike `peitho build`.

The cause: preview must not let a failed build kill the server (it serves an error page and reloads on the next success), so it swallows the `Report` and prints it with `{}`. `Display` on a `Report` emits only the flat message, bypassing the installed miette handler entirely — no colors, no layout, no width-aware wrapping.

The same bug affects three other sites, so this is one root cause with four symptoms:

- `emit_initial_preview_root` (preview, first build)
- `rebuild_preview_once_for_watch` (preview, watch rebuild)
- `rebuild_once_for_watch` (`build --watch`, both branches)
- `cmd_layouts` (`layouts --explain`, unknown slide key)

Measured before, under a PTY:

```
build failed: deck.md:3: invalid deck frontmatter: unknown field `bogus_key`, expected one of ...
```

versus `peitho build` on the same deck:

```
Error:   × deck.md:3: invalid deck frontmatter: unknown field `bogus_key`, expected
  ╂ one of `time`, `aspect_ratio`, ...
```

## Fix

One shared `render_diagnostic` helper, used by every terminal-facing site that consumes a diagnostic instead of returning it. It formats with `{:?}`, which dispatches through `Report`'s `Debug` to the *installed* miette handler — the same path a `main`-returned error takes.

Formatting via the installed handler rather than constructing a `GraphicalReportHandler` locally is load-bearing: a locally built handler hardcodes `termwidth: 200`, which produced correctly-colored but unwrapped output that still didn't match `build`. Going through the handler inherits terminal-width detection, color support, and `NO_COLOR` handling with no duplicated logic to drift.

After the fix, preview output is byte-identical to `build`'s.

## The one place that must NOT change

`emit_preview_error_page` keeps `err.to_string()`. It embeds the message into HTML, and ANSI escapes there would render as garbage in the browser. `preview_error_page_keeps_ansi_escapes_out_of_html` pins that boundary so a future refactor can't route the HTML sink through the colored path.

## Verification

- Verified end-to-end in a real terminal (PTY): preview now matches `build` exactly, including wrapping.
- Verified piped (no TTY): output is automatically escape-free — no `NO_COLOR` handling needed on our side.
- Verified the generated error page contains zero `\x1b` bytes.
- Full gates: `cargo test --workspace` 3x green (1370 tests), clippy `-D warnings` clean, `cargo fmt --check`, no `bindings/` drift, TS build/test/typecheck green, no shell/preview/remote bundle drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)