### PR TITLE
Represent empty slots as data-empty-slots on the slide root

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,14 @@ Point `layouts:` in the deck's frontmatter at an HTML file or a directory of `*.
 2. **Single layout, unconditional** — if there is only one layout, always use it (contract violations still error with line numbers, as usual)
 3. **Type-driven dispatch** — with multiple layouts, each slide is routed to the layout whose slot contract matches the shape of its content (title only / has body / has code, etc.). Exactly one match is required; **multiple matches (ambiguous) and zero matches are both build errors** rather than silently resolved, prompting an explicit choice
 
+Rendered slide roots list empty slots in `data-empty-slots`, so layout CSS can hide their wrappers without relying on whitespace-sensitive `:empty` matching:
+
+```css
+.peitho-slide[data-empty-slots~="quote"] .quote { display: none; }
+```
+
+Here, `.quote` is whatever class the layout author put on the wrapper element; `quote` in the attribute selector is the slot name, and Peitho does not tie the two together.
+
 ### Syntax highlighting
 
 Code blocks with a language tag are turned into `hl-*` class spans by [syntect](https://github.com/trishume/syntect) at build time. There is no runtime JS; colors are defined in theme CSS. An unknown language tag is a build error with a line number (no tag means plain rendering).

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -171,12 +171,26 @@ fn render_slide(
     let page_number_value = attrs.page_number.map(|number| number.to_string());
     let page_total_value = attrs.page_total.map(|total| total.to_string());
     let reveal_steps_value = (attrs.reveal_steps > 0).then(|| attrs.reveal_steps.to_string());
+    let empty_slot_names = layout
+        .slots()
+        .keys()
+        .filter(|name| {
+            slots
+                .get(*name)
+                .is_none_or(|slot| slot.fragments().is_empty())
+        })
+        .map(SlotName::as_str)
+        .collect::<Vec<_>>();
+    let empty_slots_value = (!empty_slot_names.is_empty()).then(|| empty_slot_names.join(" "));
     let slot_values = slots.clone();
     let mut rewriter = HtmlRewriter::new(
         Settings {
             element_content_handlers: vec![
                 element!("section", move |el| {
                     el.set_attribute("data-slide-key", &key_value)?;
+                    if let Some(empty_slots) = &empty_slots_value {
+                        el.set_attribute("data-empty-slots", empty_slots)?;
+                    }
                     if let Some(number) = &page_number_value {
                         el.set_attribute("data-peitho-page-number", number)?;
                     }
@@ -2822,6 +2836,10 @@ mod tests {
         assert!(!html.contains("peitho-footnotes"), "{html}");
         assert!(!html.contains("peitho-footnote-ref"), "{html}");
         assert!(
+            html.contains(r#"data-empty-slots="code footnotes""#),
+            "{html}"
+        );
+        assert!(
             html.contains(r#"<footer class="footnotes"></footer>"#),
             "{html}"
         );
@@ -2850,6 +2868,7 @@ mod tests {
         assert!(!body_region.contains("peitho-footnotes"), "{html}");
         assert!(html.contains(r#"<pre class="slot-code"><code>"#), "{html}");
         assert!(html.contains(r#"<li><p>Supporting note.</p>"#), "{html}");
+        assert!(!html.contains("data-empty-slots"), "{html}");
     }
 
     #[test]
@@ -3286,6 +3305,7 @@ mod tests {
             r#"<section data-slide-key="intro" class="peitho-slide"><h1><span class="slot-title">Intro</span></h1><div class="slot-body"><p>Body</p>
 </div></section>"#
         );
+        assert!(!plain.slides()[0].html().contains("data-empty-slots"));
         assert_eq!(plain.css(), theme_css);
         assert_eq!(
             math.slides()[0].html(),
@@ -3328,6 +3348,48 @@ mod tests {
 
         assert!(html.contains(r#"<figure class="code"></figure>"#));
         assert!(!html.contains(r#"class="slot-code""#));
+    }
+
+    #[test]
+    fn renders_one_empty_slot_on_slide_root() {
+        let rendered = render_checked_deck_with_layout(
+            "<!-- {\"key\":\"empty-quote\"} -->\n# Architecture",
+            title_quote_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains(r#"data-empty-slots="quote""#), "{html}");
+        assert!(!html.contains(r#"data-empty-slots="title""#), "{html}");
+    }
+
+    #[test]
+    fn renders_all_empty_slots_on_slide_root() {
+        let layout = parse_layout(
+            "title-quote-aside",
+            r#"<section>
+  <h1><slot name="title" accepts="inline" arity="1"></slot></h1>
+  <blockquote><slot name="quote" accepts="blocks" arity="0..1"></slot></blockquote>
+  <aside><slot name="aside" accepts="blocks" arity="0..1"></slot></aside>
+</section>"#,
+        )
+        .unwrap();
+
+        let rendered = render_checked_deck_with_layout("# Architecture", layout);
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains(r#"data-empty-slots="aside quote""#), "{html}");
+    }
+
+    #[test]
+    fn empty_slot_state_preserves_slide_key_and_class_stamping() {
+        let rendered = render_checked_deck_with_layout(
+            "<!-- {\"key\":\"arch-1\"} -->\n# Architecture",
+            title_quote_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains(r#"data-slide-key="arch-1""#), "{html}");
+        assert!(html.contains(r#"class="feature peitho-slide""#), "{html}");
     }
 
     #[test]
@@ -4634,6 +4696,17 @@ Paragraph after heading.
         parse_layout(
             "title-body",
             r#"<section><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot></section>"#,
+        )
+        .unwrap()
+    }
+
+    fn title_quote_layout() -> Layout {
+        parse_layout(
+            "title-quote",
+            r#"<section class="feature">
+  <h1><slot name="title" accepts="inline" arity="1"></slot></h1>
+  <blockquote class="quote"><slot name="quote" accepts="blocks" arity="0..1"></slot></blockquote>
+</section>"#,
         )
         .unwrap()
     }

--- a/crates/peitho-core/src/theme.rs
+++ b/crates/peitho-core/src/theme.rs
@@ -62,6 +62,9 @@ const PEITHO_SLIDE_CLASS: &str = "peitho-slide";
 /// - a bare `.slot-*` class must exist in some provided layout
 ///   (`layout_slots`), which catches typos without breaking themes shared
 ///   across decks that use only a subset of the layouts
+/// - a slot name in `[data-empty-slots~=...]` follows the same scope as a
+///   `.slot-*` class: the addressed slide's layout when keyed, otherwise the
+///   union of provided layouts
 /// - bare root layout classes must not set `width` or `height` differently
 ///   from `.peitho-slide`, which owns the slide root's canvas sizing
 /// - everything else is unrestricted theme CSS
@@ -755,6 +758,41 @@ fn validate_override_selectors(
                 ));
             }
         }
+        for slot_selector in extract_empty_slot_values(selector, line_no)? {
+            let slot_name = &slot_selector.name;
+            let known = scope
+                .iter()
+                .filter_map(|slot| slot.strip_prefix("slot-"))
+                .any(|known_name| {
+                    if slot_selector.ascii_case_insensitive {
+                        known_name.eq_ignore_ascii_case(slot_name)
+                    } else {
+                        known_name == slot_name
+                    }
+                });
+            if !known {
+                let context = if keys.is_empty() {
+                    String::new()
+                } else {
+                    format!(" for slide '{}'", keys.join("', '"))
+                };
+                return Err(BuildError::new(
+                    ErrorKind::Theme,
+                    Some(line_no),
+                    format!(
+                        "unknown slot name '{slot_name}' in data-empty-slots selector{context}"
+                    ),
+                    format!(
+                        "use one of: {}",
+                        scope
+                            .iter()
+                            .filter_map(|slot| slot.strip_prefix("slot-"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ),
+                ));
+            }
+        }
     }
 
     Ok(())
@@ -774,13 +812,152 @@ fn extract_slot_classes(selector: &str) -> Vec<String> {
 }
 
 fn extract_slide_key_values(selector: &str, line_no: usize) -> Result<Vec<String>> {
-    const ATTR: &str = "[data-slide-key";
+    extract_attribute_values(
+        selector,
+        "[data-slide-key",
+        line_no,
+        malformed_slide_key_selector,
+    )
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct EmptySlotSelectorValue {
+    name: String,
+    ascii_case_insensitive: bool,
+}
+
+fn extract_empty_slot_values(
+    selector: &str,
+    line_no: usize,
+) -> Result<Vec<EmptySlotSelectorValue>> {
+    const ATTRIBUTE: &str = "[data-empty-slots";
+
     let mut values = Vec::new();
     let mut offset = 0;
 
-    while let Some(relative_start) = selector[offset..].find(ATTR) {
+    while let Some(relative_start) = selector[offset..].find(ATTRIBUTE) {
         let attr_start = offset + relative_start;
-        let after_name_start = attr_start + ATTR.len();
+        let after_name_start = attr_start + ATTRIBUTE.len();
+        let after_name = &selector[after_name_start..];
+        let Some(close_relative) = after_name.find(']') else {
+            return Err(malformed_empty_slots_selector(line_no));
+        };
+        let close_index = after_name_start + close_relative;
+        let body = selector[after_name_start..close_index].trim_start();
+
+        if body.starts_with('-')
+            || body
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphanumeric())
+        {
+            offset = after_name_start;
+            continue;
+        }
+
+        if body.trim().is_empty() {
+            offset = close_index + 1;
+            continue;
+        }
+
+        let Some(value_part) = body.strip_prefix("~=") else {
+            return Err(malformed_empty_slots_selector(line_no));
+        };
+        values.push(parse_empty_slot_value(value_part, line_no)?);
+        offset = close_index + 1;
+    }
+
+    Ok(values)
+}
+
+fn parse_empty_slot_value(value_part: &str, line_no: usize) -> Result<EmptySlotSelectorValue> {
+    let value_part = value_part.trim_start();
+    if value_part.is_empty() {
+        return Err(malformed_empty_slots_selector(line_no));
+    }
+
+    let (name, trailing) = match value_part.chars().next() {
+        Some(quote @ ('"' | '\'')) => {
+            let rest = &value_part[quote.len_utf8()..];
+            let Some(end) = find_unescaped_quote(rest, quote) else {
+                return Err(malformed_empty_slots_selector(line_no));
+            };
+            (rest[..end].to_owned(), &rest[end + quote.len_utf8()..])
+        }
+        Some(_) => {
+            let end = value_part
+                .find(char::is_whitespace)
+                .unwrap_or(value_part.len());
+            let name = &value_part[..end];
+            if !is_unquoted_css_ident(name) {
+                return Err(malformed_empty_slots_selector(line_no));
+            }
+            (name.to_owned(), &value_part[end..])
+        }
+        None => return Err(malformed_empty_slots_selector(line_no)),
+    };
+
+    let trimmed_trailing = trailing.trim();
+    let ascii_case_insensitive = if trimmed_trailing.is_empty() {
+        false
+    } else {
+        if !trailing.chars().next().is_some_and(char::is_whitespace) {
+            return Err(malformed_empty_slots_selector(line_no));
+        }
+        match trimmed_trailing {
+            "i" | "I" => true,
+            _ => return Err(malformed_empty_slots_selector(line_no)),
+        }
+    };
+
+    Ok(EmptySlotSelectorValue {
+        name,
+        ascii_case_insensitive,
+    })
+}
+
+fn find_unescaped_quote(value: &str, quote: char) -> Option<usize> {
+    let mut escaped = false;
+    for (index, ch) in value.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == quote {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn is_unquoted_css_ident(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    let valid_start = first.is_ascii_alphabetic()
+        || first == '_'
+        || (first == '-'
+            && chars
+                .clone()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_' || ch == '-'));
+
+    valid_start && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+fn extract_attribute_values(
+    selector: &str,
+    attribute: &str,
+    line_no: usize,
+    malformed_selector: fn(usize) -> BuildError,
+) -> Result<Vec<String>> {
+    let mut values = Vec::new();
+    let mut offset = 0;
+
+    while let Some(relative_start) = selector[offset..].find(attribute) {
+        let attr_start = offset + relative_start;
+        let after_name_start = attr_start + attribute.len();
         let after_name = &selector[after_name_start..];
         let Some(close_relative) = after_name.find(']') else {
             return Err(malformed_selector(line_no));
@@ -800,14 +977,14 @@ fn extract_slide_key_values(selector: &str, line_no: usize) -> Result<Vec<String
         }
 
         let Some(value_part) = strip_attr_operator(body) else {
-            if body.trim() == "]" || body.trim().is_empty() {
+            if body.trim().is_empty() {
                 offset = close_index + 1;
                 continue;
             }
             return Err(malformed_selector(line_no));
         };
 
-        let value = parse_attr_value(value_part, line_no)?;
+        let value = parse_attr_value(value_part, line_no, malformed_selector)?;
         values.push(value);
         offset = close_index + 1;
     }
@@ -825,7 +1002,11 @@ fn strip_attr_operator(body: &str) -> Option<&str> {
     None
 }
 
-fn parse_attr_value(value_part: &str, line_no: usize) -> Result<String> {
+fn parse_attr_value(
+    value_part: &str,
+    line_no: usize,
+    malformed_selector: fn(usize) -> BuildError,
+) -> Result<String> {
     let value_part = value_part.trim_start();
     if value_part.is_empty() {
         return Err(malformed_selector(line_no));
@@ -852,12 +1033,21 @@ fn parse_attr_value(value_part: &str, line_no: usize) -> Result<String> {
     }
 }
 
-fn malformed_selector(line_no: usize) -> BuildError {
+fn malformed_slide_key_selector(line_no: usize) -> BuildError {
     BuildError::new(
         ErrorKind::Theme,
         Some(line_no),
         "malformed selector for data-slide-key",
         r#"write selectors like [data-slide-key="arch-1"] .slot-code"#,
+    )
+}
+
+fn malformed_empty_slots_selector(line_no: usize) -> BuildError {
+    BuildError::new(
+        ErrorKind::Theme,
+        Some(line_no),
+        "malformed selector for data-empty-slots",
+        r#"use '~=' (token match) because data-empty-slots holds a space-separated list; write selectors like [data-empty-slots~="quote"] .quote"#,
     )
 }
 
@@ -1086,6 +1276,146 @@ mod tests {
         assert_eq!(err.line, Some(1));
         assert!(err.to_string().contains("unknown slot class '.slot-code'"));
         assert_eq!(err.help, "use one of: .slot-title");
+    }
+
+    #[test]
+    fn rejects_unknown_slot_name_in_data_empty_slots_selector() {
+        let err = build(
+            "",
+            ".quote { display: block; }\n[data-empty-slots~=\"qoute\"] .quote { display: none; }",
+            &slots(&[("arch-1", &["slot-title", "slot-quote"])]),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Theme);
+        assert_eq!(err.line, Some(2));
+        assert!(err
+            .to_string()
+            .contains("unknown slot name 'qoute' in data-empty-slots selector"));
+        assert_eq!(err.help, "use one of: quote, title");
+    }
+
+    #[test]
+    fn accepts_known_slot_name_in_data_empty_slots_selector() {
+        let slide_slots = slots(&[("cover", &["slot-title"])]);
+        let layout_slots = ["slot-title", "slot-quote"]
+            .iter()
+            .map(|class| (*class).to_owned())
+            .collect();
+        let css = build_theme_css(
+            &[CssFile {
+                name: "base.css".to_owned(),
+                content: r#"[data-empty-slots~="quote"] .quote { display: none; }"#.to_owned(),
+            }],
+            &slide_slots,
+            &layout_slots,
+            &BTreeSet::new(),
+        )
+        .unwrap();
+
+        assert!(css.contains(r#"[data-empty-slots~="quote"] .quote"#));
+    }
+
+    fn assert_rejects_data_empty_slots_operator(operator: &str, value: &str) {
+        let err = build(
+            "",
+            &format!("\n[data-empty-slots{operator}=\"{value}\"] .quote {{ display: none; }}"),
+            &slots(&[("arch-1", &["slot-title", "slot-quote"])]),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Theme);
+        assert_eq!(err.line, Some(2));
+        assert!(
+            err.to_string()
+                .contains("malformed selector for data-empty-slots"),
+            "{err}"
+        );
+        assert!(err.help.contains("use '~=' (token match)"), "{err}");
+        assert!(err.help.contains("space-separated list"), "{err}");
+    }
+
+    #[test]
+    fn rejects_equals_operator_for_data_empty_slots_selector() {
+        assert_rejects_data_empty_slots_operator("", "quote");
+    }
+
+    #[test]
+    fn rejects_dash_match_operator_for_data_empty_slots_selector() {
+        assert_rejects_data_empty_slots_operator("|", "quote");
+    }
+
+    #[test]
+    fn rejects_prefix_operator_for_data_empty_slots_selector() {
+        assert_rejects_data_empty_slots_operator("^", "quote");
+    }
+
+    #[test]
+    fn rejects_suffix_operator_for_data_empty_slots_selector() {
+        assert_rejects_data_empty_slots_operator("$", "quote");
+    }
+
+    #[test]
+    fn rejects_substring_operator_for_data_empty_slots_selector() {
+        assert_rejects_data_empty_slots_operator("*", "quo");
+    }
+
+    #[test]
+    fn accepts_ascii_case_insensitive_data_empty_slots_selector() {
+        let css = build(
+            "",
+            r#"[data-empty-slots~="Quote" i] .quote { display: none; }
+[data-empty-slots~='TITLE' I] .title { display: none; }"#,
+            &slots(&[("arch-1", &["slot-title", "slot-quote"])]),
+        )
+        .unwrap();
+
+        assert!(css.contains(r#"[data-empty-slots~="Quote" i] .quote"#));
+        assert!(css.contains(r#"[data-empty-slots~='TITLE' I] .title"#));
+    }
+
+    #[test]
+    fn accepts_unquoted_ident_in_data_empty_slots_selector() {
+        let css = build(
+            "",
+            "[data-empty-slots ~= quote ] .quote { display: none; }",
+            &slots(&[("arch-1", &["slot-quote"])]),
+        )
+        .unwrap();
+
+        assert!(css.contains("[data-empty-slots ~= quote ] .quote"));
+    }
+
+    #[test]
+    fn accepts_bare_data_empty_slots_presence_selector() {
+        let css = build(
+            "",
+            "[data-empty-slots] .quote { display: none; }",
+            &slots(&[("arch-1", &["slot-quote"])]),
+        )
+        .unwrap();
+
+        assert!(css.contains("[data-empty-slots] .quote"));
+    }
+
+    #[test]
+    fn keyed_data_empty_slots_selector_uses_that_slides_layout() {
+        let deck_slots = slots(&[
+            ("walkthrough", &["slot-title", "slot-quote"]),
+            ("cover", &["slot-title"]),
+        ]);
+
+        let err = build(
+            "",
+            r#"[data-slide-key="cover"][data-empty-slots~="quote"] .quote { display: none; }"#,
+            &deck_slots,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("unknown slot name 'quote' in data-empty-slots selector for slide 'cover'"));
+        assert_eq!(err.help, "use one of: title");
     }
 
     #[test]

--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -1588,7 +1588,10 @@ fn base_theme_contains_footnote_rules() {
 
     assert!(css.contains(".footnotes"));
     assert!(css.contains("margin-top: auto;"));
-    assert!(rule_block(".footnotes:empty").contains("display: none;"));
+    assert!(
+        rule_block(r#".peitho-slide[data-empty-slots~="footnotes"] .footnotes"#)
+            .contains("display: none;")
+    );
     assert!(css.contains(".peitho-footnotes"));
     let footnote_ref = rule_block(".peitho-footnote-ref");
     assert!(footnote_ref.contains("font-size: 0.62em;"));
@@ -2103,7 +2106,7 @@ fn write_layout_dir(root: &Path, name: &str, class: &str) -> PathBuf {
     fs::write(
         dir.join("statement.html"),
         format!(
-            r#"<section class="{class}"><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot></section>"#
+            r#"<section class="{class}"><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot><footer class="footnotes"><slot name="footnotes" accepts="blocks" arity="0..1"></slot></footer></section>"#
         ),
     )
     .unwrap();

--- a/crates/peitho/tests/present.rs
+++ b/crates/peitho/tests/present.rs
@@ -1216,7 +1216,7 @@ fn write_layout_dir(root: &Path, name: &str, class: &str) -> PathBuf {
     fs::write(
         dir.join("statement.html"),
         format!(
-            r#"<section class="{class}"><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot></section>"#
+            r#"<section class="{class}"><h1><slot name="title" accepts="inline" arity="1"></slot></h1><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot><footer class="footnotes"><slot name="footnotes" accepts="blocks" arity="0..1"></slot></footer></section>"#
         ),
     )
     .unwrap();

--- a/crates/peitho/tests/tweet_embeds.rs
+++ b/crates/peitho/tests/tweet_embeds.rs
@@ -60,7 +60,7 @@ fn write_tweet_deck(path: &Path) {
     fs::create_dir_all(&layouts).unwrap();
     fs::write(
         layouts.join("title-image.html"),
-        r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot><slot name="image" accepts="image" arity="1"></slot></section>"#,
+        r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot><slot name="image" accepts="image" arity="1"></slot><slot name="footnotes" accepts="blocks" arity="0..1"></slot></section>"#,
     )
     .unwrap();
     fs::write(path, format!("# Tweet\n\n```embed\n{STATUS_URL}\n```\n")).unwrap();
@@ -71,7 +71,7 @@ fn write_embed_deck(path: &Path, blocks: &[(&str, Option<&str>)]) {
     fs::create_dir_all(&layouts).unwrap();
     fs::write(
         layouts.join("title-image.html"),
-        r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot><slot name="image" accepts="image" arity="0..*"></slot></section>"#,
+        r#"<section><slot name="title" accepts="inline" arity="1"></slot><slot name="body" accepts="blocks" arity="0..*"></slot><slot name="code" accepts="code" arity="0..1"></slot><slot name="image" accepts="image" arity="0..*"></slot><slot name="footnotes" accepts="blocks" arity="0..1"></slot></section>"#,
     )
     .unwrap();
     let mut markdown = "# Tweet\n\n".to_owned();

--- a/docs/plans/2026-08-16-empty-slot-state.md
+++ b/docs/plans/2026-08-16-empty-slot-state.md
@@ -1,0 +1,76 @@
+# Represent empty slots on the rendered slide (Issue #423)
+
+Date: 2026-08-16
+Issue: #423 — empty slots leave layout whitespace in wrapper elements, so `:empty` styling silently fails
+
+## Problem
+
+When a slot receives no fragments, `render_slot` returns an empty string and
+the `<slot>` element is removed (`crates/peitho-core/src/render.rs`). The
+layout author's wrapper element survives with the indentation whitespace that
+surrounded the slot tag, so `.wrapper:empty { display: none }` silently does
+nothing — whether `:empty` works depends on invisible layout formatting
+(base.css's `.footnotes:empty` only works because that slot happens to be
+written inline).
+
+## Decision
+
+Option 2 from the issue: make the state representable instead of inferable.
+The rendered slide root gains `data-empty-slots="<name> <name>"` listing every
+layout slot that received zero fragments, in sorted slot-name order (the
+`~=` selector is order-insensitive, so declaration order would be
+unobservable — see Changes). CSS targets the state deliberately:
+
+```css
+.peitho-slide[data-empty-slots~="quote"] .quote { display: none; }
+```
+
+All three lenses select this option: trimming adjacent whitespace (option 1)
+guesses at which parent is "the wrapper" and can eat non-slot content;
+documenting `:not(:has(.slot-*))` (option 3) leaves the silent trap in place.
+The attribute is emitted **only when at least one slot is empty**, so decks
+whose slides fill every slot build byte-identical.
+
+## Changes
+
+(Revised 2026-08-16 after adversarial review.)
+
+1. `render.rs`: before the lol_html rewrite, compute the empty-slot list from
+   the checked slots (a slot missing from the checked map counts as empty —
+   the slot element handler still hard-errors on that unreachable state, so
+   the two consumers of the invariant agree). Order is the sorted slot-map
+   order: the `~=` attribute selector is order-insensitive, so declaration
+   order is unobservable and not worth a parallel `Vec<SlotName>` shadowing
+   the map (rejected: parallel state with an unguarded sync invariant). In
+   the existing slide-root element handler, set `data-empty-slots` when the
+   list is non-empty.
+2. Theme validation: the documented consumption form
+   `[data-empty-slots~="name"]` joins the validated selector vocabulary —
+   `build_theme_css` checks slot names inside such attribute selectors the
+   same way it checks `.slot-*` classes (typos and renamed slots are
+   line-numbered build errors, not silent no-ops; anything less would
+   recreate the silent-CSS class this issue exists to kill).
+3. `themes/base.css` (and the example copy `examples/footnotes/css/base.css`):
+   `.footnotes:empty { display: none }` is a first-party sibling of the same
+   whitespace-sensitive `:empty` bug class — it only works because the
+   built-in layout happens to write that one slot inline. Replace it with
+   `.peitho-slide[data-empty-slots~="footnotes"] .footnotes { display: none }`
+   so the built-in theme consumes the new mechanism and stops depending on
+   invisible layout formatting.
+4. Docs: README's layout/slot section + the guide's slot styling discussion
+   gain the CSS recipe, with a clarifying sentence that the wrapper class in
+   the recipe is the layout author's own class (the attribute token is the
+   slot name; the system does not tie the two together).
+
+## Tests (TDD order)
+
+1. A slide leaving one optional slot empty renders
+   `data-empty-slots="quote"` on the root; the filled slots are not listed.
+2. Two empty slots → both names, sorted slot-name order.
+3. All slots filled → attribute absent entirely (byte-identical guarantee).
+4. Regression: `data-slide-key` and `peitho-slide` class stamping unchanged.
+
+## Non-goals
+
+- No whitespace trimming around removed slots.
+- No per-slot marker elements.

--- a/examples/footnotes/css/base.css
+++ b/examples/footnotes/css/base.css
@@ -100,7 +100,7 @@
   line-height: 1.35;
 }
 
-.footnotes:empty {
+.peitho-slide[data-empty-slots~="footnotes"] .footnotes {
   display: none;
 }
 

--- a/site/content/guide/layouts.md
+++ b/site/content/guide/layouts.md
@@ -41,6 +41,19 @@ content.
 
 ![peitho build refusing a deck with two code blocks against a slot that allows 0..1](/guide-shots/build-error.png)
 
+## Styling empty slot wrappers
+
+Rendered slide roots list empty slots in `data-empty-slots`, so CSS can hide
+their wrappers without relying on whitespace-sensitive `:empty` matching:
+
+```css
+.peitho-slide[data-empty-slots~="quote"] .quote { display: none; }
+```
+
+Here, `.quote` is whatever class the layout author put on the wrapper element;
+`quote` in the attribute selector is the slot name, and Peitho does not tie the
+two together.
+
 ## Hybrid dispatch
 
 When multiple layouts are available, Peitho chooses a layout in this order:

--- a/themes/base.css
+++ b/themes/base.css
@@ -100,7 +100,7 @@
   line-height: 1.35;
 }
 
-.footnotes:empty {
+.peitho-slide[data-empty-slots~="footnotes"] .footnotes {
   display: none;
 }
 


### PR DESCRIPTION
Closes #423

## What

From real-world deck writing: hiding an empty slot's wrapper with `.quote:empty` silently fails, because the removed `<slot>` leaves the layout's surrounding whitespace inside the wrapper. The author had to discover `.quote:not(:has(.slot-quote))` by trial and error.

The rendered slide root now carries `data-empty-slots="<name> …"` listing every slot that received zero fragments, so CSS can target the state deliberately:

```css
.peitho-slide[data-empty-slots~="quote"] .quote { display: none; }
```

## Design points

- **Byte-identical when full**: the attribute is emitted only when at least one slot is empty (golden test asserts absence).
- **Validated like everything else**: slot names inside `[data-empty-slots~="…"]` selectors are checked against the layouts exactly like `.slot-*` classes (union + keyed scopes) — a typo'd or renamed slot is a line-numbered build error, not a silent no-op (anything less would recreate the silent-CSS class this issue exists to kill). Only bare presence and `~=` are accepted: the attribute holds a space-joined list, so `=`/`^=`/`$=`/`*=`/`|=` would silently never match slides with 2+ empty slots and are rejected with help pointing at `~=`. The `i` flag is honored case-insensitively.
- **Sorted slot order**: the `~=` selector is order-insensitive, so declaration order is unobservable; a parallel declaration-order Vec was rejected in review as unguarded parallel state.
- **First-party sibling fixed**: `themes/base.css` (and the examples/footnotes copy) swap `.footnotes:empty` — which only worked because the built-in layout writes that one slot inline — to the new mechanism. Verified with built decks: footnote-less slides hide the wrapper, slides with footnotes keep it.

Docs: README + guide gain the recipe, with the clarification that the wrapper class in the recipe is the layout author's own class (the attribute token is the slot name).

## Verification

- `cargo test --workspace` ×3 green, clippy `-D warnings`, fmt, bindings/dist drift, npm gates.
- Review: 8-angle code review + revision + 2 verification rounds; empirical builds of footnotes/footnote-less/all-slots-filled decks; operator/quoting/flag edge cases traced (remaining quirks are shared, pre-existing `data-slide-key` scanner limitations — consistency preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV