### PR TITLE
Make the PDF flattening readiness poll expression total

### DIFF
--- a/crates/peitho/src/cdp.rs
+++ b/crates/peitho/src/cdp.rs
@@ -15,8 +15,13 @@ use tungstenite::{protocol::WebSocketConfig, Message, WebSocket};
 const DEVTOOLS_PORT_FILE: &str = "DevToolsActivePort";
 const HTTP_RESPONSE_LIMIT: usize = 1024 * 1024;
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
+// Total expression: it must never throw. The poll can land in a freshly
+// created document before `<html>` is inserted, where `documentElement` is
+// null (measured on CI, issue #418) — that window is "not ready", not an
+// error. The `?? null` keeps the result null-or-string, so the strict
+// RemoteObject decoding below stays exhaustive.
 const PDF_FLATTENED_EXPRESSION: &str =
-    "document.documentElement.getAttribute('data-peitho-pdf-flattened')";
+    "document.documentElement?.getAttribute('data-peitho-pdf-flattened') ?? null";
 
 pub(crate) fn wait_for_devtools_port(
     profile: &Path,

--- a/docs/plans/2026-08-05-cdp-ordered-pdf-print.md
+++ b/docs/plans/2026-08-05-cdp-ordered-pdf-print.md
@@ -54,12 +54,19 @@ in `pdf.html`; `displayHeaderFooter: false` replaces `--no-pdf-header-footer`;
 4. WebSocket via `tungstenite` (ws:// on loopback only — no TLS features).
    `Page.enable`, `Page.navigate` to the `pdf.html` file URL.
 5. Poll `Runtime.evaluate` on
-   `document.documentElement.getAttribute('data-peitho-pdf-flattened')` until
-   non-null. The attribute is set on both the success path and the top-level
-   catch of `flattenPdfArtifacts`, so it always appears when the script parses;
-   a parse failure or never-settling chain hits the deadline → loud error
-   naming flattening readiness. **The attribute written since the flatten
-   feature landed finally has its reader.**
+   `document.documentElement?.getAttribute('data-peitho-pdf-flattened') ?? null`
+   until non-null. The attribute is set on both the success path and the
+   top-level catch of `flattenPdfArtifacts`, so it always appears when the
+   script parses; a parse failure or never-settling chain hits the deadline →
+   loud error naming flattening readiness. **The attribute written since the
+   flatten feature landed finally has its reader.**
+   (Amendment 2026-08-06, issue #418: the expression must be total — the poll
+   can land in a freshly created document before `<html>` is inserted, where
+   `documentElement` is null; measured once on CI as an in-page `TypeError`
+   that failed the export hard. That window is "not ready", not an error, so
+   the expression null-guards itself and `?? null` keeps the result
+   null-or-string; the protocol-level transient retry for
+   "Execution context was destroyed" is unchanged.)
 6. Only then `Page.printToPDF { printBackground, preferCSSPageSize,
    displayHeaderFooter: false }`; decode base64, write the output file.
 7. `Browser.close`, wait bounded, kill+reap if it lingers (throwaway profile —


### PR DESCRIPTION
Closes #418

Observed once on PR #417's e2e run (unrelated diff): the flattening-readiness `Runtime.evaluate` landed in a freshly created document before `<html>` was inserted, `document.documentElement` was `null`, the expression threw `TypeError` in-page, and the export failed hard — the transient retry only covers protocol-level races (`Execution context was destroyed` / `Cannot find default execution context`).

Fix at the expression seam so the poll is total and can never throw for a missing element:

```
document.documentElement?.getAttribute('data-peitho-pdf-flattened') ?? null
```

That window now reads as "not ready" (`null`) and the poll continues. The `?? null` keeps the result null-or-string, so the strict RemoteObject decoding (`undefined`/unexpected values are still hard errors) and the loud-deadline behavior are unchanged; genuine in-page exceptions still fail the export. Design record amended (`docs/plans/2026-08-05-cdp-ordered-pdf-print.md`).

## Test plan

- `cargo test --workspace` × 3 green, clippy `-D warnings`, fmt, `bindings/` drift clean.
- Local real-Chrome e2e: `cargo test -p peitho --test export_pdf -- --ignored --test-threads=1` — 4/4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)