### PR TITLE
Release 1.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.22.0"
+version = "1.22.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.22.0"
+version = "1.22.1"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.22.0"
+version = "1.22.1"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Bump version to 1.22.1.

Included since v1.22.0:
- #417: Right-align the help: label under error: and warning: (+ insta snapshot tests)
- #419: Make the PDF flattening readiness poll expression total (#418)

🤖 Generated with [Claude Code](https://claude.com/claude-code)