### PR TITLE
Support blockquotes in slide bodies

### DIFF
--- a/crates/peitho-core/src/check.rs
+++ b/crates/peitho-core/src/check.rs
@@ -118,6 +118,7 @@ fn accepts_fragment(accepts: Accepts, fragment: &SourceFragment) -> bool {
             | (Accepts::Blocks, FragmentKind::Heading { .. })
             | (Accepts::Blocks, FragmentKind::Paragraph)
             | (Accepts::Blocks, FragmentKind::List)
+            | (Accepts::Blocks, FragmentKind::Blockquote)
             | (Accepts::Blocks, FragmentKind::Math { .. })
             | (Accepts::Blocks, FragmentKind::EmbedCard { .. })
             | (Accepts::Blocks, FragmentKind::GenericEmbedCard { .. })
@@ -409,6 +410,37 @@ mod tests {
         assert_eq!(err.kind, ErrorKind::Accepts);
         assert_eq!(err.line, Some(3));
         assert!(err.to_string().contains("slot 'body' accepts inline"));
+        assert_eq!(
+            err.help,
+            "change the layout accepts to 'blocks' or move this content to a blocks slot"
+        );
+    }
+
+    #[test]
+    fn rejects_blockquote_in_explicit_inline_slot_with_named_contract_error() {
+        let layout = parse_layout(
+            "inline-body",
+            r#"<section><slot name="body" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let mapped = map_by_convention(
+            parse_markdown(
+                "::: {slot=body}\n\n> quoted\n\n:::\n",
+                &crate::highlight::Highlighter::defaults(),
+            )
+            .unwrap(),
+            &layout,
+        )
+        .unwrap();
+
+        let err = check_deck(mapped).unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Accepts);
+        assert_eq!(err.line, Some(3));
+        assert_eq!(
+            err.message,
+            "slot 'body' accepts inline, but got blockquote"
+        );
         assert_eq!(
             err.help,
             "change the layout accepts to 'blocks' or move this content to a blocks slot"

--- a/crates/peitho-core/src/code_images.rs
+++ b/crates/peitho-core/src/code_images.rs
@@ -563,7 +563,8 @@ fn transform_fragment<S: SvgRunner, E: EmbedRenderer, F: OEmbedFetcher>(
             | FragmentKind::GenericEmbedCard { .. }
             | FragmentKind::Footnotes { .. }
             | FragmentKind::Image { .. }
-            | FragmentKind::List => Ok(fragment),
+            | FragmentKind::List
+            | FragmentKind::Blockquote => Ok(fragment),
         }
     })()?;
 

--- a/crates/peitho-core/src/domain.rs
+++ b/crates/peitho-core/src/domain.rs
@@ -709,6 +709,7 @@ pub enum FragmentKind<S = RawImagePath> {
         src: S,
     },
     List,
+    Blockquote,
     /// A `::: {slot=name}` fenced block. Mapping expands the children into
     /// the named slot; SlotGroup itself never leaves the Mapped phase.
     SlotGroup {
@@ -741,6 +742,7 @@ impl<S> FragmentKind<S> {
             Self::Footnotes { .. } => Accepts::Blocks,
             Self::Image { .. } => Accepts::Image,
             Self::List => Accepts::List,
+            Self::Blockquote => Accepts::Blocks,
             // SlotGroup is expanded in mapping, so its own accepts value never
             // reaches contract checks. Report a conservative blocks default so
             // any accidental reader gets a stable answer instead of unreachable!.
@@ -760,6 +762,7 @@ impl<S> FragmentKind<S> {
             Self::Footnotes { .. } => "footnote block",
             Self::Image { .. } => "image",
             Self::List => "list",
+            Self::Blockquote => "blockquote",
             Self::SlotGroup { .. } => "slot group",
         }
     }
@@ -778,6 +781,7 @@ impl<S> fmt::Display for FragmentKind<S> {
             Self::Footnotes { .. } => "footnotes",
             Self::Image { .. } => "image",
             Self::List => "list",
+            Self::Blockquote => "blockquote",
             Self::SlotGroup { .. } => "slot group",
         })
     }
@@ -834,6 +838,20 @@ impl SourceFragment<RawImagePath> {
         Self {
             line,
             kind: FragmentKind::List,
+            reveal_span: None,
+            emphasis: None,
+            embed_options: None,
+            markdown: markdown.into(),
+            text: String::new(),
+            code: String::new(),
+            language: None,
+        }
+    }
+
+    pub fn blockquote(line: usize, markdown: impl Into<String>) -> Self {
+        Self {
+            line,
+            kind: FragmentKind::Blockquote,
             reveal_span: None,
             emphasis: None,
             embed_options: None,
@@ -1059,6 +1077,7 @@ impl<S> SourceFragment<S> {
             FragmentKind::Footnotes { entries } => FragmentKind::Footnotes { entries },
             FragmentKind::Image { alt, src } => FragmentKind::Image { alt, src: f(src)? },
             FragmentKind::List => FragmentKind::List,
+            FragmentKind::Blockquote => FragmentKind::Blockquote,
             FragmentKind::SlotGroup { name, children } => {
                 let mut mapped_children = Vec::with_capacity(children.len());
                 for child in children {

--- a/crates/peitho-core/src/include.rs
+++ b/crates/peitho-core/src/include.rs
@@ -1163,7 +1163,13 @@ mod tests {
             "# Included\n\nIncluded paragraph\n",
         )
         .unwrap();
-        let source = "<!-- {\"include\":\"shared.md\"} -->\n---\n# After\n\n> unsupported\n";
+        let source = "<!-- {\"include\":\"shared.md\"} -->
+---
+# After
+
+| unsupported |
+| --- |
+";
 
         let expanded = expand_includes(source, 0, &deck).unwrap();
         let frontmatter = crate::parser::parse_frontmatter(&expanded.source).unwrap();

--- a/crates/peitho-core/src/mapping.rs
+++ b/crates/peitho-core/src/mapping.rs
@@ -315,6 +315,7 @@ fn map_slide(slide: &ParsedSlide, layout: &Layout) -> Result<MappedSlide> {
             | FragmentKind::EmbedCard { .. }
             | FragmentKind::GenericEmbedCard { .. }
             | FragmentKind::List
+            | FragmentKind::Blockquote
             | FragmentKind::Text => {
                 SlotName::new("body").expect("conventional slot names are valid")
             }
@@ -410,6 +411,7 @@ fn shallowest_heading_line(fragments: &[SourceFragment]) -> Option<usize> {
             | FragmentKind::Footnotes { .. }
             | FragmentKind::Image { .. }
             | FragmentKind::List
+            | FragmentKind::Blockquote
             | FragmentKind::SlotGroup { .. } => None,
         })
         .min_by_key(|(level, line)| (*level, *line))

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -232,6 +232,29 @@ enum OpenBlock {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ContainerKind {
+    List,
+    Blockquote,
+}
+
+impl ContainerKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::List => "list",
+            Self::Blockquote => "blockquote",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OpenContainer {
+    kind: ContainerKind,
+    start: usize,
+}
+
+type ContainerState = Vec<OpenContainer>;
+
 enum ParagraphInline {
     Empty,
     Text,
@@ -570,24 +593,34 @@ pub(crate) fn parse_markdown(
 fn split_slide_ranges(source: &str, content_start: usize) -> Result<Vec<SlideRange>> {
     let mut ranges = Vec::new();
     let mut start = content_start;
-    let mut list_depth = 0usize;
+    let mut block_depth = 0usize;
     let content = &source[content_start..];
 
     for (event, range) in Parser::new_ext(content, slide_split_options()).into_offset_iter() {
         let global_start = content_start + range.start;
         let global_end = content_start + range.end;
-        match event {
-            Event::Start(Tag::List(_)) => list_depth += 1,
-            Event::End(TagEnd::List(_)) => list_depth = list_depth.saturating_sub(1),
-            Event::Rule if list_depth == 0 => {
-                ranges.push(SlideRange {
-                    start,
-                    end: global_start,
-                });
-                start = global_end;
-            }
-            Event::Rule => {}
-            _ => {}
+        if let Event::Start(Tag::List(_ordered)) = &event {
+            block_depth += 1;
+            continue;
+        }
+        if let Event::Start(Tag::BlockQuote(_kind)) = &event {
+            block_depth += 1;
+            continue;
+        }
+        if let Event::End(TagEnd::List(_ordered)) = &event {
+            block_depth = block_depth.saturating_sub(1);
+            continue;
+        }
+        if let Event::End(TagEnd::BlockQuote(_kind)) = &event {
+            block_depth = block_depth.saturating_sub(1);
+            continue;
+        }
+        if matches!(event, Event::Rule) && block_depth == 0 {
+            ranges.push(SlideRange {
+                start,
+                end: global_start,
+            });
+            start = global_end;
         }
     }
 
@@ -1725,6 +1758,42 @@ fn push_checked_fragment(
     Ok(())
 }
 
+fn enter_container(container: &mut ContainerState, kind: ContainerKind, start: usize) {
+    container.push(OpenContainer { kind, start });
+}
+
+fn close_container(
+    container: &mut ContainerState,
+    closing_kind: ContainerKind,
+    source: &str,
+    event_start: usize,
+    event_end: usize,
+) -> Result<Option<(usize, SourceFragment)>> {
+    let Some(open) = container.pop() else {
+        return Err(unsupported_construct(
+            line_for_offset(source, event_start),
+            &format!(
+                "{} end without {} start",
+                closing_kind.name(),
+                closing_kind.name()
+            ),
+        ));
+    };
+
+    debug_assert_eq!(open.kind, closing_kind);
+    if !container.is_empty() {
+        return Ok(None);
+    }
+
+    let line = line_for_offset(source, open.start);
+    let markdown = source_slice(source, open.start, event_end);
+    let fragment = match open.kind {
+        ContainerKind::List => SourceFragment::list(line, markdown),
+        ContainerKind::Blockquote => SourceFragment::blockquote(line, markdown),
+    };
+    Ok(Some((open.start, fragment)))
+}
+
 fn parse_slide(
     source: &str,
     range: SlideRange,
@@ -1750,8 +1819,7 @@ fn parse_slide(
     let mut block: Option<OpenBlock> = None;
     let mut footnotes = FootnoteAccumulator::default();
     let mut footnote_capture: Option<FootnoteCapture> = None;
-    let mut list_depth = 0usize;
-    let mut list_start = None;
+    let mut container = ContainerState::new();
     let mut seen_content = false;
     // An HTML block can span multiple `Event::Html` events (one per source line
     // for a multi-line comment). We buffer them between Start(HtmlBlock)/End
@@ -1762,10 +1830,13 @@ fn parse_slide(
     for (event, local_range) in Parser::new_ext(slice, parser_options()).into_offset_iter() {
         let global_start = range.start + local_range.start;
         let global_end = range.start + local_range.end;
-        let line = line_for_offset(source, global_start);
         if let Event::Start(Tag::FootnoteDefinition(label)) = &event {
-            if list_depth > 0 {
-                let err = unsupported_construct(line, "footnote definition inside list");
+            let line = line_for_offset(source, global_start);
+            if let Some(open) = container.last() {
+                let err = unsupported_construct(
+                    line,
+                    &format!("footnote definition inside {}", open.kind.name()),
+                );
                 return Err(attach_slide_context(
                     err,
                     index,
@@ -1786,6 +1857,7 @@ fn parse_slide(
             continue;
         }
         if let Some(capture) = footnote_capture.as_mut() {
+            let line = line_for_offset(source, global_start);
             match event {
                 Event::End(TagEnd::FootnoteDefinition) => {
                     let capture = footnote_capture
@@ -1839,6 +1911,15 @@ fn parse_slide(
                 | Event::End(TagEnd::Strikethrough)
                 | Event::Start(Tag::Link { .. })
                 | Event::End(TagEnd::Link) => continue,
+                Event::Start(Tag::BlockQuote(_kind)) | Event::End(TagEnd::BlockQuote(_kind)) => {
+                    let err = unsupported_footnote_block_error(line);
+                    return Err(attach_slide_context(
+                        err,
+                        index,
+                        explicit_key.as_ref(),
+                        &fragments,
+                    ));
+                }
                 Event::Start(Tag::Image { .. })
                 | Event::End(TagEnd::Image)
                 | Event::Start(Tag::Heading { .. })
@@ -1849,8 +1930,6 @@ fn parse_slide(
                 | Event::End(TagEnd::List(_))
                 | Event::Start(Tag::Item)
                 | Event::End(TagEnd::Item)
-                | Event::Start(Tag::BlockQuote(_))
-                | Event::End(TagEnd::BlockQuote(_))
                 | Event::Start(Tag::HtmlBlock)
                 | Event::End(TagEnd::HtmlBlock)
                 | Event::Start(Tag::Table(_))
@@ -1890,25 +1969,59 @@ fn parse_slide(
                 }
             }
         }
-        match event {
-            Event::Rule => {
-                let err = unsupported_construct(line, "thematic break inside slide");
-                return Err(attach_slide_context(
-                    err,
-                    index,
-                    explicit_key.as_ref(),
-                    &fragments,
-                ));
+
+        let opening_kind = if let Event::Start(Tag::List(_ordered)) = &event {
+            Some(ContainerKind::List)
+        } else if let Event::Start(Tag::BlockQuote(_kind)) = &event {
+            Some(ContainerKind::Blockquote)
+        } else {
+            None
+        };
+        if let Some(kind) = opening_kind {
+            enter_container(&mut container, kind, global_start);
+            continue;
+        }
+
+        let closing_kind = if let Event::End(TagEnd::List(_ordered)) = &event {
+            Some(ContainerKind::List)
+        } else if let Event::End(TagEnd::BlockQuote(_kind)) = &event {
+            Some(ContainerKind::Blockquote)
+        } else {
+            None
+        };
+        if let Some(kind) = closing_kind {
+            let closed = close_container(&mut container, kind, source, global_start, global_end)
+                .map_err(|err| {
+                    attach_slide_context(err, index, explicit_key.as_ref(), &fragments)
+                })?;
+            if let Some((start, fragment)) = closed {
+                push_checked_fragment(
+                    source,
+                    start,
+                    global_end,
+                    &markers,
+                    &mut fragments,
+                    &mut div_stack,
+                    fragment,
+                )
+                .map_err(|err| {
+                    attach_slide_context(err, index, explicit_key.as_ref(), &fragments)
+                })?;
+                seen_content = true;
             }
-            Event::Start(Tag::List(_)) => {
-                if list_depth == 0 {
-                    list_start = Some(global_start);
-                }
-                list_depth += 1;
-            }
-            Event::End(TagEnd::List(_)) => {
-                if list_depth == 0 {
-                    let err = unsupported_construct(line, "list end without list start");
+            continue;
+        }
+
+        if let Some(open) = container.last() {
+            if open.kind == ContainerKind::Blockquote {
+                if let Event::Start(Tag::CodeBlock(_kind)) = &event {
+                    let message = format!("code block inside a {}", open.kind.name());
+                    let err = BuildError::new(
+                        ErrorKind::Parse,
+                        Some(line_for_offset(source, global_start)),
+                        message,
+                        "move the code block out of the quote",
+                    );
                     return Err(attach_slide_context(
                         err,
                         index,
@@ -1916,32 +2029,38 @@ fn parse_slide(
                         &fragments,
                     ));
                 }
-                list_depth -= 1;
-                if list_depth == 0 {
-                    if let Some(start) = list_start.take() {
-                        let fragment = SourceFragment::list(
-                            line_for_offset(source, start),
-                            source_slice(source, start, global_end),
-                        );
-                        if let Err(err) = push_checked_fragment(
-                            source,
-                            start,
-                            global_end,
-                            &markers,
-                            &mut fragments,
-                            &mut div_stack,
-                            fragment,
-                        ) {
-                            return Err(attach_slide_context(
-                                err,
-                                index,
-                                explicit_key.as_ref(),
-                                &fragments,
-                            ));
-                        }
-                        seen_content = true;
-                    }
-                }
+            }
+        }
+
+        if container
+            .last()
+            .is_some_and(|open| event_allowed_inside_container(open.kind, &event))
+        {
+            continue;
+        }
+
+        let line = line_for_offset(source, global_start);
+        match event {
+            Event::Rule => {
+                let err = if container
+                    .last()
+                    .is_some_and(|open| open.kind == ContainerKind::Blockquote)
+                {
+                    BuildError::new(
+                        ErrorKind::Parse,
+                        Some(line),
+                        "thematic break inside a blockquote",
+                        "end the quote before the separator",
+                    )
+                } else {
+                    unsupported_construct(line, "thematic break inside slide")
+                };
+                return Err(attach_slide_context(
+                    err,
+                    index,
+                    explicit_key.as_ref(),
+                    &fragments,
+                ));
             }
             Event::Html(html) | Event::InlineHtml(html) => {
                 if let Some((buf, _)) = html_buf.as_mut() {
@@ -1956,7 +2075,7 @@ fn parse_slide(
                         index,
                         &fragments,
                         &ctx,
-                        list_depth,
+                        container.len(),
                         seen_content,
                         &mut explicit_key,
                         &mut layout_request,
@@ -1979,8 +2098,9 @@ fn parse_slide(
                 ));
             }
             Event::Start(Tag::Image { dest_url, .. }) => {
-                if list_depth > 0 {
-                    let err = unsupported_construct(line, "image inside list");
+                if let Some(open) = container.last() {
+                    let err =
+                        unsupported_construct(line, &format!("image inside {}", open.kind.name()));
                     return Err(attach_slide_context(
                         err,
                         index,
@@ -2045,7 +2165,19 @@ fn parse_slide(
                     }
                 }
             }
-            _ if list_depth > 0 => {}
+            Event::Start(tag) if unsupported_tag(&tag) => {
+                let name = container.last().map_or_else(
+                    || unsupported_tag_name(&tag).to_owned(),
+                    |open| format!("{} inside {}", unsupported_tag_name(&tag), open.kind.name()),
+                );
+                let err = unsupported_construct(line, &name);
+                return Err(attach_slide_context(
+                    err,
+                    index,
+                    explicit_key.as_ref(),
+                    &fragments,
+                ));
+            }
             Event::Start(Tag::Heading { level, .. }) => {
                 block = Some(OpenBlock::Heading {
                     level: heading_level_to_u8(level),
@@ -2441,7 +2573,7 @@ fn parse_slide(
                         index,
                         &fragments,
                         &ctx,
-                        list_depth,
+                        container.len(),
                         seen_content,
                         &mut explicit_key,
                         &mut layout_request,
@@ -2453,15 +2585,6 @@ fn parse_slide(
                         &mut note_fragments,
                     )?;
                 }
-            }
-            Event::Start(tag) if unsupported_tag(&tag) => {
-                let err = unsupported_construct(line, unsupported_tag_name(&tag));
-                return Err(attach_slide_context(
-                    err,
-                    index,
-                    explicit_key.as_ref(),
-                    &fragments,
-                ));
             }
             Event::Start(Tag::Item)
             | Event::End(TagEnd::Item)
@@ -2658,7 +2781,7 @@ fn revealed_footnote_reference_range(
 ) -> Option<RevealedFootnoteReferenceRange> {
     let span = fragment.reveal_span()?;
     match fragment.kind() {
-        FragmentKind::Heading { .. } | FragmentKind::Paragraph => {
+        FragmentKind::Heading { .. } | FragmentKind::Paragraph | FragmentKind::Blockquote => {
             let (start_line, end_line) = fragment_line_range(fragment);
             Some(RevealedFootnoteReferenceRange::Fragment {
                 start_line,
@@ -2779,7 +2902,7 @@ fn process_html_chunk(
     index: usize,
     fragments: &[SourceFragment],
     explicit_key_ctx: &Option<(SlideKey, usize)>,
-    list_depth: usize,
+    block_container_depth: usize,
     seen_content: bool,
     explicit_key: &mut Option<(SlideKey, usize)>,
     layout_request: &mut Option<LayoutRequest>,
@@ -2793,7 +2916,7 @@ fn process_html_chunk(
     if let Some(settings) = parse_page_comment(raw, line)
         .map_err(|err| attach_slide_context(err, index, explicit_key_ctx.as_ref(), fragments))?
     {
-        if list_depth > 0 || seen_content {
+        if block_container_depth > 0 || seen_content {
             let err = BuildError::new(
                 ErrorKind::Parse,
                 Some(line),
@@ -3087,7 +3210,7 @@ fn unsupported_construct(line: usize, name: &str) -> BuildError {
         ErrorKind::Parse,
         Some(line),
         format!("unsupported construct '{name}'"),
-        "rewrite this slide using headings, paragraphs, lists, or fenced code blocks for milestone 1",
+        "rewrite this slide using headings, paragraphs, lists, blockquotes, or fenced code blocks",
     )
 }
 
@@ -3121,15 +3244,61 @@ fn unexpected_frontmatter_content_error(source: &str, offset: usize) -> BuildErr
 fn unsupported_tag(tag: &Tag<'_>) -> bool {
     matches!(
         tag,
-        Tag::BlockQuote(_) | Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell
+        Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell
     )
 }
 
 fn unsupported_tag_name(tag: &Tag<'_>) -> &'static str {
     match tag {
-        Tag::BlockQuote(_) => "blockquote",
         Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell => "table",
         _ => "markdown",
+    }
+}
+
+fn event_allowed_inside_container(kind: ContainerKind, event: &Event<'_>) -> bool {
+    let allowed_in_any_container = matches!(
+        event,
+        Event::Start(Tag::Heading { .. })
+            | Event::End(TagEnd::Heading(_))
+            | Event::Start(Tag::Paragraph)
+            | Event::End(TagEnd::Paragraph)
+            | Event::Start(Tag::Item)
+            | Event::End(TagEnd::Item)
+            | Event::Start(Tag::DefinitionList)
+            | Event::End(TagEnd::DefinitionList)
+            | Event::Start(Tag::DefinitionListTitle)
+            | Event::End(TagEnd::DefinitionListTitle)
+            | Event::Start(Tag::DefinitionListDefinition)
+            | Event::End(TagEnd::DefinitionListDefinition)
+            | Event::Start(Tag::Emphasis)
+            | Event::End(TagEnd::Emphasis)
+            | Event::Start(Tag::Strong)
+            | Event::End(TagEnd::Strong)
+            | Event::Start(Tag::Strikethrough)
+            | Event::End(TagEnd::Strikethrough)
+            | Event::Start(Tag::Superscript)
+            | Event::End(TagEnd::Superscript)
+            | Event::Start(Tag::Subscript)
+            | Event::End(TagEnd::Subscript)
+            | Event::Start(Tag::Link { .. })
+            | Event::End(TagEnd::Link)
+            | Event::Text(_)
+            | Event::Code(_)
+            | Event::InlineMath(_)
+            | Event::DisplayMath(_)
+            | Event::SoftBreak
+            | Event::HardBreak
+            | Event::TaskListMarker(_)
+    );
+    match kind {
+        ContainerKind::List => {
+            allowed_in_any_container
+                || matches!(
+                    event,
+                    Event::Start(Tag::CodeBlock(_)) | Event::End(TagEnd::CodeBlock)
+                )
+        }
+        ContainerKind::Blockquote => allowed_in_any_container,
     }
 }
 
@@ -4486,7 +4655,7 @@ After reveal.
             .contains("unsupported construct 'footnote definition inside list'"));
         assert_eq!(
             err.help,
-            "rewrite this slide using headings, paragraphs, lists, or fenced code blocks for milestone 1"
+            "rewrite this slide using headings, paragraphs, lists, blockquotes, or fenced code blocks"
         );
     }
 
@@ -5076,9 +5245,32 @@ After list
     }
 
     #[test]
-    fn rejects_unsupported_construct_with_line_and_help() {
+    fn parses_blockquotes_with_nested_content_and_explicit_slot_children() {
+        let deck = parse_markdown(
+            "# Title\n\n> First paragraph.\n>\n> Second paragraph.\n>\n> > Nested quote.\n\n::: {slot=body}\n\n> Slotted quote.\n\n:::\n",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+
+        assert_eq!(slide.fragments[1].kind(), &FragmentKind::Blockquote);
+        assert_eq!(slide.fragments[1].line(), 3);
+        assert_eq!(
+            slide.fragments[1].markdown(),
+            "> First paragraph.\n>\n> Second paragraph.\n>\n> > Nested quote."
+        );
+        let FragmentKind::SlotGroup { children, .. } = slide.fragments[2].kind() else {
+            panic!("expected explicit slot group");
+        };
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].kind(), &FragmentKind::Blockquote);
+        assert_eq!(children[0].markdown(), "> Slotted quote.");
+    }
+
+    #[test]
+    fn rejects_image_inside_blockquote_with_source_line() {
         let err = parse_markdown(
-            "# Title\n\n> quoted",
+            "# Title\n\n> ![Architecture](x.png)",
             &crate::highlight::Highlighter::defaults(),
         )
         .unwrap_err();
@@ -5087,17 +5279,205 @@ After list
         assert_eq!(err.line, Some(3));
         assert!(err
             .to_string()
-            .contains("unsupported construct 'blockquote'"));
+            .contains("unsupported construct 'image inside blockquote'"));
+    }
+
+    #[test]
+    fn rejects_footnote_definition_inside_blockquote_with_named_container() {
+        let err = parse_markdown(
+            "# Title\n\n> [^a]: quoted note",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert!(err
+            .to_string()
+            .contains("unsupported construct 'footnote definition inside blockquote'"));
+    }
+
+    #[test]
+    fn rejects_fenced_code_inside_blockquote_before_language_or_renderer_dispatch() {
+        for language in ["notalang", "mermaid", "rust"] {
+            let markdown = format!("# Title\n\n> ```{language}\n> value\n> ```");
+            let err =
+                parse_markdown(&markdown, &crate::highlight::Highlighter::defaults()).unwrap_err();
+
+            assert_eq!(err.kind, ErrorKind::Parse, "{language}");
+            assert_eq!(err.line, Some(3), "{language}");
+            assert!(
+                err.to_string().contains("code block inside a blockquote"),
+                "{language}: {err}"
+            );
+            assert_eq!(
+                err.help, "move the code block out of the quote",
+                "{language}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_language_fence_inside_blockquote_nested_in_list() {
+        let err = parse_markdown(
+            "# Title\n\n- > ```notalang\n  > value\n  > ```",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert!(
+            err.to_string().contains("code block inside a blockquote"),
+            "{err}"
+        );
+        assert_eq!(err.help, "move the code block out of the quote");
+    }
+
+    #[test]
+    fn rejects_thematic_break_inside_blockquote_nested_in_list() {
+        let err = parse_markdown(
+            "# Title\n\n- > Before.\n  >\n  > ---\n  >\n  > After.",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(5));
+        assert!(
+            err.to_string()
+                .contains("thematic break inside a blockquote"),
+            "{err}"
+        );
+        assert_eq!(err.help, "end the quote before the separator");
+    }
+
+    #[test]
+    fn rejects_image_inside_blockquote_nested_in_list_with_innermost_name() {
+        let err = parse_markdown(
+            "# Title\n\n- > ![Architecture](x.png)",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert!(
+            err.to_string()
+                .contains("unsupported construct 'image inside blockquote'"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn keeps_fenced_code_swallowing_for_list_nested_in_blockquote() {
+        let deck = parse_markdown(
+            "# Title\n\n> - ```notalang\n>   value\n>   ```",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .expect("list-context fenced code remains deferred to #437");
+        let slide = &deck.parsed_slides()[0];
+
+        assert_eq!(slide.fragments[1].kind(), &FragmentKind::Blockquote);
+    }
+
+    #[test]
+    fn rejects_thematic_break_inside_blockquote_with_actionable_help() {
+        let err = parse_markdown(
+            "# Title\n\n> Before.\n>\n> ---\n>\n> After.",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(5));
+        assert!(err
+            .to_string()
+            .contains("thematic break inside a blockquote"));
+        assert_eq!(err.help, "end the quote before the separator");
+    }
+
+    #[test]
+    fn rejects_table_inside_blockquote_with_named_container() {
+        let err = parse_markdown(
+            "# Title\n\n> | A | B |\n> | - | - |\n> | 1 | 2 |",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert!(err
+            .to_string()
+            .contains("unsupported construct 'table inside blockquote'"));
+    }
+
+    #[test]
+    fn rejects_table_inside_list_with_named_container() {
+        let err = parse_markdown(
+            "# Title\n\n- | A | B |\n  | - | - |\n  | 1 | 2 |",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert!(err
+            .to_string()
+            .contains("unsupported construct 'table inside list'"));
+    }
+
+    #[test]
+    fn reveal_blockquote_contributes_exactly_one_step() {
+        let deck = parse_markdown(
+            "# Title\n\n::: {reveal}\n\n> Quote.\n>\n> - nested one\n> - nested two\n\n:::\n",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+        let blockquote = &slide.fragments[1];
+
+        assert_eq!(blockquote.kind(), &FragmentKind::Blockquote);
+        assert_eq!(
+            blockquote.reveal_span(),
+            Some(RevealSpan { start: 1, len: 1 })
+        );
+        assert_eq!(slide.step_count, 1);
+    }
+
+    #[test]
+    fn unsupported_table_help_names_blockquotes_without_milestone_wording() {
+        let err = parse_markdown(
+            "# Title\n\n| A | B |\n| - | - |\n| 1 | 2 |",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
         assert_eq!(
             err.help,
-            "rewrite this slide using headings, paragraphs, lists, or fenced code blocks for milestone 1"
+            "rewrite this slide using headings, paragraphs, lists, blockquotes, or fenced code blocks"
         );
+        assert!(!err.help.contains("milestone 1"));
     }
 
     #[test]
     fn rejects_inline_html_inside_list_items() {
         let err = parse_markdown(
             "# Title\n\n- item <b>raw</b>",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert!(err.to_string().contains("unsupported construct 'html'"));
+    }
+
+    #[test]
+    fn rejects_multiline_non_comment_html_inside_blockquote() {
+        let err = parse_markdown(
+            "# Title\n\n> <div>\n> raw html\n> </div>",
             &crate::highlight::Highlighter::defaults(),
         )
         .unwrap_err();
@@ -6785,7 +7165,7 @@ After list
     #[test]
     fn unsupported_construct_after_delimiter_reports_global_line_and_slide() {
         let err = parse_markdown(
-            "# One\n\n---\n\n# Two\n\n> quote",
+            "# One\n\n---\n\n# Two\n\n| A | B |\n| - | - |\n| 1 | 2 |",
             &crate::highlight::Highlighter::defaults(),
         )
         .unwrap_err();
@@ -6793,9 +7173,7 @@ After list
         assert_eq!(err.kind, ErrorKind::Parse);
         assert_eq!(err.line, Some(7));
         assert!(err.to_string().contains("slide 2 ('two'), line 7"));
-        assert!(err
-            .to_string()
-            .contains("unsupported construct 'blockquote'"));
+        assert!(err.to_string().contains("unsupported construct 'table'"));
     }
 
     #[test]

--- a/crates/peitho-core/src/plain.rs
+++ b/crates/peitho-core/src/plain.rs
@@ -27,7 +27,7 @@ pub(crate) fn slide_text<S>(slide: &CheckedSlide<S>) -> ManifestSlideText {
                         FragmentKind::Heading { .. } | FragmentKind::Text => {
                             fragment.plain_text().to_owned()
                         }
-                        FragmentKind::Paragraph | FragmentKind::List => {
+                        FragmentKind::Paragraph | FragmentKind::List | FragmentKind::Blockquote => {
                             body_fragment_text(fragment.markdown())
                         }
                         FragmentKind::Math { .. } => fragment.code_text().trim_end().to_owned(),
@@ -68,6 +68,7 @@ pub(crate) fn slide_text<S>(slide: &CheckedSlide<S>) -> ManifestSlideText {
 fn body_fragment_text(markdown: &str) -> String {
     let mut text = String::new();
     let mut in_image = false;
+    let mut blockquote_depth = 0usize;
 
     for event in Parser::new_ext(markdown, BODY_MARKDOWN_OPTIONS) {
         match event {
@@ -75,8 +76,13 @@ fn body_fragment_text(markdown: &str) -> String {
             Event::End(TagEnd::Image) => in_image = false,
             _ if in_image => {}
             Event::FootnoteReference(_) => {}
-            Event::Start(Tag::Item) if !text.is_empty() && !text.ends_with('\n') => {
-                text.push('\n');
+            Event::Start(Tag::BlockQuote(_kind)) => blockquote_depth += 1,
+            Event::End(TagEnd::BlockQuote(_kind)) => {
+                blockquote_depth = blockquote_depth.saturating_sub(1);
+            }
+            Event::Start(Tag::Item) => push_block_separator(&mut text),
+            Event::Start(Tag::Paragraph) if blockquote_depth > 0 => {
+                push_block_separator(&mut text);
             }
             Event::Text(value) | Event::Code(value) => text.push_str(&value),
             Event::SoftBreak | Event::HardBreak
@@ -90,6 +96,12 @@ fn body_fragment_text(markdown: &str) -> String {
     }
 
     text
+}
+
+fn push_block_separator(text: &mut String) {
+    if !text.is_empty() && !text.ends_with('\n') {
+        text.push('\n');
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +168,19 @@ mod tests {
         let text = checked_slide_text("# Title\n\n- item1\n- item2");
 
         assert_eq!(text.body(), "item1\nitem2");
+    }
+
+    #[test]
+    fn manifest_body_text_contains_blockquote_text_without_markers() {
+        let text = checked_slide_text(
+            "# Title\n\n> First **quoted** paragraph.\n>\n> Second paragraph with `code`.",
+        );
+
+        assert_eq!(
+            text.body(),
+            "First quoted paragraph.\nSecond paragraph with code."
+        );
+        assert!(!text.body().contains('>'));
     }
 
     #[test]

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -503,7 +503,8 @@ fn render_block_slot(
             FragmentKind::Heading { .. }
             | FragmentKind::Paragraph
             | FragmentKind::Text
-            | FragmentKind::List => markdown_run.push(fragment.markdown()),
+            | FragmentKind::List
+            | FragmentKind::Blockquote => markdown_run.push(fragment.markdown()),
             FragmentKind::Code | FragmentKind::Image { .. } | FragmentKind::SlotGroup { .. } => {
                 unreachable!("validated by contract guard")
             }
@@ -600,6 +601,14 @@ fn render_revealed_fragment(
             breaks,
             footnote_numbers,
         ),
+        FragmentKind::Blockquote => render_revealed_markdown_root(
+            body,
+            fragment,
+            RevealedMarkdownRoot::Blockquote,
+            span.start,
+            breaks,
+            footnote_numbers,
+        ),
         FragmentKind::Text => unreachable!("revealed Text fragments are not renderable"),
         FragmentKind::Code => {
             let code = render_code_fragment(fragment, highlighter)?;
@@ -688,6 +697,7 @@ fn render_revealed_fragment(
 enum RevealedMarkdownRoot {
     Heading,
     Paragraph,
+    Blockquote,
 }
 
 fn render_revealed_markdown_root(
@@ -700,6 +710,7 @@ fn render_revealed_markdown_root(
 ) -> Result<()> {
     let mut events = Vec::new();
     let mut stamped = false;
+    let mut in_html_comment = false;
     for event in Parser::new_ext(fragment.markdown(), BODY_MARKDOWN_OPTIONS) {
         let event = match (root, stamped, event) {
             (
@@ -722,14 +733,23 @@ fn render_revealed_markdown_root(
                 stamped = true;
                 Event::Html(format!(r#"<p data-reveal-step="{step}">"#).into())
             }
+            (RevealedMarkdownRoot::Blockquote, false, Event::Start(Tag::BlockQuote(_kind))) => {
+                stamped = true;
+                Event::Html(format!(r#"<blockquote data-reveal-step="{step}">"#).into())
+            }
             (_, _, event) => event,
         };
-        events.push(normalize_markdown_event(event, breaks, footnote_numbers)?);
+        if let Some(event) =
+            normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
+        {
+            events.push(event);
+        }
     }
     if !stamped {
         let label = match root {
             RevealedMarkdownRoot::Heading => "heading",
             RevealedMarkdownRoot::Paragraph => "paragraph",
+            RevealedMarkdownRoot::Blockquote => "blockquote",
         };
         unreachable!("revealed {label} fragment produced no {label} root");
     }
@@ -747,6 +767,7 @@ fn render_revealed_list_fragment(
     let mut raw_events = Vec::new();
     let mut events = Vec::new();
     let mut top_level_item_index = 0usize;
+    let mut in_html_comment = false;
     walk_body_markdown_list_items(fragment.markdown(), |event, top_level_item| {
         if top_level_item {
             let step = span.start + top_level_item_index;
@@ -765,7 +786,11 @@ fn render_revealed_list_fragment(
         );
     }
     for event in raw_events {
-        events.push(normalize_markdown_event(event, breaks, footnote_numbers)?);
+        if let Some(event) =
+            normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
+        {
+            events.push(event);
+        }
     }
     html::push_html(body, events.into_iter());
     Ok(())
@@ -815,8 +840,13 @@ fn render_markdown_run(
     }
     let markdown = markdown_run.join("\n\n");
     let mut events = Vec::new();
+    let mut in_html_comment = false;
     for event in Parser::new_ext(&markdown, BODY_MARKDOWN_OPTIONS) {
-        events.push(normalize_markdown_event(event, breaks, footnote_numbers)?);
+        if let Some(event) =
+            normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
+        {
+            events.push(event);
+        }
     }
     html::push_html(body, events.into_iter());
     Ok(())
@@ -826,7 +856,11 @@ fn normalize_markdown_event<'a>(
     event: Event<'a>,
     breaks: bool,
     footnote_numbers: &BTreeMap<String, usize>,
-) -> Result<Event<'a>> {
+    in_html_comment: &mut bool,
+) -> Result<Option<Event<'a>>> {
+    if drop_html_comment_event(&event, in_html_comment) {
+        return Ok(None);
+    }
     let event = match (breaks, event) {
         (true, Event::SoftBreak) => Event::HardBreak,
         (_, event) => event,
@@ -836,7 +870,7 @@ fn normalize_markdown_event<'a>(
             let Some(number) = footnote_numbers.get(label.as_ref()).copied() else {
                 return Err(missing_footnote_render_error(label.as_ref()));
             };
-            Ok(Event::Html(render_footnote_reference(number).into()))
+            Ok(Some(Event::Html(render_footnote_reference(number).into())))
         }
         Event::Start(Tag::FootnoteDefinition(label)) => {
             Err(unexpected_footnote_definition_render_error(label.as_ref()))
@@ -844,8 +878,33 @@ fn normalize_markdown_event<'a>(
         Event::End(TagEnd::FootnoteDefinition) => {
             Err(unexpected_footnote_definition_render_error(""))
         }
-        event => Ok(event),
+        event => Ok(Some(event)),
     }
+}
+
+fn drop_html_comment_event(event: &Event<'_>, in_html_comment: &mut bool) -> bool {
+    let raw = if let Event::Html(raw) = event {
+        Some(raw.as_ref())
+    } else if let Event::InlineHtml(raw) = event {
+        Some(raw.as_ref())
+    } else {
+        None
+    };
+    let Some(raw) = raw else {
+        return false;
+    };
+
+    if *in_html_comment {
+        if raw.contains("-->") {
+            *in_html_comment = false;
+        }
+        return true;
+    }
+    if !raw.trim_start().starts_with("<!--") {
+        return false;
+    }
+    *in_html_comment = !raw.contains("-->");
+    true
 }
 
 fn render_heading_inline_fragment(
@@ -966,6 +1025,7 @@ fn render_image_fragment_inner(
         | FragmentKind::GenericEmbedCard { .. }
         | FragmentKind::Footnotes { .. }
         | FragmentKind::List
+        | FragmentKind::Blockquote
         | FragmentKind::SlotGroup { .. } => unreachable!("validated by contract guard"),
     }
 }
@@ -1004,6 +1064,7 @@ fn accepts_fragment(accepts: Accepts, fragment: &SourceFragment<ResolvedImagePat
             | (Accepts::Blocks, FragmentKind::Heading { .. })
             | (Accepts::Blocks, FragmentKind::Paragraph)
             | (Accepts::Blocks, FragmentKind::List)
+            | (Accepts::Blocks, FragmentKind::Blockquote)
             | (Accepts::Blocks, FragmentKind::Math { .. })
             | (Accepts::Blocks, FragmentKind::EmbedCard { .. })
             | (Accepts::Blocks, FragmentKind::GenericEmbedCard { .. })
@@ -2129,6 +2190,106 @@ mod tests {
             "{html}"
         );
         assert!(!html.contains("~~deleted~~"), "{html}");
+    }
+
+    #[test]
+    fn renders_blockquotes_with_nested_blocks_and_inline_markup() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n> Quoted *emphasis* and ~~deleted~~.\n>\n> - nested item\n>\n> > nested quote\n",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert_eq!(html.matches("<blockquote>").count(), 2, "{html}");
+        assert!(
+            html.contains("<p>Quoted <em>emphasis</em> and <del>deleted</del>.</p>"),
+            "{html}"
+        );
+        assert!(html.contains("<ul>\n<li>nested item</li>\n</ul>"), "{html}");
+        assert!(html.contains("<p>nested quote</p>"), "{html}");
+    }
+
+    #[test]
+    fn renders_gfm_alert_marker_literally_as_quote_text() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n::: {reveal}\n\n> [!NOTE]\n> Alert body.\n\n:::\n",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains(r#"data-reveal-steps="1""#), "{html}");
+        assert!(
+            html.contains(r#"<blockquote data-reveal-step="1">"#),
+            "{html}"
+        );
+        assert!(html.contains("[!NOTE]"), "{html}");
+        assert!(!html.contains("markdown-alert-"), "{html}");
+    }
+
+    #[test]
+    fn blockquote_comment_is_collected_as_notes_but_not_rendered() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n::: {reveal}\n\n> Visible quote.\n>\n> <!-- blockquote speaker secret -->\n\n:::",
+            title_body_layout(),
+        );
+        let slide = &rendered.slides()[0];
+
+        assert_eq!(slide.notes(), Some("blockquote speaker secret"));
+        assert!(slide.html().contains("Visible quote."), "{}", slide.html());
+        assert!(
+            !slide.html().contains("blockquote speaker secret"),
+            "{}",
+            slide.html()
+        );
+    }
+
+    #[test]
+    fn multiline_blockquote_comment_is_collected_as_joined_note_but_not_rendered() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n> Visible quote.\n>\n> <!--\n> blockquote speaker\n> secret\n> -->",
+            title_body_layout(),
+        );
+        let slide = &rendered.slides()[0];
+
+        assert_eq!(slide.notes(), Some("blockquote speaker\nsecret"));
+        assert!(slide.html().contains("Visible quote."), "{}", slide.html());
+        assert!(
+            !slide.html().contains("blockquote speaker"),
+            "{}",
+            slide.html()
+        );
+        assert!(!slide.html().contains("secret"), "{}", slide.html());
+    }
+
+    #[test]
+    fn list_comment_is_collected_as_notes_but_not_rendered() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n- Visible item.\n  <!-- list speaker secret -->",
+            title_body_layout(),
+        );
+        let slide = &rendered.slides()[0];
+
+        assert_eq!(slide.notes(), Some("list speaker secret"));
+        assert!(slide.html().contains("Visible item."), "{}", slide.html());
+        assert!(
+            !slide.html().contains("list speaker secret"),
+            "{}",
+            slide.html()
+        );
+    }
+
+    #[test]
+    fn multiline_list_comment_is_collected_as_joined_note_but_not_rendered() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n- Visible item.\n  <!--\n  list speaker\n  secret\n  -->",
+            title_body_layout(),
+        );
+        let slide = &rendered.slides()[0];
+
+        assert_eq!(slide.notes(), Some("list speaker\nsecret"));
+        assert!(slide.html().contains("Visible item."), "{}", slide.html());
+        assert!(!slide.html().contains("list speaker"), "{}", slide.html());
+        assert!(!slide.html().contains("secret"), "{}", slide.html());
     }
 
     #[test]

--- a/docs/plans/2026-08-16-blockquote-support.md
+++ b/docs/plans/2026-08-16-blockquote-support.md
@@ -1,0 +1,98 @@
+# Blockquote support in slide bodies (Issue #424)
+
+Date: 2026-08-16
+Issue: #424
+
+## Problem
+
+`>` blockquotes fail the build with `unsupported construct 'blockquote'`
+(help still says "for milestone 1"). Quoting other material is a common
+slide need with real-world demand (deck-writing report, 2026-08-16).
+
+## Design
+
+Blockquotes become a first-class block fragment, mirroring how `List`
+works today: `FragmentKind::Blockquote` (unit variant), the fragment's
+markdown slice carries the source, and rendering re-parses that slice with
+`BODY_MARKDOWN_OPTIONS` through the existing `push_html` path — so inline
+content (emphasis, strong, strikethrough, links, code spans, footnote
+references) and nested block content (paragraphs, lists, nested quotes,
+fenced code) work without new rendering machinery.
+
+- **Parser**: `Tag::BlockQuote` leaves the unsupported list. The walk
+  tracks blockquote depth like it tracks lists; inner constructs are
+  validated with the same rules as inside lists — images inside a
+  blockquote are a line-numbered error (images route to image slots),
+  tables stay `unsupported construct 'table'` (until #425), footnote
+  *definitions* inside a quote stay rejected as today, inline/HTML events
+  keep their existing handling. No arm becomes `_ => {}`.
+- **Mapping / check**: convention mapping routes blockquotes to the body
+  (blocks) slot. `Accepts::Blocks` accepts `Blockquote`; every other
+  accepts kind rejects it with the existing named-error shape.
+- **Reveal**: a top-level blockquote inside `::: {reveal}` is one step,
+  falling out of the existing fragment-level span behavior (lists keep
+  their per-item steps; blockquotes are not lists).
+- **Plain text / manifest / keys**: `plain.rs` collects the quote's inner
+  text through the existing event walk (BlockQuote tags fall through, text
+  events accumulate) — verify with a test.
+- **Error text**: `unsupported_construct`'s help drops the stale "for
+  milestone 1" and now reads
+  "rewrite this slide using headings, paragraphs, lists, blockquotes, or
+  fenced code blocks" (table keeps pointing at this help until #425).
+- **Theme**: `themes/base.css` gains a modest blockquote rule (left
+  border + muted foreground, spacing consistent with existing vars); the
+  example copy `examples/footnotes/css/base.css` mirrors it if that file
+  is a verbatim theme copy.
+
+## Tests (TDD order)
+
+1. Parse: `> quoted` produces a `Blockquote` fragment with the source
+   markdown; multi-paragraph and nested quotes parse.
+2. Render: `<blockquote>` with inner `<p>`; nested list and fenced code
+   inside a quote render; strikethrough/emphasis inside a quote render.
+3. Image inside a blockquote → line-numbered error naming the construct.
+4. Table inside a blockquote → still `unsupported construct 'table'`.
+5. Check: blockquote mapped to a non-blocks slot (e.g. explicit slot with
+   accepts="inline") is a check error.
+6. Reveal: a blockquote inside `::: {reveal}` contributes exactly one step.
+7. Plain text: manifest body text contains the quote's inner text without
+   `>` markers.
+8. Help text: unsupported-table error carries the new help wording (no
+   "milestone 1").
+
+## Non-goals
+
+- Table support (#425).
+- Attribution/citation syntax (`<cite>`), callout/admonition styling.
+
+## Amendments (2026-08-17, after adversarial review)
+
+- **Fenced code inside a blockquote is a line-numbered build error** for v1
+  ("move the code block out of the quote"). The first cut swallowed it into
+  the quote's markdown, bypassing unknown-language validation, syntect
+  highlighting, emphasis errors, and code_images dispatch — silent behavior
+  the project forbids. Lists have the same pre-existing gap; that sibling
+  stays untouched here (it pre-exists on main independent of this feature)
+  and gets its own issue covering both containers uniformly.
+- **HTML comments inside container fragments no longer leak into rendered
+  HTML.** A comment inside a blockquote (or list — same pre-existing bug)
+  was collected as a speaker note AND kept in the fragment markdown, so the
+  note text shipped in dist/, violating the notes-never-enter-dist
+  invariant. Fixed once at the render seam: comment HTML events are dropped
+  when container markdown is re-rendered. Covered for both containers.
+- **No GFM alert processing.** The first cut enabled the GFM blockquote
+  extension, which consumed `[!NOTE]` markers and stamped `markdown-alert-*`
+  classes no CSS defines — the marker text silently vanished. Admonitions
+  stay a non-goal: without the extension the marker renders literally,
+  which is visible and honest.
+- **Thematic break inside a blockquote is a named error** ("thematic break
+  inside a blockquote"), not the misleading "thematic break inside slide"
+  whose help recommends blockquotes.
+- **Tables inside list items become hard errors** (previously silently
+  rendered as literal pipe text). Accepted: #425 lands real table support in
+  the same release, so the intermediate state never ships.
+- **Container tracking is one seam**: a single container-state
+  (kind + depth + start) with one shared close-container path, instead of
+  parallel list/blockquote copies of the guard and close logic.
+- Plain-text extraction inserts separators at block boundaries inside a
+  quote (consecutive quoted paragraphs no longer concatenate).

--- a/examples/footnotes/css/base.css
+++ b/examples/footnotes/css/base.css
@@ -87,6 +87,17 @@
   margin: 0 0 24px;
 }
 
+.slot-body blockquote {
+  margin: 0 0 var(--peitho-blockquote-spacing, 24px);
+  padding-left: var(--peitho-blockquote-spacing, 24px);
+  border-left: 4px solid var(--peitho-blockquote-border-color, #8a8578);
+  color: var(--peitho-blockquote-color, #8a8578);
+}
+
+.slot-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
 .slot-body ul {
   margin: 0;
   padding-left: 34px;

--- a/themes/base.css
+++ b/themes/base.css
@@ -87,6 +87,17 @@
   margin: 0 0 24px;
 }
 
+.slot-body blockquote {
+  margin: 0 0 var(--peitho-blockquote-spacing, 24px);
+  padding-left: var(--peitho-blockquote-spacing, 24px);
+  border-left: 4px solid var(--peitho-blockquote-border-color, #8a8578);
+  color: var(--peitho-blockquote-color, #8a8578);
+}
+
+.slot-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
 .slot-body ul {
   margin: 0;
   padding-left: 34px;


### PR DESCRIPTION
Closes #424

## What

`>` quotes were `unsupported construct 'blockquote'` (help still said "for milestone 1"). Blockquotes become a first-class block fragment mirroring `List`: the fragment's markdown re-renders through the existing `push_html` path, so inline markup (emphasis/strong/strikethrough/links/code spans/footnote refs), nested lists, and nested quotes work with no new rendering machinery. Convention mapping routes quotes to body; `Accepts::Blocks` accepts them; a modest themeable rule lands in the base theme.

## Loud boundaries (all line-numbered, per pillar ③)

- **Fenced code inside a quote is an error** — it would ride the quote's markdown and bypass unknown-language validation, syntect, and code_images dispatch entirely (measured: `> ```notalang` built clean in the first cut). The pre-existing list-side sibling gap is tracked in #437.
- Thematic break / image / table / footnote definition inside a quote are named errors ("… inside a blockquote").
- GFM `[!NOTE]` markers render **literally** — the first cut enabled the GFM extension, which consumed the marker and stamped `markdown-alert-*` classes no CSS defines (the marker text silently vanished). Admonitions stay a non-goal.
- The stale "for milestone 1" help wording is gone.

## Fixes riding along (same seams)

- **Container tracking is a stack** (`ContainerKind` per open container): the first cut froze the kind at the outermost container, so a quote nested in a list silently bypassed every quote-specific check (adversarial review caught it; nested shapes are now regression-tested in both directions, with the list-side deferral boundary pinned explicitly).
- **HTML comments inside containers no longer leak into dist/**: a comment inside a list (pre-existing) or quote was collected as a speaker note AND rendered into slide HTML — violating "notes never enter dist". Comment events are dropped once at the container render seam; multi-line comments now buffer inside containers like at top level.
- Manifest plain text separates quoted blocks (`> First.` / `> Second.` no longer concatenate).

## Known intermediate state

Tables inside list items are now hard errors (previously rendered as literal pipe text). #425 lands real table support in the same release, so this state never ships to users.

## Verification

- `cargo test --workspace` ×3 green (907 core tests), clippy `-D warnings`, fmt, bindings/dist drift, npm gates.
- Review: 8-angle code review (10 findings — all fixed or explicitly decided above) + 2 verification rounds with E2E builds: rendering shapes, all error paths with line attribution, notes-vs-dist for both containers, reveal/explicit-slot integration, all 19 examples build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV