### PR TITLE
Render GFM strikethrough as <del>

### DIFF
--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -1835,6 +1835,8 @@ fn parse_slide(
                 | Event::End(TagEnd::Emphasis)
                 | Event::Start(Tag::Strong)
                 | Event::End(TagEnd::Strong)
+                | Event::Start(Tag::Strikethrough)
+                | Event::End(TagEnd::Strikethrough)
                 | Event::Start(Tag::Link { .. })
                 | Event::End(TagEnd::Link) => continue,
                 Event::Start(Tag::Image { .. })
@@ -1874,8 +1876,6 @@ fn parse_slide(
                 | Event::End(TagEnd::DefinitionListTitle)
                 | Event::Start(Tag::DefinitionListDefinition)
                 | Event::End(TagEnd::DefinitionListDefinition)
-                | Event::Start(Tag::Strikethrough)
-                | Event::End(TagEnd::Strikethrough)
                 | Event::Start(Tag::Superscript)
                 | Event::End(TagEnd::Superscript)
                 | Event::Start(Tag::Subscript)
@@ -2469,6 +2469,8 @@ fn parse_slide(
             | Event::End(TagEnd::Emphasis)
             | Event::Start(Tag::Strong)
             | Event::End(TagEnd::Strong)
+            | Event::Start(Tag::Strikethrough)
+            | Event::End(TagEnd::Strikethrough)
             | Event::Start(Tag::Link { .. })
             | Event::End(TagEnd::Link) => {
                 if matches!(
@@ -2892,6 +2894,7 @@ fn attach_slide_context(
 fn parser_options() -> Options {
     Options::ENABLE_TABLES
         | Options::ENABLE_OLD_FOOTNOTES
+        | Options::ENABLE_STRIKETHROUGH
         | Options::ENABLE_YAML_STYLE_METADATA_BLOCKS
 }
 
@@ -4148,6 +4151,25 @@ enum Phase { Parsed, Mapped, Checked }
             .contains("- Markdown = source of truth"));
         assert_eq!(slide.fragments[3].kind(), &FragmentKind::Code);
         assert_eq!(slide.fragments[3].line(), 9);
+    }
+
+    #[test]
+    fn parses_strikethrough_in_paragraph() {
+        let markdown = "# Title\n\nThis is ~~deleted~~ text.";
+        let events = Parser::new_ext(markdown, parser_options()).collect::<Vec<_>>();
+
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, Event::Start(Tag::Strikethrough))));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, Event::End(TagEnd::Strikethrough))));
+
+        let deck = parse_markdown(markdown, &crate::highlight::Highlighter::defaults()).unwrap();
+        let paragraph = &deck.parsed_slides()[0].fragments[1];
+
+        assert_eq!(paragraph.kind(), &FragmentKind::Paragraph);
+        assert_eq!(paragraph.markdown(), "This is ~~deleted~~ text.");
     }
 
     #[test]

--- a/crates/peitho-core/src/plain.rs
+++ b/crates/peitho-core/src/plain.rs
@@ -1,6 +1,9 @@
-use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{Event, Parser, Tag, TagEnd};
 
-use crate::{domain::FragmentKind, manifest::ManifestSlideText, phase::CheckedSlide};
+use crate::{
+    domain::FragmentKind, manifest::ManifestSlideText, phase::CheckedSlide,
+    render::BODY_MARKDOWN_OPTIONS,
+};
 
 pub(crate) fn slide_text<S>(slide: &CheckedSlide<S>) -> ManifestSlideText {
     let mut title = Vec::new();
@@ -66,7 +69,7 @@ fn body_fragment_text(markdown: &str) -> String {
     let mut text = String::new();
     let mut in_image = false;
 
-    for event in Parser::new_ext(markdown, Options::ENABLE_OLD_FOOTNOTES) {
+    for event in Parser::new_ext(markdown, BODY_MARKDOWN_OPTIONS) {
         match event {
             Event::Start(Tag::Image { .. }) => in_image = true,
             Event::End(TagEnd::Image) => in_image = false,
@@ -81,6 +84,7 @@ fn body_fragment_text(markdown: &str) -> String {
             {
                 text.push(' ');
             }
+            Event::Start(Tag::Strikethrough) | Event::End(TagEnd::Strikethrough) => {}
             _ => {}
         }
     }

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -23,7 +23,8 @@ use crate::{
 const PDF_FLATTEN_JS: &str = include_str!("pdf_flatten.js");
 const LINT_MEASURE_JS: &str = include_str!("lint_measure.js");
 
-pub(crate) const BODY_MARKDOWN_OPTIONS: Options = Options::ENABLE_OLD_FOOTNOTES;
+pub(crate) const BODY_MARKDOWN_OPTIONS: Options =
+    Options::ENABLE_OLD_FOOTNOTES.union(Options::ENABLE_STRIKETHROUGH);
 
 pub(crate) fn walk_body_markdown_list_items<'a>(
     markdown: &'a str,
@@ -2090,6 +2091,41 @@ mod tests {
         assert!(html.contains("main"));
     }
 
+    #[test]
+    fn renders_strikethrough_in_paragraph() {
+        let markdown = "# Title\n\nThis is ~~deleted~~ text.";
+        let layout = title_body_layout();
+        let checked = check_deck(
+            map_by_convention(
+                parse_markdown(markdown, &crate::highlight::Highlighter::defaults()).unwrap(),
+                &layout,
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let text = crate::plain::slide_text(&checked.checked_slides()[0]);
+        assert_eq!(text.body(), "This is deleted text.");
+
+        let rendered = render_checked(checked);
+        let html = rendered.slides()[0].html();
+
+        assert!(
+            html.contains("<p>This is <del>deleted</del> text.</p>"),
+            "{html}"
+        );
+        assert!(!html.contains("~~deleted~~"), "{html}");
+    }
+
+    #[test]
+    fn renders_unclosed_strikethrough_delimiters_literally() {
+        let rendered =
+            render_checked_deck_with_layout("# Title\n\nThis is a ~~ b", title_body_layout());
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains("<p>This is a ~~ b</p>"), "{html}");
+    }
+
     /// Render a deck whose layout has a code slot, returning slide 0's HTML.
     fn render_code_html(markdown: &str) -> String {
         let layout = parse_layout(
@@ -2812,6 +2848,21 @@ mod tests {
     }
 
     #[test]
+    fn renders_strikethrough_in_footnote_definition() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\nClaim[^a].\n\n[^a]: ~~Deleted~~ note.",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(
+            html.contains("<li><p><del>Deleted</del> note.</p>"),
+            "{html}"
+        );
+        assert!(!html.contains("~~Deleted~~"), "{html}");
+    }
+
+    #[test]
     fn deck_without_footnotes_renders_no_footnotes_block() {
         let rendered = render_checked_deck_with_layout(
             "# Title\n\nBody only.",
@@ -3378,6 +3429,20 @@ mod tests {
         assert!(html.contains("<code>Phase</code>"));
         assert!(html.contains(r#"<a href="https://example.com">docs</a>"#));
         assert!(!html.contains("<p><strong>Architecture</strong>"));
+    }
+
+    #[test]
+    fn renders_strikethrough_in_heading_and_derives_key_from_text() {
+        let rendered = render_checked_deck("# ~~Obsolete~~ Architecture");
+        let slide = &rendered.slides()[0];
+
+        assert_eq!(slide.key().as_str(), "obsolete-architecture");
+        assert!(
+            slide.html().contains("<del>Obsolete</del> Architecture"),
+            "{}",
+            slide.html()
+        );
+        assert!(!slide.html().contains("~~Obsolete~~"), "{}", slide.html());
     }
 
     #[test]

--- a/docs/plans/2026-08-16-strikethrough-support.md
+++ b/docs/plans/2026-08-16-strikethrough-support.md
@@ -1,0 +1,60 @@
+# Strikethrough support (Issue #426)
+
+Date: 2026-08-16
+Issue: #426 — `~~x~~` passes through as literal text instead of rendering or erroring
+
+## Problem
+
+`ENABLE_STRIKETHROUGH` is absent from both the parse grammar
+(`parser_options()`, `crates/peitho-core/src/parser.rs`) and the renderer's
+`BODY_MARKDOWN_OPTIONS` (`crates/peitho-core/src/render.rs`), so
+`This is ~~deleted~~ text.` builds without error and renders the tildes
+literally. Unlike blockquotes/tables (loud `unsupported construct` errors),
+this degrades silently — the pillar ③ failure mode.
+
+## Decision
+
+Enable the GFM strikethrough extension and render `<del>` (option 1 in the
+issue). All three project lenses select it: it is the long-term behavior
+users expect from GFM input, the change happens at the two grammar seams
+rather than per-consumer, and pulldown-cmark's exhaustive event matches force
+every walk site to make an explicit decision (no silent path can survive the
+compile).
+
+## Changes
+
+1. `parser_options()`: add `Options::ENABLE_STRIKETHROUGH`. Leave
+   `slide_split_options()` unchanged — strikethrough is inline and cannot
+   affect `Event::Rule` detection; the split grammar stays minimal on
+   purpose (two-grammar pitfall).
+2. `BODY_MARKDOWN_OPTIONS` (render.rs): add `Options::ENABLE_STRIKETHROUGH`
+   so fragment re-rendering emits `<del>`.
+3. Chase the compile/behavior consequences at every exhaustive event match
+   that can now legally see `Start(Tag::Strikethrough)` /
+   `End(TagEnd::Strikethrough)`:
+   - the main parse walk treats it like Emphasis/Strong (legal inline
+     content, rides the fragment's markdown source),
+   - the footnote-definition walk allows it wherever Emphasis is allowed,
+   - plain-text extraction walks (key derivation, heading text, notes)
+     treat it as transparent formatting (keep the inner text).
+   No arm may become `_ => {}`.
+4. Theme: no CSS required (`<del>` gets the UA line-through); do not add
+   unsolicited styles.
+
+## Tests (TDD order)
+
+1. Parse: `~~deleted~~` inside a paragraph parses (no error) and the
+   fragment markdown retains the source text.
+2. Render: rendered slide HTML contains `<del>deleted</del>` (and not the
+   literal tildes).
+3. Strikethrough inside a heading: renders `<del>` in the heading, and the
+   derived slide key from that heading text ignores the markup (matches how
+   emphasis-in-heading keys behave today — mirror the existing test).
+4. Strikethrough inside a footnote definition renders.
+5. Regression: a paragraph with literal `~~` that is not closed (e.g.
+   `a ~~ b`) still renders literally (GFM semantics, no error).
+
+## Non-goals
+
+- No `del`-specific theme styling.
+- No change to the slide-split grammar.


### PR DESCRIPTION
Closes #426

## What

`~~x~~` previously built without error and rendered as literal tildes — the only silent degradation among the unsupported-construct reports in #424/#425/#426 (blockquote/table at least fail loudly). This enables the GFM strikethrough extension and renders `<del>`, restoring the "works or errors loudly" invariant.

## How

- `parser_options()` and `BODY_MARKDOWN_OPTIONS` gain `ENABLE_STRIKETHROUGH`; the slide-split grammar is deliberately untouched (strikethrough is inline and cannot affect `Event::Rule` — the two-grammar pitfall).
- `Start/End(Tag::Strikethrough)` moves from the unsupported arms to the inline-content arms (grouped with Emphasis/Strong) in both the main walk and the footnote-definition walk. As a consequence, `~~x~~` inside image alt text is now rejected like Emphasis/Strong there — previously it degraded silently to literal tildes.
- `plain.rs` extraction is transparent to the markup and now reuses `BODY_MARKDOWN_OPTIONS` instead of duplicating the options literal.
- No theme CSS: `<del>` gets the UA line-through.

## Known behavior notes

- Derived slide keys change only for headings with `~~x~~` **directly adjacent** to other text (`# a~~b~~c`: `a-b-c` → `abc`) — identical to the existing Emphasis/Strong precedent; whitespace-separated spans derive the same key as before.

## Verification

- TDD (5 new tests: parse, render, heading + key derivation, footnote definition, unclosed-delimiter literal).
- `cargo test --workspace` ×3 green, clippy `-D warnings`, fmt, bindings/dist drift checks, npm build/test/typecheck all green.
- Review: multi-agent code review (all candidates refuted with measurement) + 5 review rounds, including E2E probes for PDF export (CDP path), `breaks: true`, footnote refs inside spans, reveal fences, and explicit slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV