### PR TITLE
peitho docs: embed the full guide in the binary for offline/agent reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Peitho is the Greek goddess who presides over the power to move people's hearts 
 
 Docs & demos: **[peitho.gosu.ke](https://peitho.gosu.ke/)** — a guide, an examples gallery, and the example decks built and served under `/demo/<name>/`. Auto-deployed on push to `main`; `envchain peitho make deploy-demo` for manual deploys.
 
+## Offline and agent reference
+
+The complete guide is embedded in the `peitho` binary. Run `peitho docs` to list topics, `peitho docs <topic>` to print one Markdown page, or `peitho docs --all` to print the full guide without network access.
+
 ## How it works
 
 Content is Markdown. Design is layout HTML plus theme CSS, versioned in git right next to the content. The two never mix — and the layout itself is the schema: each `<slot>` declares what it accepts and how many, and peitho type-checks every slide against its layout at build time. This is the built-in default layout, in its entirety:

--- a/crates/peitho/src/docs.rs
+++ b/crates/peitho/src/docs.rs
@@ -1,0 +1,523 @@
+use std::{fmt::Write as _, sync::LazyLock};
+
+use peitho_core::error::{BuildError, ErrorKind};
+
+// These paths reach outside the crate, so `cargo package`/`publish` would break; peitho ships as a repo-built Homebrew binary, not a crates.io crate.
+const GUIDE_SOURCES: &[(&str, &str)] = &[
+    ("cli", include_str!("../../../site/content/guide/cli.md")),
+    (
+        "frontmatter",
+        include_str!("../../../site/content/guide/frontmatter.md"),
+    ),
+    (
+        "getting-started",
+        include_str!("../../../site/content/guide/getting-started.md"),
+    ),
+    (
+        "layouts",
+        include_str!("../../../site/content/guide/layouts.md"),
+    ),
+    (
+        "writing-decks",
+        include_str!("../../../site/content/guide/writing-decks.md"),
+    ),
+];
+
+#[derive(Debug)]
+pub(crate) struct Topic {
+    pub(crate) slug: &'static str,
+    pub(crate) title: &'static str,
+    pub(crate) description: &'static str,
+    pub(crate) body: &'static str,
+    weight: i64,
+}
+
+pub(crate) static TOPICS: LazyLock<Vec<Topic>> = LazyLock::new(|| {
+    let mut topics = GUIDE_SOURCES
+        .iter()
+        .map(|&(slug, source)| parse_topic(slug, source))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|err| panic!("failed to parse embedded guide: {err}"));
+    topics.sort_by_key(|topic| topic.weight);
+    topics
+});
+
+fn parse_topic(slug: &'static str, source: &'static str) -> Result<Topic, BuildError> {
+    let source = source
+        .strip_prefix("+++\n")
+        .ok_or_else(|| invalid_frontmatter(slug, "the opening `+++` delimiter is missing"))?;
+    let (frontmatter, body) = source
+        .split_once("\n+++\n")
+        .ok_or_else(|| invalid_frontmatter(slug, "the closing `+++` delimiter is missing"))?;
+    let body = body.strip_prefix('\n').unwrap_or(body);
+
+    let mut title = None;
+    let mut description = None;
+    let mut weight = None;
+    for line in frontmatter.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            let key = line.split_whitespace().next().unwrap_or("<missing>");
+            return Err(invalid_frontmatter(
+                slug,
+                format!("`{key}` must use `key = <value>` syntax"),
+            ));
+        };
+        let key = key.trim();
+        match key {
+            "title" => title = Some(parse_string(slug, "title", value)?),
+            "description" => description = Some(parse_string(slug, "description", value)?),
+            "weight" => {
+                weight = Some(
+                    value
+                        .trim()
+                        .parse::<i64>()
+                        .map_err(|_| invalid_frontmatter(slug, "`weight` must be an integer"))?,
+                )
+            }
+            "template" | "insert_anchor_links" => {
+                parse_quoted_string(slug, key, value)?;
+            }
+            _ => {
+                return Err(invalid_frontmatter(
+                    slug,
+                    format!(
+                        "unknown key `{key}`; expected one of `title`, `description`, `weight`, `template`, or `insert_anchor_links`"
+                    ),
+                ));
+            }
+        }
+    }
+
+    let title = title.ok_or_else(|| invalid_frontmatter(slug, "`title` is missing"))?;
+    let description =
+        description.ok_or_else(|| invalid_frontmatter(slug, "`description` is missing"))?;
+    let weight = weight.ok_or_else(|| invalid_frontmatter(slug, "`weight` is missing"))?;
+
+    Ok(Topic {
+        slug,
+        title,
+        description,
+        body,
+        weight,
+    })
+}
+
+fn parse_string(slug: &str, key: &str, value: &'static str) -> Result<&'static str, BuildError> {
+    let parsed = parse_quoted_string(slug, key, value)?;
+    if parsed.is_empty() {
+        return Err(invalid_frontmatter(
+            slug,
+            format!("`{key}` must be a non-empty quoted string"),
+        ));
+    }
+    Ok(parsed)
+}
+
+fn parse_quoted_string(
+    slug: &str,
+    key: &str,
+    value: &'static str,
+) -> Result<&'static str, BuildError> {
+    let value = value.trim();
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .ok_or_else(|| invalid_frontmatter(slug, format!("`{key}` must be a quoted string")))
+}
+
+fn invalid_frontmatter(slug: &str, detail: impl Into<String>) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        None,
+        format!(
+            "invalid embedded guide frontmatter for topic '{slug}': {}",
+            detail.into()
+        ),
+        "guide pages must start with Zola TOML frontmatter containing title, weight, and description",
+    )
+}
+
+pub(crate) fn render(topic: Option<&str>, all: bool) -> Result<String, BuildError> {
+    if all {
+        return Ok(render_all());
+    }
+    match topic {
+        Some(slug) => TOPICS
+            .iter()
+            .find(|topic| topic.slug == slug)
+            .map(render_topic)
+            .ok_or_else(|| unknown_topic(slug)),
+        None => Ok(render_list()),
+    }
+}
+
+fn render_list() -> String {
+    let width = TOPICS
+        .iter()
+        .map(|topic| topic.slug.len())
+        .max()
+        .unwrap_or(0);
+    let mut output = String::new();
+    for topic in TOPICS.iter() {
+        writeln!(output, "{:<width$}  {}", topic.slug, topic.description)
+            .expect("writing to a string cannot fail");
+    }
+    writeln!(
+        output,
+        "\nRun `peitho docs <topic>` for one topic or `peitho docs --all` for the complete guide."
+    )
+    .expect("writing to a string cannot fail");
+    output
+}
+
+fn render_all() -> String {
+    let mut output = String::new();
+    for (index, topic) in TOPICS.iter().enumerate() {
+        if index > 0 {
+            output.push('\n');
+        }
+        output.push_str(&render_topic(topic));
+    }
+    output
+}
+
+fn render_topic(topic: &Topic) -> String {
+    let mut output = String::new();
+    writeln!(output, "# {}\n", topic.title).expect("writing to a string cannot fail");
+    output.push_str(&rewrite_internal_links(topic.body));
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
+fn rewrite_internal_links(body: &str) -> String {
+    const LINK_MARKER: &str = "](";
+
+    let mut output = String::with_capacity(body.len());
+    let mut remaining = body;
+    while let Some(label_end) = remaining.find(LINK_MARKER) {
+        let destination_start = label_end + LINK_MARKER.len();
+        let destination = &remaining[destination_start..];
+        let is_zola_link = destination.starts_with("@/");
+        let is_root_relative_link = destination.starts_with('/') && !destination.starts_with("//");
+        if !is_zola_link && !is_root_relative_link {
+            output.push_str(&remaining[..destination_start]);
+            remaining = destination;
+            continue;
+        }
+
+        let Some(destination_end_offset) = remaining[destination_start..].find(')') else {
+            break;
+        };
+        let destination_end = destination_start + destination_end_offset;
+        let Some(label_start) = remaining[..label_end].rfind('[') else {
+            output.push_str(&remaining[..=destination_end]);
+            remaining = &remaining[destination_end + 1..];
+            continue;
+        };
+
+        output.push_str(&remaining[..label_start]);
+        let label = &remaining[label_start + 1..label_end];
+        let destination = &remaining[destination_start..destination_end];
+        write_rewritten_link(&mut output, label, destination);
+        remaining = &remaining[destination_end + 1..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn write_rewritten_link(output: &mut String, label: &str, destination: &str) {
+    if destination.starts_with('/') {
+        write!(output, "[{label}](https://peitho.gosu.ke{destination})")
+            .expect("writing to a string cannot fail");
+        return;
+    }
+
+    if let Some(guide_path) = destination.strip_prefix("@/guide/") {
+        let page = guide_path
+            .split_once('#')
+            .map_or(guide_path, |(page, _)| page);
+        if let Some(slug) = page.strip_suffix(".md") {
+            write!(output, "{label} (see `peitho docs {slug}`)")
+                .expect("writing to a string cannot fail");
+            return;
+        }
+    }
+
+    let path_with_anchor = destination
+        .strip_prefix("@/")
+        .expect("only Zola-internal links reach this function");
+    let (path, anchor) = path_with_anchor
+        .split_once('#')
+        .map_or((path_with_anchor, None), |(path, anchor)| {
+            (path, Some(anchor))
+        });
+    let path = path.strip_suffix(".md").unwrap_or(path);
+
+    write!(output, "[{label}](https://peitho.gosu.ke/{path}")
+        .expect("writing to a string cannot fail");
+    if !path.ends_with('/') {
+        output.push('/');
+    }
+    if let Some(anchor) = anchor {
+        write!(output, "#{anchor}").expect("writing to a string cannot fail");
+    }
+    output.push(')');
+}
+
+fn unknown_topic(slug: &str) -> BuildError {
+    BuildError::new(
+        ErrorKind::Parse,
+        None,
+        format!("unknown docs topic '{slug}'"),
+        format!(
+            "valid topics: {}",
+            TOPICS
+                .iter()
+                .map(|topic| topic.slug)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, fs, path::Path};
+
+    use assert_cmd::Command as AssertCommand;
+
+    use super::*;
+
+    #[test]
+    fn topic_table_parses_every_embedded_page() {
+        for &(slug, source) in GUIDE_SOURCES {
+            let topic = parse_topic(slug, source)
+                .unwrap_or_else(|err| panic!("failed to parse {slug}: {err}"));
+
+            assert!(!topic.title.is_empty(), "missing title for {slug}");
+            assert!(
+                !topic.description.is_empty(),
+                "missing description for {slug}"
+            );
+            assert!(!topic.body.trim_start().starts_with("+++"));
+        }
+
+        assert!(TOPICS
+            .windows(2)
+            .all(|pair| pair[0].weight <= pair[1].weight));
+    }
+
+    #[test]
+    fn strict_frontmatter_accepts_supported_ignored_keys_and_blank_lines() {
+        let topic = parse_topic(
+            "test",
+            "+++\ntitle = \"Test\"\n\ndescription = \"Description\"\nweight = -1\ntemplate = \"guide-page.html\"\ninsert_anchor_links = \"right\"\n+++\n\nBody\n",
+        )
+        .unwrap();
+
+        assert_eq!(topic.title, "Test");
+        assert_eq!(topic.weight, -1);
+        assert_eq!(topic.body, "Body\n");
+    }
+
+    #[test]
+    fn strict_frontmatter_rejects_unknown_structure_and_malformed_values() {
+        let cases = [
+            (
+                "+++\ntitle \"Test\"\n+++\n\nBody\n",
+                "`title`",
+                "key = <value>",
+            ),
+            (
+                "+++\ntitle = \"Test\"\ndescription = \"Description\"\nweight = 1\ntemplate = guide-page.html\n+++\n\nBody\n",
+                "`template`",
+                "quoted string",
+            ),
+            (
+                "+++\ntitle = \"Test\"\ndescription = \"Description\"\nweight = 1\ninsert_anchor_links = false\n+++\n\nBody\n",
+                "`insert_anchor_links`",
+                "quoted string",
+            ),
+            (
+                "+++\ntitle = \"Test\"\ndescription = \"Description\"\nweight = heavy\n+++\n\nBody\n",
+                "`weight`",
+                "integer",
+            ),
+            (
+                "+++\ntitle = \"Test\"\ndescription = \"Description\"\nweight = 1\nextra = \"value\"\n+++\n\nBody\n",
+                "`extra`",
+                "expected one of",
+            ),
+        ];
+
+        for (source, key, expectation) in cases {
+            let err = parse_topic("broken", source).unwrap_err();
+            assert!(err.message.contains("topic 'broken'"), "{err}");
+            assert!(err.message.contains(key), "{err}");
+            assert!(err.message.contains(expectation), "{err}");
+        }
+    }
+
+    #[test]
+    fn embedded_topics_match_guide_pages() {
+        let guide_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../site/content/guide");
+        let expected = fs::read_dir(guide_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("md"))
+            .filter_map(|path| guide_slug(&path))
+            .collect::<BTreeSet<_>>();
+        let actual = TOPICS
+            .iter()
+            .map(|topic| topic.slug.to_owned())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn docs_list() {
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .arg("docs")
+            .assert()
+            .success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+        for topic in TOPICS.iter() {
+            assert!(stdout.contains(topic.slug), "actual stdout: {stdout}");
+            assert!(
+                stdout.contains(topic.description),
+                "actual stdout: {stdout}"
+            );
+        }
+        assert!(stdout.contains("peitho docs <topic>"));
+        assert!(stdout.contains("peitho docs --all"));
+    }
+
+    #[test]
+    fn docs_topic() {
+        let topic = TOPICS.first().expect("embedded topics");
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .args(["docs", topic.slug])
+            .assert()
+            .success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+
+        assert_eq!(stdout, render_topic(topic));
+        assert!(stdout.starts_with(&format!("# {}\n\n", topic.title)));
+        assert!(!stdout.trim_start().starts_with("+++"));
+    }
+
+    #[test]
+    fn docs_all() {
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .args(["docs", "--all"])
+            .assert()
+            .success();
+        let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+        let mut previous_heading = None;
+
+        for topic in TOPICS.iter() {
+            let heading = format!("# {}\n", topic.title);
+            let position = stdout
+                .find(&heading)
+                .unwrap_or_else(|| panic!("missing {heading:?} in stdout"));
+            if let Some(previous) = previous_heading {
+                assert!(previous < position, "topics are not in weight order");
+            }
+            previous_heading = Some(position);
+            assert!(stdout.contains(&render_topic(topic)));
+        }
+    }
+
+    #[test]
+    fn guide_links_without_anchors_become_command_references() {
+        assert_eq!(
+            rewrite_internal_links("Read [Writing Decks](@/guide/writing-decks.md)."),
+            "Read Writing Decks (see `peitho docs writing-decks`)."
+        );
+    }
+
+    #[test]
+    fn guide_links_with_anchors_become_command_references() {
+        assert_eq!(
+            rewrite_internal_links("Read [`peitho present`](@/guide/cli.md#peitho-present)."),
+            "Read `peitho present` (see `peitho docs cli`)."
+        );
+    }
+
+    #[test]
+    fn other_zola_links_become_absolute_docs_site_links_and_keep_anchors() {
+        assert_eq!(
+            rewrite_internal_links(
+                "[Example](@/examples/code-images.md) [Section](@/examples/code-images.md#mermaid)"
+            ),
+            "[Example](https://peitho.gosu.ke/examples/code-images/) [Section](https://peitho.gosu.ke/examples/code-images/#mermaid)"
+        );
+    }
+
+    #[test]
+    fn root_relative_image_links_become_absolute_and_keep_queries_and_anchors() {
+        assert_eq!(
+            rewrite_internal_links(
+                "![Preview](/guide-shots/preview-single.png) [Raw](/guide-shots/preview-single.png?raw=1#preview)"
+            ),
+            "![Preview](https://peitho.gosu.ke/guide-shots/preview-single.png) [Raw](https://peitho.gosu.ke/guide-shots/preview-single.png?raw=1#preview)"
+        );
+    }
+
+    #[test]
+    fn protocol_relative_and_external_links_are_untouched() {
+        let body = "[Protocol relative](//example.com/path) [HTTPS](https://example.com/path) [HTTP](http://example.com) [relative](../guide.md#topic)";
+
+        assert_eq!(rewrite_internal_links(body), body);
+    }
+
+    #[test]
+    fn rendered_topic_bodies_have_no_zola_internal_links() {
+        for topic in TOPICS.iter() {
+            let rendered = render(Some(topic.slug), false).unwrap();
+            assert!(
+                !rendered.contains("@/"),
+                "rendered topic '{}' still contains a Zola link:\n{rendered}",
+                topic.slug
+            );
+            assert!(
+                !rendered.contains("](/"),
+                "rendered topic '{}' still contains a root-relative link:\n{rendered}",
+                topic.slug
+            );
+        }
+    }
+
+    #[test]
+    fn docs_unknown_topic_names_valid_topics() {
+        let assert = AssertCommand::cargo_bin("peitho")
+            .unwrap()
+            .args(["docs", "missing"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+
+        assert!(
+            stderr.contains("unknown docs topic 'missing'"),
+            "actual stderr: {stderr}"
+        );
+        for topic in TOPICS.iter() {
+            assert!(stderr.contains(topic.slug), "actual stderr: {stderr}");
+        }
+    }
+
+    fn guide_slug(path: &Path) -> Option<String> {
+        let stem = path.file_stem()?.to_str()?;
+        (stem != "_index").then(|| stem.to_owned())
+    }
+}

--- a/crates/peitho/src/main.rs
+++ b/crates/peitho/src/main.rs
@@ -29,6 +29,7 @@ use sha2::{Digest, Sha256};
 mod asset_resolution;
 mod cdp;
 mod diagnostics;
+mod docs;
 mod doctor;
 mod lint;
 mod new_cmd;
@@ -695,6 +696,9 @@ struct PreviewOptions {
 #[command(name = "peitho")]
 #[command(version)]
 #[command(about = "Build HTML-native presentations from Markdown")]
+#[command(
+    long_about = "Build HTML-native presentations from Markdown.\n\nRun `peitho docs` for the embedded guide, available offline and suitable for agent reference."
+)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -787,6 +791,17 @@ enum Command {
     Export {
         #[command(subcommand)]
         command: ExportCommand,
+    },
+    /// Read the embedded guide offline.
+    Docs {
+        #[arg(
+            value_name = "TOPIC",
+            conflicts_with = "all",
+            help = "Guide topic slug; run `peitho docs` to list them"
+        )]
+        topic: Option<String>,
+        #[arg(long, help = "Print every guide page in order")]
+        all: bool,
     },
     Completions {
         shell: Shell,
@@ -945,6 +960,14 @@ fn run() -> miette::Result<()> {
         Command::Export { command } => match command {
             ExportCommand::Pdf { input, out } => export_pdf(input, out),
         },
+        Command::Docs { topic, all } => {
+            let output = core(docs::render(topic.as_deref(), all))?;
+            match std::io::stdout().write_all(output.as_bytes()) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+                Err(err) => Err(err).into_diagnostic(),
+            }
+        }
         Command::Completions { shell } => {
             let mut cmd = Cli::command();
             let name = cmd.get_name().to_string();
@@ -6857,6 +6880,7 @@ contexts:
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected present command");
@@ -6881,6 +6905,7 @@ contexts:
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected present command");
@@ -7327,6 +7352,7 @@ contexts:
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected present command");
@@ -7345,6 +7371,7 @@ contexts:
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected present command");
@@ -7363,6 +7390,7 @@ contexts:
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected present command");
@@ -7393,6 +7421,7 @@ contexts:
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected lint command");
@@ -7422,6 +7451,7 @@ contexts:
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected preview command");
@@ -7448,6 +7478,7 @@ contexts:
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected export pdf command");
@@ -7472,6 +7503,7 @@ contexts:
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected completions command");
             }
@@ -7500,6 +7532,7 @@ contexts:
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected layouts command");
@@ -9440,6 +9473,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected new command");
@@ -9467,6 +9501,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Present { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected new command");
@@ -9586,6 +9621,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected build command");
@@ -9609,6 +9645,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected present command");
@@ -9634,6 +9671,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Preview { .. }
             | Command::Present { .. }
             | Command::Publish { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected export pdf command");
@@ -9677,6 +9715,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected build command");
@@ -9702,6 +9741,7 @@ rehearsal-20260719-135241  (recorded 2026-07-19 13:52)
             | Command::Preview { .. }
             | Command::Publish { .. }
             | Command::Export { .. }
+            | Command::Docs { .. }
             | Command::Completions { .. }
             | Command::Rehearsal { .. } => {
                 panic!("expected build command");

--- a/docs/plans/2026-08-16-docs-command.md
+++ b/docs/plans/2026-08-16-docs-command.md
@@ -1,0 +1,58 @@
+# peitho docs: embedded guide for offline/AI-agent reference (Issue #429)
+
+Date: 2026-08-16
+Issue: #429
+
+## Problem
+
+The deep documentation (frontmatter keys, layout/slot contract, explicit slot
+syntax, CLI reference) lives in `site/content/guide/*.md` and is only
+reachable online. An agent (or offline human) working from the installed
+binary has only the README that Homebrew happens to ship. Author request
+2026-08-16: make the complete reference discoverable from the binary itself.
+
+## Design
+
+New CLI subcommand `peitho docs`, single-sourced from the same guide pages
+the docs site builds from (no second wiring site to drift):
+
+- `peitho docs` — list topics (slug + the page's `description` from its Zola
+  frontmatter), one per line, plus a pointer to `peitho docs <topic>` /
+  `--all`.
+- `peitho docs <topic>` — print that page as plain Markdown on stdout.
+- `peitho docs --all` — print every page in guide weight order, separated by
+  a `# <title>` heading per page.
+- Unknown topic → error listing valid topics (line-numbered convention does
+  not apply; this is a CLI-argument error).
+
+Embedding: `include_str!` per guide page in a new `crates/peitho/src/docs.rs`
+module with a static topic table `(slug, title, description, body)`. The Zola
+TOML frontmatter (`+++ ... +++`) is stripped at compile-time-adjacent runtime
+(small parser in docs.rs); `title`/`description`/`weight` come from it, so the
+table is derived, not hand-maintained.
+
+Output stays plain Markdown: no paging, no ANSI — what an agent ingests.
+
+Drift guard: a test enumerates `../../site/content/guide/*.md` (excluding
+`_index.md`) from the repo at test time and asserts the embedded topic set
+matches, so adding a guide page without wiring it into docs.rs fails CI.
+(`include_str!` already guarantees embedded bytes match the files.)
+
+Discoverability: `--help` long about text mentions `peitho docs`; README gets
+a short section.
+
+## Tests (TDD order)
+
+1. Topic table: every embedded page parses (frontmatter stripped, title and
+   description non-empty).
+2. Drift test: embedded slugs == `site/content/guide/*.md` slugs.
+3. `docs_list` output contains each slug and description.
+4. `docs_topic` prints body without `+++` frontmatter.
+5. `docs_all` contains every page in weight order.
+6. Unknown topic errors and names valid topics.
+
+## Non-goals
+
+- No HTML rendering, no pager, no search.
+- No README embedding (README stays the human quick reference).
+- No llms.txt on the site (separate concern; can follow later if wanted).


### PR DESCRIPTION
Closes #429

## What

Author request: the Homebrew-shipped README is not enough for an AI agent to drive peitho. `peitho docs` embeds the complete guide in the binary:

- `peitho docs` — topic list (slug + description) with a pointer to the other forms
- `peitho docs <topic>` — one page as plain Markdown on stdout (`# <title>` heading, no paging, no ANSI)
- `peitho docs --all` — every page in guide weight order

Single-sourced from `site/content/guide/*.md` (the drift test enumerates the directory at test time, so adding a guide page without wiring it fails CI; `include_str!` keeps the bytes honest).

## Design points

- **Links are useful offline**: `@/guide/<slug>.md` links become `see peitho docs <slug>`; other site-internal and root-relative asset links become absolute `https://peitho.gosu.ke/...` URLs. An all-topics test asserts no Zola-internal link syntax survives rendering.
- **Strict embedded-frontmatter parsing**: known keys only, malformed values are loud errors naming topic/key — no `_ => {}` swallowing (a future `description = """` multi-line edit fails tests instead of shipping garbage).
- **`peitho docs --all | head` works**: BrokenPipe on the docs stdout write is success; all other write errors keep the diagnostic path.
- Unknown topic errors list the valid topics; `docs` is wired into `--help` long-about, README ("Offline and agent reference"), and shell completions (clap-derived).
- `include_str!` paths reach outside the crate (breaks `cargo package`) — noted in a comment; peitho ships as a repo-built binary, not a crates.io crate.

## Verification

- `cargo test --workspace` ×3 green, clippy `-D warnings`, fmt, bindings/dist drift, npm gates.
- Review rounds ran the built binary through every invocation (list/topic/--all/unknown/conflict/pipe), verified exit codes and stream separation, and grepped the full `--all` output for leaked internal links (zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV