### PR TITLE
Make the include splice seam construct-proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ A slide's page settings are one `<!-- { ... } -->` JSON comment (at most one per
   ---
   ```
 
-  Deck-relative paths only, nested up to 64 levels, cycles/absolute/`..`-escape are build errors. Included files may not carry frontmatter but may declare their own `section`/`time` markers. Watch mode rebuilds when any included file changes.
+  Deck-relative paths only, nested up to 64 levels, cycles/absolute/`..`-escape are build errors. Included files may not carry frontmatter or end inside an unclosed code fence or HTML block, which would swallow the following slide, but may declare their own `section`/`time` markers. Watch mode rebuilds when any included file changes.
 
 ### Speaker notes
 

--- a/crates/peitho-core/src/include.rs
+++ b/crates/peitho-core/src/include.rs
@@ -3,6 +3,7 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
+use pulldown_cmark::{Event, Parser, Tag};
 use serde_json::Value;
 
 use crate::{
@@ -39,29 +40,22 @@ impl LineMap {
         }
 
         let mut output_line = 0usize;
-        let mut previous = None;
-        for origin in &self.origins {
-            if origin.original_line == 0 {
-                if output_line + 1 == line && previous.is_none() {
-                    return (origin.file.clone(), 1);
+        for (index, origin) in self.origins.iter().enumerate() {
+            match origin.kind {
+                LineOriginKind::Source { line: source_line } => {
+                    output_line += 1;
+                    if output_line == line {
+                        return (origin.file.clone(), source_line);
+                    }
                 }
-                continue;
+                LineOriginKind::SyntheticLine => {
+                    output_line += 1;
+                    if output_line == line {
+                        return self.translate_synthetic_origin(index);
+                    }
+                }
+                LineOriginKind::SyntheticTerminator => {}
             }
-
-            output_line += 1;
-            if output_line == line {
-                return (origin.file.clone(), origin.original_line);
-            }
-            previous = Some(origin);
-        }
-
-        let index = line - 1;
-        if self
-            .origins
-            .get(index)
-            .is_some_and(|origin| origin.original_line == 0)
-        {
-            return self.translate_synthetic_origin(index);
         }
 
         (PathBuf::new(), line)
@@ -78,8 +72,10 @@ impl LineMap {
             .unwrap_or_default()
             .iter()
             .rev()
-            .find(|origin| origin.original_line != 0)
-            .map(|origin| (origin.file.clone(), origin.original_line))
+            .find_map(|origin| match origin.kind {
+                LineOriginKind::Source { line } => Some((origin.file.clone(), line)),
+                LineOriginKind::SyntheticTerminator | LineOriginKind::SyntheticLine => None,
+            })
             .unwrap_or_else(|| (synthetic.file.clone(), 1))
     }
 
@@ -88,7 +84,7 @@ impl LineMap {
             origins: (1..=line_count(source))
                 .map(|line| LineOrigin {
                     file: path.to_path_buf(),
-                    original_line: line,
+                    kind: LineOriginKind::Source { line },
                 })
                 .collect(),
         }
@@ -98,7 +94,14 @@ impl LineMap {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LineOrigin {
     pub file: PathBuf,
-    pub original_line: usize,
+    pub kind: LineOriginKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineOriginKind {
+    Source { line: usize },
+    SyntheticTerminator,
+    SyntheticLine,
 }
 
 pub fn expand_includes(
@@ -168,6 +171,8 @@ fn expand_includes_for_source(
         if let Some(line) = crate::parser::detect_frontmatter_present(&included_source) {
             return Err(included_frontmatter_error(line).with_origin_file(&include_path));
         }
+        validate_included_source_boundary(&included_source)
+            .map_err(|err| err.with_origin_file(&include_path))?;
         stack.push(include_key);
         let expanded =
             expand_includes_for_source(&included_source, 0, &include_path, deck_root, stack)?;
@@ -182,7 +187,7 @@ fn expand_includes_for_source(
         );
         source.push_str(&expanded.source);
         origins.extend(expanded.line_map.origins);
-        append_separator_boundary_newline_if_needed(
+        append_separator_boundary_blank_line_if_needed(
             &mut source,
             &mut origins,
             source_input,
@@ -278,37 +283,55 @@ fn append_region_leading_newline_if_needed(
         return;
     }
     if source[region_start..].starts_with('\n') {
-        output.push('\n');
-        origins.push(synthetic_boundary_origin(current_path));
+        append_synthetic_boundary_newline(output, origins, current_path);
     }
 }
 
-fn append_separator_boundary_newline_if_needed(
+fn append_separator_boundary_blank_line_if_needed(
     output: &mut String,
     origins: &mut Vec<LineOrigin>,
     source: &str,
     next: usize,
     current_path: &Path,
 ) {
-    if output.is_empty() || output.ends_with('\n') {
-        return;
-    }
     let next_line = source[next..]
         .split_inclusive('\n')
         .next()
         .unwrap_or_default()
         .trim_end_matches('\n')
         .trim_end_matches('\r');
-    if is_slide_separator(next_line) {
-        output.push('\n');
-        origins.push(synthetic_boundary_origin(current_path));
+    if !is_slide_separator(next_line) {
+        return;
+    }
+    while !ends_with_blank_line(output) {
+        append_synthetic_boundary_newline(output, origins, current_path);
     }
 }
 
-fn synthetic_boundary_origin(current_path: &Path) -> LineOrigin {
+fn append_synthetic_boundary_newline(
+    output: &mut String,
+    origins: &mut Vec<LineOrigin>,
+    current_path: &Path,
+) {
+    let kind = if output.ends_with('\n') {
+        LineOriginKind::SyntheticLine
+    } else {
+        LineOriginKind::SyntheticTerminator
+    };
+    output.push('\n');
+    origins.push(synthetic_boundary_origin(current_path, kind));
+}
+
+fn ends_with_blank_line(source: &str) -> bool {
+    source
+        .strip_suffix('\n')
+        .is_some_and(|source| source.trim_end_matches('\r').ends_with('\n'))
+}
+
+fn synthetic_boundary_origin(current_path: &Path, kind: LineOriginKind) -> LineOrigin {
     LineOrigin {
         file: current_path.to_path_buf(),
-        original_line: 0,
+        kind,
     }
 }
 
@@ -632,6 +655,63 @@ fn included_frontmatter_error(line: usize) -> BuildError {
     )
 }
 
+fn validate_included_source_boundary(source: &str) -> Result<()> {
+    const PROBE_PARAGRAPH: &str = "peitho include boundary probe";
+
+    let source_end = source.len();
+    let mut probe = String::with_capacity(source_end + PROBE_PARAGRAPH.len() + 7);
+    probe.push_str(source);
+    probe.push_str("\n\n---\n");
+    probe.push_str(PROBE_PARAGRAPH);
+
+    let mut spanning_event = None;
+    for (event, range) in
+        Parser::new_ext(&probe, crate::parser::slide_split_options()).into_offset_iter()
+    {
+        if matches!(&event, Event::Rule) && range.start >= source_end {
+            return Ok(());
+        }
+        if spanning_event.is_none() && range.start < source_end && range.end > source_end {
+            spanning_event = Some((event, range.start));
+        }
+    }
+
+    let Some((event, opening_offset)) = spanning_event else {
+        let line = crate::parser::line_for_offset(source, source_end.saturating_sub(1));
+        return Err(included_unclosed_construct_error(
+            line,
+            "parser event boundary",
+        ));
+    };
+    let line = crate::parser::line_for_offset(source, opening_offset);
+    let construct = match event {
+        Event::Start(Tag::CodeBlock(_)) => "code fence".to_owned(),
+        Event::Start(Tag::HtmlBlock) | Event::Html(_) => "HTML block".to_owned(),
+        Event::Start(tag) => format!("Markdown construct ({tag:?})"),
+        Event::End(tag) => format!("Markdown construct (End({tag:?}))"),
+        Event::Text(_) => "Markdown construct (Text)".to_owned(),
+        Event::Code(_) => "Markdown construct (Code)".to_owned(),
+        Event::InlineMath(_) => "Markdown construct (InlineMath)".to_owned(),
+        Event::DisplayMath(_) => "Markdown construct (DisplayMath)".to_owned(),
+        Event::InlineHtml(_) => "Markdown construct (InlineHtml)".to_owned(),
+        Event::FootnoteReference(_) => "Markdown construct (FootnoteReference)".to_owned(),
+        Event::SoftBreak => "Markdown construct (SoftBreak)".to_owned(),
+        Event::HardBreak => "Markdown construct (HardBreak)".to_owned(),
+        Event::Rule => "Markdown construct (Rule)".to_owned(),
+        Event::TaskListMarker(_) => "Markdown construct (TaskListMarker)".to_owned(),
+    };
+    Err(included_unclosed_construct_error(line, &construct))
+}
+
+fn included_unclosed_construct_error(line: usize, construct: &str) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        Some(line),
+        format!("included file ends inside an unclosed {construct}"),
+        "close it before the end of the included file",
+    )
+}
+
 fn append_chunk(
     output: &mut String,
     origins: &mut Vec<LineOrigin>,
@@ -648,7 +728,9 @@ fn append_chunk(
     output.push_str(chunk);
     origins.extend((0..line_count(chunk)).map(|index| LineOrigin {
         file: path.to_path_buf(),
-        original_line: first_line + index,
+        kind: LineOriginKind::Source {
+            line: first_line + index,
+        },
     }));
 }
 
@@ -991,7 +1073,7 @@ mod tests {
 
         assert_eq!(
             expanded.source,
-            "# Before\n\n---\n# Included One\n\n---\n<!-- {\"section\":\"Shared\",\"time\":\"1m\"} -->\n# Included Two\n---\n# After\n"
+            "# Before\n\n---\n# Included One\n\n---\n<!-- {\"section\":\"Shared\",\"time\":\"1m\"} -->\n# Included Two\n\n---\n# After\n"
         );
         assert_eq!(
             expanded.line_map.translate(4),
@@ -1001,7 +1083,209 @@ mod tests {
     }
 
     #[test]
-    fn include_without_trailing_newline_keeps_following_separator_on_new_line() {
+    fn include_ending_in_paragraph_keeps_following_slide() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included\n\nIncluded paragraph\n",
+        )
+        .unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 3);
+        assert_eq!(parsed.parsed_slides()[2].fragments[0].markdown(), "# After");
+    }
+
+    #[test]
+    fn include_ending_in_list_keeps_following_slide() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included\n\n- Included item\n",
+        )
+        .unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 3);
+        assert_eq!(parsed.parsed_slides()[2].fragments[0].markdown(), "# After");
+    }
+
+    #[test]
+    fn include_ending_in_closed_fence_keeps_following_slide() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included\n\n```\nincluded code\n```\n",
+        )
+        .unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 3);
+        assert_eq!(parsed.parsed_slides()[2].fragments[0].markdown(), "# After");
+    }
+
+    #[test]
+    fn line_map_after_include_maps_following_slide_error_to_deck_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included\n\nIncluded paragraph\n",
+        )
+        .unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n\n> unsupported\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let err = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+        let (origin_file, original_line) = expanded.line_map.translate(err.line.unwrap());
+
+        assert_eq!(origin_file, deck);
+        assert_eq!(original_line, 5);
+    }
+
+    #[test]
+    fn unclosed_fence_in_included_file_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let included = dir.path().join("shared.md");
+        fs::write(&included, "# Included\n\n```rust\nfn included() {}\n").unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(3));
+        assert_eq!(err.origin_file, Some(included));
+        assert_eq!(
+            err.message,
+            "included file ends inside an unclosed code fence"
+        );
+        assert_eq!(err.help, "close it before the end of the included file");
+    }
+
+    #[test]
+    fn unclosed_html_comment_in_included_file_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let included = dir.path().join("shared.md");
+        fs::write(&included, "# Included\n\n<!-- oops\n").unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(3));
+        assert_eq!(err.origin_file, Some(included));
+        assert_eq!(
+            err.message,
+            "included file ends inside an unclosed HTML block"
+        );
+        assert_eq!(err.help, "close it before the end of the included file");
+    }
+
+    #[test]
+    fn four_space_indented_backticks_do_not_open_a_fence() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included\n\n    ```\n\nIncluded paragraph\n",
+        )
+        .unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 3);
+        assert_eq!(parsed.parsed_slides()[2].fragments[0].markdown(), "# After");
+    }
+
+    #[test]
+    fn backticks_inside_closed_html_comment_do_not_open_a_fence() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        fs::write(
+            dir.path().join("shared.md"),
+            "# Included\n\n<!--\n```\n-->\n\nIncluded paragraph\n",
+        )
+        .unwrap();
+        let source = "# Before\n\n---\n<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n";
+
+        let expanded = expand_includes(source, 0, &deck).unwrap();
+        let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();
+        let parsed = crate::parser::parse_markdown(
+            &expanded.source,
+            frontmatter,
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.parsed_slides().len(), 3);
+        assert_eq!(parsed.parsed_slides()[2].fragments[0].markdown(), "# After");
+    }
+
+    #[test]
+    fn unclosed_cdata_in_included_file_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let deck = dir.path().join("deck.md");
+        let included = dir.path().join("shared.md");
+        fs::write(&included, "# Included\n\n<![CDATA[\noops\n").unwrap();
+        let source = "<!-- {\"include\":\"shared.md\"} -->\n";
+
+        let err = expand_includes(source, 0, &deck).unwrap_err();
+
+        assert_eq!(err.line, Some(3));
+        assert_eq!(err.origin_file, Some(included));
+        assert_eq!(
+            err.message,
+            "included file ends inside an unclosed HTML block"
+        );
+        assert_eq!(err.help, "close it before the end of the included file");
+    }
+
+    #[test]
+    fn include_without_trailing_newline_keeps_blank_line_before_following_separator() {
         let dir = tempfile::tempdir().unwrap();
         let deck = dir.path().join("deck.md");
         fs::write(dir.path().join("shared.md"), "# Included").unwrap();
@@ -1011,9 +1295,9 @@ mod tests {
 
         assert_eq!(
             expanded.source,
-            "# Before\n\n---\n# Included\n---\n# After\n"
+            "# Before\n\n---\n# Included\n\n---\n# After\n"
         );
-        assert_eq!(expanded.line_map.translate(6), (deck, 6));
+        assert_eq!(expanded.line_map.translate(7), (deck, 6));
     }
 
     #[test]
@@ -1031,11 +1315,9 @@ mod tests {
             expanded.line_map.translate(4),
             (dir.path().join("shared.md"), 1)
         );
-        assert!(expanded
-            .line_map
-            .origins
-            .iter()
-            .any(|origin| origin.file == deck && origin.original_line == 0));
+        assert!(expanded.line_map.origins.iter().any(|origin| {
+            origin.file == deck && origin.kind == LineOriginKind::SyntheticTerminator
+        }));
     }
 
     #[test]

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -2895,7 +2895,7 @@ fn parser_options() -> Options {
         | Options::ENABLE_YAML_STYLE_METADATA_BLOCKS
 }
 
-fn slide_split_options() -> Options {
+pub(crate) fn slide_split_options() -> Options {
     Options::ENABLE_TABLES | Options::ENABLE_OLD_FOOTNOTES
 }
 

--- a/docs/plans/2026-08-16-include-boundary-blank-line.md
+++ b/docs/plans/2026-08-16-include-boundary-blank-line.md
@@ -1,0 +1,112 @@
+# Include boundary: make the splice seam construct-proof (Issue #421)
+
+Date: 2026-08-16
+Issue: #421 — Slide following an include is silently merged into the include's last slide
+
+## Problem
+
+Include expansion is a textual splice performed before pulldown-cmark runs
+(`expand_includes_for_source`, `crates/peitho-core/src/include.rs`). The
+boundary guards (`append_region_leading_newline_if_needed`,
+`append_separator_boundary_newline_if_needed`) only guarantee the output ends
+with a single `\n` before the deck's following separator line is copied back
+in. When the included file ends in a paragraph, the spliced text is:
+
+```
+Included slide B
+---
+# Slide After Include
+```
+
+In CommonMark a `---` directly under a paragraph is a **setext H2 underline**,
+not a thematic break, so `split_slide_ranges` never sees an `Event::Rule` and
+the two slides silently fuse — the reported bug.
+
+Every existing include test uses an included file whose last line is an ATX
+heading (where the following `---` *is* a thematic break), which is why the
+seam was never exercised.
+
+## Root cause framing
+
+The invariant that broke: **the include splice must not let the included
+file's trailing parse state change the meaning of the deck text that follows
+the include region.** Two constructs can leak across the seam:
+
+1. **Trailing paragraph → setext underline.** The deck's own separator line is
+   reinterpreted as part of the included content (the reported bug).
+2. **Unclosed code fence in the included file.** After the splice, the open
+   fence swallows the deck's separator *and everything after it* into a code
+   block — same class, worse blast radius.
+
+Both are fixed at the single splice seam; no downstream phase changes.
+
+## Fix
+
+### 1. Blank-line normalization before a following separator
+
+Extend `append_separator_boundary_newline_if_needed` so that when the text at
+`region.end` starts with a slide separator line, the output is guaranteed to
+end with a **blank line** (`\n\n`), not merely a newline. Each synthetic `\n`
+pushes a `synthetic_boundary_origin` (original_line == 0) exactly like the
+existing single-newline guard, so `LineMap::translate` needs no changes.
+
+This is unconditional normalization — no classification of "risky" trailing
+constructs. A blank line before a thematic break is semantically inert for
+every construct that can legally end an included file (paragraph, heading,
+list, closed fence, blockquote-free peitho subset), so heading-ending includes
+keep building the same slides; only the intermediate expanded source gains one
+synthetic line.
+
+### 2. Included files that end inside an unclosed block are build errors
+
+(Revised 2026-08-16 after adversarial review; the first cut was a hand-rolled
+`opening_code_fence` / `is_closing_code_fence` scan, which false-positived on
+4-space-indented ``` lines and on ``` inside closed HTML comments, and missed
+the sibling leak entirely: an included file ending with an unterminated
+`<!--` swallows the following slides through CommonMark HTML block type 2 —
+measured, silent. `<?`, `<!`, and `<![CDATA[` leak the same way.)
+
+The shipped gate is `validate_included_source_boundary`: append a sentinel
+(`\n\n---\n` + a probe paragraph) to the included file's raw source and parse
+the whole thing with pulldown-cmark under `slide_split_options()` (made
+`pub(crate)` so the probe and the real splitter share one grammar). If an
+`Event::Rule` starts at or after the original source end, the file ends at a
+clean block boundary. Otherwise the first event spanning the boundary names
+the construct (code fence vs HTML block, exhaustively matched — no silent
+arm) and its opening line, and the build fails with
+`with_origin_file(&include_path)` plus help to close it. Because the real
+grammar does the classification there are no false positives by
+construction, and every construct blank lines cannot terminate (fences, HTML
+blocks types 2–5) is covered by one total check. The gate runs per included
+file at every recursion depth, on the raw on-disk source.
+
+A standalone deck with an unclosed fence at EOF stays legal (pulldown-cmark
+closes it at EOF; nothing follows) — only the include path creates the leak,
+so only the include path gets the check.
+
+## Tests (TDD order)
+
+1. `include_ending_in_paragraph_keeps_following_slide` — deck with
+   `include → separator → # After` where the included file ends in a
+   paragraph; assert the parsed deck has all slides and `# After` is its own
+   slide (this is the reproduction from #421; fails before the fix).
+2. `include_ending_in_list_keeps_following_slide` — same shape, included file
+   ends in a list item.
+3. `include_ending_in_closed_fence_keeps_following_slide` — same shape,
+   included file ends with a properly closed code fence.
+4. Line-map regression: an error in the slide *after* the include still
+   reports the deck file + correct source line (the synthetic blank line must
+   not shift attribution).
+5. `unclosed_fence_in_included_file_is_error` — included file with an
+   unterminated ``` fence; assert error names the included file, the opening
+   fence line, and carries help.
+6. Existing include tests stay green (they assert parsed slides, not raw
+   expanded bytes; update any that assert exact expanded source).
+
+## Non-goals
+
+- No change to slide splitting (`split_slide_ranges`) or the two-grammar
+  frontmatter/split setup.
+- No attempt to support included files that *intentionally* end mid-construct;
+  the included file must be a self-contained sequence of slides (matches the
+  #330 design).

--- a/site/content/guide/writing-decks.md
+++ b/site/content/guide/writing-decks.md
@@ -324,6 +324,8 @@ frontmatter — the top-level deck is the sole source of deck-wide settings.
 Paths are resolved relative to the including file and must stay under the
 top-level deck's directory. Absolute paths, `..` escapes, missing targets,
 cycles, chains exceeding 64 nested includes, empty included files, and any
-of the above malformed shapes are all line-numbered build errors. Watch
-mode observes the entire include tree, so edits to any included file
-trigger a rebuild.
+of the above malformed shapes are all line-numbered build errors. Files that
+end inside an unclosed code fence or HTML block are also rejected because the
+unterminated block would otherwise swallow the following slide. Watch mode
+observes the entire include tree, so edits to any included file trigger a
+rebuild.


### PR DESCRIPTION
Closes #421

## What

Reported from real-world deck writing (v1.22.1): the slide following an include silently disappeared — merged into the include's last slide with no error, no trace. Reproduced, root-caused, and fixed at the single splice seam.

## Root cause

Include expansion is a textual splice. When the included file ends in a paragraph, the spliced text puts the deck's `---` separator directly under that paragraph — CommonMark reads that as a **setext H2 underline**, not a thematic break, so `split_slide_ranges` never sees the boundary and the two slides fuse. Every prior include test ended its included file with a heading (where `---` *is* a thematic break), which is why the seam was never exercised.

## Fix

- **Blank-line normalization**: the output before a following separator is guaranteed to end with a blank line. Synthetic newlines ride a typed `LineOriginKind` (`Source`/`SyntheticTerminator`/`SyntheticLine`) — the zero-sentinel and any parallel index bookkeeping are unrepresentable now — and error line attribution across the seam is regression-tested.
- **Total boundary gate**: an included file ending inside a block that blank lines cannot close (unclosed fence, unclosed HTML block — comments, `<![CDATA[`, …) is a line-numbered build error naming the construct, its opening line, and the included file. Detection is a pulldown-cmark **sentinel probe** (append `\n\n---\n` + probe paragraph, require an `Event::Rule` past the source end) sharing `slide_split_options()` with the real splitter — the real grammar classifies, so 4-space-indented ``` lines and fences inside closed comments cannot false-positive (both were confirmed false positives of the first-cut hand scanner, caught in adversarial review and covered by regression tests).

## Verification

- E2E with the built binary: the original repro builds 5 slides (main: 4 with silent merge). Error output verified via CLI (file/line point at the included file's opening construct).
- Adversarial review probed ~35 boundary shapes (reference defs, footnote defs at EOF, tables, lists, setext, lazy continuation, CRLF …) plus an old-vs-new `LineMap` algorithm comparison — no discrepancies.
- `cargo test --workspace` ×3 green, clippy `-D warnings`, fmt, bindings/dist drift, npm gates all green.

Docs: README include bullet + guide error enumeration extended with the new rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV