### PR TITLE
Support Markdown tables in slide bodies

### DIFF
--- a/crates/peitho-core/src/check.rs
+++ b/crates/peitho-core/src/check.rs
@@ -119,6 +119,7 @@ fn accepts_fragment(accepts: Accepts, fragment: &SourceFragment) -> bool {
             | (Accepts::Blocks, FragmentKind::Paragraph)
             | (Accepts::Blocks, FragmentKind::List)
             | (Accepts::Blocks, FragmentKind::Blockquote)
+            | (Accepts::Blocks, FragmentKind::Table)
             | (Accepts::Blocks, FragmentKind::Math { .. })
             | (Accepts::Blocks, FragmentKind::EmbedCard { .. })
             | (Accepts::Blocks, FragmentKind::GenericEmbedCard { .. })
@@ -441,6 +442,34 @@ mod tests {
             err.message,
             "slot 'body' accepts inline, but got blockquote"
         );
+        assert_eq!(
+            err.help,
+            "change the layout accepts to 'blocks' or move this content to a blocks slot"
+        );
+    }
+
+    #[test]
+    fn rejects_table_in_explicit_inline_slot_with_named_contract_error() {
+        let layout = parse_layout(
+            "inline-body",
+            r#"<section><slot name="body" accepts="inline" arity="1"></slot></section>"#,
+        )
+        .unwrap();
+        let mapped = map_by_convention(
+            parse_markdown(
+                "::: {slot=body}\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\n:::\n",
+                &crate::highlight::Highlighter::defaults(),
+            )
+            .unwrap(),
+            &layout,
+        )
+        .unwrap();
+
+        let err = check_deck(mapped).unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Accepts);
+        assert_eq!(err.line, Some(3));
+        assert_eq!(err.message, "slot 'body' accepts inline, but got table");
         assert_eq!(
             err.help,
             "change the layout accepts to 'blocks' or move this content to a blocks slot"

--- a/crates/peitho-core/src/code_images.rs
+++ b/crates/peitho-core/src/code_images.rs
@@ -564,7 +564,8 @@ fn transform_fragment<S: SvgRunner, E: EmbedRenderer, F: OEmbedFetcher>(
             | FragmentKind::Footnotes { .. }
             | FragmentKind::Image { .. }
             | FragmentKind::List
-            | FragmentKind::Blockquote => Ok(fragment),
+            | FragmentKind::Blockquote
+            | FragmentKind::Table => Ok(fragment),
         }
     })()?;
 

--- a/crates/peitho-core/src/domain.rs
+++ b/crates/peitho-core/src/domain.rs
@@ -710,6 +710,7 @@ pub enum FragmentKind<S = RawImagePath> {
     },
     List,
     Blockquote,
+    Table,
     /// A `::: {slot=name}` fenced block. Mapping expands the children into
     /// the named slot; SlotGroup itself never leaves the Mapped phase.
     SlotGroup {
@@ -743,6 +744,7 @@ impl<S> FragmentKind<S> {
             Self::Image { .. } => Accepts::Image,
             Self::List => Accepts::List,
             Self::Blockquote => Accepts::Blocks,
+            Self::Table => Accepts::Blocks,
             // SlotGroup is expanded in mapping, so its own accepts value never
             // reaches contract checks. Report a conservative blocks default so
             // any accidental reader gets a stable answer instead of unreachable!.
@@ -763,6 +765,7 @@ impl<S> FragmentKind<S> {
             Self::Image { .. } => "image",
             Self::List => "list",
             Self::Blockquote => "blockquote",
+            Self::Table => "table",
             Self::SlotGroup { .. } => "slot group",
         }
     }
@@ -782,6 +785,7 @@ impl<S> fmt::Display for FragmentKind<S> {
             Self::Image { .. } => "image",
             Self::List => "list",
             Self::Blockquote => "blockquote",
+            Self::Table => "table",
             Self::SlotGroup { .. } => "slot group",
         })
     }
@@ -852,6 +856,20 @@ impl SourceFragment<RawImagePath> {
         Self {
             line,
             kind: FragmentKind::Blockquote,
+            reveal_span: None,
+            emphasis: None,
+            embed_options: None,
+            markdown: markdown.into(),
+            text: String::new(),
+            code: String::new(),
+            language: None,
+        }
+    }
+
+    pub fn table(line: usize, markdown: impl Into<String>) -> Self {
+        Self {
+            line,
+            kind: FragmentKind::Table,
             reveal_span: None,
             emphasis: None,
             embed_options: None,
@@ -1078,6 +1096,7 @@ impl<S> SourceFragment<S> {
             FragmentKind::Image { alt, src } => FragmentKind::Image { alt, src: f(src)? },
             FragmentKind::List => FragmentKind::List,
             FragmentKind::Blockquote => FragmentKind::Blockquote,
+            FragmentKind::Table => FragmentKind::Table,
             FragmentKind::SlotGroup { name, children } => {
                 let mut mapped_children = Vec::with_capacity(children.len());
                 for child in children {

--- a/crates/peitho-core/src/include.rs
+++ b/crates/peitho-core/src/include.rs
@@ -1167,8 +1167,7 @@ mod tests {
 ---
 # After
 
-| unsupported |
-| --- |
+<div>unsupported</div>
 ";
 
         let expanded = expand_includes(source, 0, &deck).unwrap();

--- a/crates/peitho-core/src/mapping.rs
+++ b/crates/peitho-core/src/mapping.rs
@@ -316,6 +316,7 @@ fn map_slide(slide: &ParsedSlide, layout: &Layout) -> Result<MappedSlide> {
             | FragmentKind::GenericEmbedCard { .. }
             | FragmentKind::List
             | FragmentKind::Blockquote
+            | FragmentKind::Table
             | FragmentKind::Text => {
                 SlotName::new("body").expect("conventional slot names are valid")
             }
@@ -412,6 +413,7 @@ fn shallowest_heading_line(fragments: &[SourceFragment]) -> Option<usize> {
             | FragmentKind::Image { .. }
             | FragmentKind::List
             | FragmentKind::Blockquote
+            | FragmentKind::Table
             | FragmentKind::SlotGroup { .. } => None,
         })
         .min_by_key(|(level, line)| (*level, *line))

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -236,6 +236,7 @@ enum OpenBlock {
 enum ContainerKind {
     List,
     Blockquote,
+    Table,
 }
 
 impl ContainerKind {
@@ -243,6 +244,7 @@ impl ContainerKind {
         match self {
             Self::List => "list",
             Self::Blockquote => "blockquote",
+            Self::Table => "table",
         }
     }
 }
@@ -1790,6 +1792,7 @@ fn close_container(
     let fragment = match open.kind {
         ContainerKind::List => SourceFragment::list(line, markdown),
         ContainerKind::Blockquote => SourceFragment::blockquote(line, markdown),
+        ContainerKind::Table => SourceFragment::table(line, markdown),
     };
     Ok(Some((open.start, fragment)))
 }
@@ -1974,6 +1977,8 @@ fn parse_slide(
             Some(ContainerKind::List)
         } else if let Event::Start(Tag::BlockQuote(_kind)) = &event {
             Some(ContainerKind::Blockquote)
+        } else if let Event::Start(Tag::Table(_alignments)) = &event {
+            Some(ContainerKind::Table)
         } else {
             None
         };
@@ -1986,6 +1991,8 @@ fn parse_slide(
             Some(ContainerKind::List)
         } else if let Event::End(TagEnd::BlockQuote(_kind)) = &event {
             Some(ContainerKind::Blockquote)
+        } else if let Event::End(TagEnd::Table) = &event {
+            Some(ContainerKind::Table)
         } else {
             None
         };
@@ -2164,19 +2171,6 @@ fn parse_slide(
                         ));
                     }
                 }
-            }
-            Event::Start(tag) if unsupported_tag(&tag) => {
-                let name = container.last().map_or_else(
-                    || unsupported_tag_name(&tag).to_owned(),
-                    |open| format!("{} inside {}", unsupported_tag_name(&tag), open.kind.name()),
-                );
-                let err = unsupported_construct(line, &name);
-                return Err(attach_slide_context(
-                    err,
-                    index,
-                    explicit_key.as_ref(),
-                    &fragments,
-                ));
             }
             Event::Start(Tag::Heading { level, .. }) => {
                 block = Some(OpenBlock::Heading {
@@ -2559,7 +2553,7 @@ fn parse_slide(
                         }
                     }
                 }
-                _ => {}
+                Some(OpenBlock::Heading { .. }) | None => {}
             },
             Event::Start(Tag::HtmlBlock) => {
                 html_buf = Some((String::new(), line));
@@ -2781,7 +2775,10 @@ fn revealed_footnote_reference_range(
 ) -> Option<RevealedFootnoteReferenceRange> {
     let span = fragment.reveal_span()?;
     match fragment.kind() {
-        FragmentKind::Heading { .. } | FragmentKind::Paragraph | FragmentKind::Blockquote => {
+        FragmentKind::Heading { .. }
+        | FragmentKind::Paragraph
+        | FragmentKind::Blockquote
+        | FragmentKind::Table => {
             let (start_line, end_line) = fragment_line_range(fragment);
             Some(RevealedFootnoteReferenceRange::Fragment {
                 start_line,
@@ -3210,7 +3207,7 @@ fn unsupported_construct(line: usize, name: &str) -> BuildError {
         ErrorKind::Parse,
         Some(line),
         format!("unsupported construct '{name}'"),
-        "rewrite this slide using headings, paragraphs, lists, blockquotes, or fenced code blocks",
+        "rewrite this slide using headings, paragraphs, lists, blockquotes, tables, or fenced code blocks",
     )
 }
 
@@ -3241,21 +3238,20 @@ fn unexpected_frontmatter_content_error(source: &str, offset: usize) -> BuildErr
     )
 }
 
-fn unsupported_tag(tag: &Tag<'_>) -> bool {
-    matches!(
-        tag,
-        Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell
-    )
-}
-
-fn unsupported_tag_name(tag: &Tag<'_>) -> &'static str {
-    match tag {
-        Tag::Table(_) | Tag::TableHead | Tag::TableRow | Tag::TableCell => "table",
-        _ => "markdown",
-    }
-}
-
 fn event_allowed_inside_container(kind: ContainerKind, event: &Event<'_>) -> bool {
+    let table_structure_event = matches!(
+        event,
+        Event::Start(Tag::TableHead)
+            | Event::End(TagEnd::TableHead)
+            | Event::Start(Tag::TableRow)
+            | Event::End(TagEnd::TableRow)
+            | Event::Start(Tag::TableCell)
+            | Event::End(TagEnd::TableCell)
+    );
+    if table_structure_event && kind != ContainerKind::Table {
+        return false;
+    }
+
     let allowed_in_any_container = matches!(
         event,
         Event::Start(Tag::Heading { .. })
@@ -3289,6 +3285,12 @@ fn event_allowed_inside_container(kind: ContainerKind, event: &Event<'_>) -> boo
             | Event::SoftBreak
             | Event::HardBreak
             | Event::TaskListMarker(_)
+            | Event::Start(Tag::TableHead)
+            | Event::End(TagEnd::TableHead)
+            | Event::Start(Tag::TableRow)
+            | Event::End(TagEnd::TableRow)
+            | Event::Start(Tag::TableCell)
+            | Event::End(TagEnd::TableCell)
     );
     match kind {
         ContainerKind::List => {
@@ -3298,7 +3300,7 @@ fn event_allowed_inside_container(kind: ContainerKind, event: &Event<'_>) -> boo
                     Event::Start(Tag::CodeBlock(_)) | Event::End(TagEnd::CodeBlock)
                 )
         }
-        ContainerKind::Blockquote => allowed_in_any_container,
+        ContainerKind::Blockquote | ContainerKind::Table => allowed_in_any_container,
     }
 }
 
@@ -3306,6 +3308,9 @@ fn event_name(event: &Event<'_>) -> &'static str {
     match event {
         Event::Rule => "thematic break",
         Event::TaskListMarker(_) => "task list marker",
+        Event::Start(Tag::TableHead) | Event::End(TagEnd::TableHead) => "table head outside table",
+        Event::Start(Tag::TableRow) | Event::End(TagEnd::TableRow) => "table row outside table",
+        Event::Start(Tag::TableCell) | Event::End(TagEnd::TableCell) => "table cell outside table",
         _ => "markdown",
     }
 }
@@ -4323,6 +4328,59 @@ enum Phase { Parsed, Mapped, Checked }
     }
 
     #[test]
+    fn parses_pipe_table_as_table_fragment_with_source_markdown() {
+        let table_markdown = "| Name | Score |\n| :--- | ---: |\n| Ada | 10 |";
+        let markdown = format!("# Title\n\n{table_markdown}");
+
+        let deck = parse_markdown(&markdown, &crate::highlight::Highlighter::defaults()).unwrap();
+        let table = &deck.parsed_slides()[0].fragments[1];
+
+        assert_eq!(table.kind(), &FragmentKind::Table);
+        assert_eq!(table.line(), 3);
+        assert_eq!(table.markdown(), table_markdown);
+    }
+
+    #[test]
+    fn absorbs_prose_without_blank_line_after_table_as_table_row() {
+        let table_markdown = "| A | B |\n| - | - |\n| 1 | 2 |\nFollowing prose";
+        let markdown = format!("# Title\n\n{table_markdown}");
+
+        let deck = parse_markdown(&markdown, &crate::highlight::Highlighter::defaults()).unwrap();
+        let slide = &deck.parsed_slides()[0];
+        let table = &slide.fragments[1];
+        let body_rows = Parser::new_ext(table.markdown(), parser_options())
+            .filter(|event| matches!(event, Event::Start(Tag::TableRow)))
+            .count();
+
+        assert_eq!(slide.fragments.len(), 2);
+        assert_eq!(table.kind(), &FragmentKind::Table);
+        assert_eq!(table.markdown(), table_markdown);
+        assert_eq!(body_rows, 2);
+    }
+
+    #[test]
+    fn stray_table_structure_events_are_named_and_rejected_outside_tables() {
+        let events = [
+            (Event::Start(Tag::TableHead), "table head outside table"),
+            (Event::End(TagEnd::TableHead), "table head outside table"),
+            (Event::Start(Tag::TableRow), "table row outside table"),
+            (Event::End(TagEnd::TableRow), "table row outside table"),
+            (Event::Start(Tag::TableCell), "table cell outside table"),
+            (Event::End(TagEnd::TableCell), "table cell outside table"),
+        ];
+
+        for (event, expected_name) in events {
+            assert!(!event_allowed_inside_container(ContainerKind::List, &event));
+            assert!(!event_allowed_inside_container(
+                ContainerKind::Blockquote,
+                &event
+            ));
+            assert!(event_allowed_inside_container(ContainerKind::Table, &event));
+            assert_eq!(event_name(&event), expected_name);
+        }
+    }
+
+    #[test]
     fn parses_strikethrough_in_paragraph() {
         let markdown = "# Title\n\nThis is ~~deleted~~ text.";
         let events = Parser::new_ext(markdown, parser_options()).collect::<Vec<_>>();
@@ -4655,7 +4713,7 @@ After reveal.
             .contains("unsupported construct 'footnote definition inside list'"));
         assert_eq!(
             err.help,
-            "rewrite this slide using headings, paragraphs, lists, blockquotes, or fenced code blocks"
+            "rewrite this slide using headings, paragraphs, lists, blockquotes, tables, or fenced code blocks"
         );
     }
 
@@ -5218,6 +5276,21 @@ Grouped content[^grouped].
     }
 
     #[test]
+    fn rejects_image_inside_table_with_source_line() {
+        let err = parse_markdown(
+            "# Title\n\n| Name | Preview |\n| --- | --- |\n| Ada | ![Architecture](x.png) |",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(5));
+        assert!(err
+            .to_string()
+            .contains("unsupported construct 'image inside table'"));
+    }
+
+    #[test]
     fn keeps_loose_nested_list_and_item_code_as_one_list_fragment() {
         let markdown = r#"# Title
 
@@ -5398,36 +5471,6 @@ After list
     }
 
     #[test]
-    fn rejects_table_inside_blockquote_with_named_container() {
-        let err = parse_markdown(
-            "# Title\n\n> | A | B |\n> | - | - |\n> | 1 | 2 |",
-            &crate::highlight::Highlighter::defaults(),
-        )
-        .unwrap_err();
-
-        assert_eq!(err.kind, ErrorKind::Parse);
-        assert_eq!(err.line, Some(3));
-        assert!(err
-            .to_string()
-            .contains("unsupported construct 'table inside blockquote'"));
-    }
-
-    #[test]
-    fn rejects_table_inside_list_with_named_container() {
-        let err = parse_markdown(
-            "# Title\n\n- | A | B |\n  | - | - |\n  | 1 | 2 |",
-            &crate::highlight::Highlighter::defaults(),
-        )
-        .unwrap_err();
-
-        assert_eq!(err.kind, ErrorKind::Parse);
-        assert_eq!(err.line, Some(3));
-        assert!(err
-            .to_string()
-            .contains("unsupported construct 'table inside list'"));
-    }
-
-    #[test]
     fn reveal_blockquote_contributes_exactly_one_step() {
         let deck = parse_markdown(
             "# Title\n\n::: {reveal}\n\n> Quote.\n>\n> - nested one\n> - nested two\n\n:::\n",
@@ -5446,9 +5489,24 @@ After list
     }
 
     #[test]
-    fn unsupported_table_help_names_blockquotes_without_milestone_wording() {
+    fn reveal_table_contributes_exactly_one_step() {
+        let deck = parse_markdown(
+            "# Title\n\n::: {reveal}\n\n| A | B |\n| - | - |\n| 1 | 2 |\n\n:::\n",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let slide = &deck.parsed_slides()[0];
+        let table = &slide.fragments[1];
+
+        assert_eq!(table.kind(), &FragmentKind::Table);
+        assert_eq!(table.reveal_span(), Some(RevealSpan { start: 1, len: 1 }));
+        assert_eq!(slide.step_count, 1);
+    }
+
+    #[test]
+    fn unsupported_construct_help_lists_tables_as_rewrite_target() {
         let err = parse_markdown(
-            "# Title\n\n| A | B |\n| - | - |\n| 1 | 2 |",
+            "# Title\n\n<div>raw html</div>",
             &crate::highlight::Highlighter::defaults(),
         )
         .unwrap_err();
@@ -5456,9 +5514,8 @@ After list
         assert_eq!(err.kind, ErrorKind::Parse);
         assert_eq!(
             err.help,
-            "rewrite this slide using headings, paragraphs, lists, blockquotes, or fenced code blocks"
+            "rewrite this slide using headings, paragraphs, lists, blockquotes, tables, or fenced code blocks"
         );
-        assert!(!err.help.contains("milestone 1"));
     }
 
     #[test]
@@ -7165,7 +7222,7 @@ After list
     #[test]
     fn unsupported_construct_after_delimiter_reports_global_line_and_slide() {
         let err = parse_markdown(
-            "# One\n\n---\n\n# Two\n\n| A | B |\n| - | - |\n| 1 | 2 |",
+            "# One\n\n---\n\n# Two\n\n<div>raw html</div>",
             &crate::highlight::Highlighter::defaults(),
         )
         .unwrap_err();
@@ -7173,7 +7230,7 @@ After list
         assert_eq!(err.kind, ErrorKind::Parse);
         assert_eq!(err.line, Some(7));
         assert!(err.to_string().contains("slide 2 ('two'), line 7"));
-        assert!(err.to_string().contains("unsupported construct 'table'"));
+        assert!(err.to_string().contains("unsupported construct 'html'"));
     }
 
     #[test]
@@ -7197,17 +7254,18 @@ After list
     }
 
     #[test]
-    fn unsupported_table_after_delimiter_is_not_silently_dropped() {
-        let err = parse_markdown(
+    fn table_after_delimiter_is_not_silently_dropped() {
+        let deck = parse_markdown(
             "# One\n\n---\n\n| a |\n| - |",
             &crate::highlight::Highlighter::defaults(),
         )
-        .unwrap_err();
+        .unwrap();
+        let slide = &deck.parsed_slides()[1];
 
-        assert_eq!(err.kind, ErrorKind::Parse);
-        assert_eq!(err.line, Some(5));
-        assert!(err.to_string().contains("slide 2 ('slide-2'), line 5"));
-        assert!(err.to_string().contains("unsupported construct 'table'"));
+        assert_eq!(slide.fragments.len(), 1);
+        assert_eq!(slide.fragments[0].line(), 5);
+        assert_eq!(slide.fragments[0].kind(), &FragmentKind::Table);
+        assert_eq!(slide.fragments[0].markdown(), "| a |\n| - |");
     }
 
     #[test]

--- a/crates/peitho-core/src/plain.rs
+++ b/crates/peitho-core/src/plain.rs
@@ -27,9 +27,10 @@ pub(crate) fn slide_text<S>(slide: &CheckedSlide<S>) -> ManifestSlideText {
                         FragmentKind::Heading { .. } | FragmentKind::Text => {
                             fragment.plain_text().to_owned()
                         }
-                        FragmentKind::Paragraph | FragmentKind::List | FragmentKind::Blockquote => {
-                            body_fragment_text(fragment.markdown())
-                        }
+                        FragmentKind::Paragraph
+                        | FragmentKind::List
+                        | FragmentKind::Blockquote
+                        | FragmentKind::Table => body_fragment_text(fragment.markdown()),
                         FragmentKind::Math { .. } => fragment.code_text().trim_end().to_owned(),
                         FragmentKind::EmbedCard { .. } => fragment.plain_text().to_owned(),
                         FragmentKind::GenericEmbedCard { .. } => fragment.plain_text().to_owned(),
@@ -68,30 +69,88 @@ pub(crate) fn slide_text<S>(slide: &CheckedSlide<S>) -> ManifestSlideText {
 fn body_fragment_text(markdown: &str) -> String {
     let mut text = String::new();
     let mut in_image = false;
-    let mut blockquote_depth = 0usize;
+    let mut at_first_cell_of_table_row = false;
 
     for event in Parser::new_ext(markdown, BODY_MARKDOWN_OPTIONS) {
         match event {
             Event::Start(Tag::Image { .. }) => in_image = true,
             Event::End(TagEnd::Image) => in_image = false,
-            _ if in_image => {}
             Event::FootnoteReference(_) => {}
-            Event::Start(Tag::BlockQuote(_kind)) => blockquote_depth += 1,
-            Event::End(TagEnd::BlockQuote(_kind)) => {
-                blockquote_depth = blockquote_depth.saturating_sub(1);
-            }
             Event::Start(Tag::Item) => push_block_separator(&mut text),
-            Event::Start(Tag::Paragraph) if blockquote_depth > 0 => {
+            Event::Start(Tag::Paragraph) => push_block_separator(&mut text),
+            Event::Start(Tag::Table(_alignments)) => {
                 push_block_separator(&mut text);
+                at_first_cell_of_table_row = true;
             }
-            Event::Text(value) | Event::Code(value) => text.push_str(&value),
+            Event::Start(Tag::TableRow) => {
+                push_block_separator(&mut text);
+                at_first_cell_of_table_row = true;
+            }
+            Event::Start(Tag::TableCell) => {
+                if !at_first_cell_of_table_row
+                    && !text.is_empty()
+                    && !text.ends_with(char::is_whitespace)
+                {
+                    text.push(' ');
+                }
+                at_first_cell_of_table_row = false;
+            }
+            Event::End(TagEnd::Table) => at_first_cell_of_table_row = false,
+            Event::Text(_) | Event::Code(_) | Event::InlineMath(_) | Event::DisplayMath(_)
+                if in_image => {}
+            Event::Text(value)
+            | Event::Code(value)
+            | Event::InlineMath(value)
+            | Event::DisplayMath(value) => text.push_str(&value),
             Event::SoftBreak | Event::HardBreak
-                if !text.is_empty() && !text.ends_with(char::is_whitespace) =>
+                if !in_image && !text.is_empty() && !text.ends_with(char::is_whitespace) =>
             {
                 text.push(' ');
             }
-            Event::Start(Tag::Strikethrough) | Event::End(TagEnd::Strikethrough) => {}
-            _ => {}
+            Event::Start(Tag::Heading { .. })
+            | Event::Start(Tag::CodeBlock(_))
+            | Event::Start(Tag::HtmlBlock)
+            | Event::Start(Tag::List(_))
+            | Event::Start(Tag::BlockQuote(_))
+            | Event::Start(Tag::FootnoteDefinition(_))
+            | Event::Start(Tag::DefinitionList)
+            | Event::Start(Tag::DefinitionListTitle)
+            | Event::Start(Tag::DefinitionListDefinition)
+            | Event::Start(Tag::Emphasis)
+            | Event::Start(Tag::Strong)
+            | Event::Start(Tag::Strikethrough)
+            | Event::Start(Tag::Superscript)
+            | Event::Start(Tag::Subscript)
+            | Event::Start(Tag::Link { .. })
+            | Event::Start(Tag::MetadataBlock(_))
+            | Event::Start(Tag::TableHead)
+            | Event::End(TagEnd::Paragraph)
+            | Event::End(TagEnd::Heading(_))
+            | Event::End(TagEnd::CodeBlock)
+            | Event::End(TagEnd::HtmlBlock)
+            | Event::End(TagEnd::List(_))
+            | Event::End(TagEnd::BlockQuote(_))
+            | Event::End(TagEnd::Item)
+            | Event::End(TagEnd::FootnoteDefinition)
+            | Event::End(TagEnd::DefinitionList)
+            | Event::End(TagEnd::DefinitionListTitle)
+            | Event::End(TagEnd::DefinitionListDefinition)
+            | Event::End(TagEnd::TableHead)
+            | Event::End(TagEnd::TableRow)
+            | Event::End(TagEnd::TableCell)
+            | Event::End(TagEnd::Emphasis)
+            | Event::End(TagEnd::Strong)
+            | Event::End(TagEnd::Strikethrough)
+            | Event::End(TagEnd::Superscript)
+            | Event::End(TagEnd::Subscript)
+            | Event::End(TagEnd::Link)
+            | Event::End(TagEnd::MetadataBlock(_))
+            | Event::Html(_)
+            | Event::InlineHtml(_)
+            | Event::SoftBreak
+            | Event::HardBreak
+            | Event::Rule
+            | Event::TaskListMarker(_) => {}
         }
     }
 
@@ -171,6 +230,13 @@ mod tests {
     }
 
     #[test]
+    fn body_slot_separates_paragraphs_in_loose_list_item() {
+        let text = checked_slide_text("# Title\n\n- first para\n\n  second para");
+
+        assert_eq!(text.body(), "first para\nsecond para");
+    }
+
+    #[test]
     fn manifest_body_text_contains_blockquote_text_without_markers() {
         let text = checked_slide_text(
             "# Title\n\n> First **quoted** paragraph.\n>\n> Second paragraph with `code`.",
@@ -181,6 +247,23 @@ mod tests {
             "First quoted paragraph.\nSecond paragraph with code."
         );
         assert!(!text.body().contains('>'));
+    }
+
+    #[test]
+    fn manifest_body_text_flattens_table_with_cell_and_row_separators() {
+        let text = checked_slide_text(
+            "# Title\n\n| Name | Score |\n| --- | --- |\n| Ada | 10 |\n| Lin | 20 |",
+        );
+
+        assert_eq!(text.body(), "Name Score\nAda 10\nLin 20");
+        assert!(!text.body().contains('|'));
+    }
+
+    #[test]
+    fn manifest_body_text_does_not_prefix_nonempty_header_after_empty_cell() {
+        let text = checked_slide_text("# Title\n\n|  | X |\n| --- | --- |\n| 1 | 2 |");
+
+        assert_eq!(text.body(), "X\n1 2");
     }
 
     #[test]

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -23,8 +23,9 @@ use crate::{
 const PDF_FLATTEN_JS: &str = include_str!("pdf_flatten.js");
 const LINT_MEASURE_JS: &str = include_str!("lint_measure.js");
 
-pub(crate) const BODY_MARKDOWN_OPTIONS: Options =
-    Options::ENABLE_OLD_FOOTNOTES.union(Options::ENABLE_STRIKETHROUGH);
+pub(crate) const BODY_MARKDOWN_OPTIONS: Options = Options::ENABLE_OLD_FOOTNOTES
+    .union(Options::ENABLE_STRIKETHROUGH)
+    .union(Options::ENABLE_TABLES);
 
 pub(crate) fn walk_body_markdown_list_items<'a>(
     markdown: &'a str,
@@ -504,7 +505,8 @@ fn render_block_slot(
             | FragmentKind::Paragraph
             | FragmentKind::Text
             | FragmentKind::List
-            | FragmentKind::Blockquote => markdown_run.push(fragment.markdown()),
+            | FragmentKind::Blockquote
+            | FragmentKind::Table => markdown_run.push(fragment.markdown()),
             FragmentKind::Code | FragmentKind::Image { .. } | FragmentKind::SlotGroup { .. } => {
                 unreachable!("validated by contract guard")
             }
@@ -609,6 +611,14 @@ fn render_revealed_fragment(
             breaks,
             footnote_numbers,
         ),
+        FragmentKind::Table => render_revealed_markdown_root(
+            body,
+            fragment,
+            RevealedMarkdownRoot::Table,
+            span.start,
+            breaks,
+            footnote_numbers,
+        ),
         FragmentKind::Text => unreachable!("revealed Text fragments are not renderable"),
         FragmentKind::Code => {
             let code = render_code_fragment(fragment, highlighter)?;
@@ -698,6 +708,7 @@ enum RevealedMarkdownRoot {
     Heading,
     Paragraph,
     Blockquote,
+    Table,
 }
 
 fn render_revealed_markdown_root(
@@ -709,10 +720,10 @@ fn render_revealed_markdown_root(
     footnote_numbers: &BTreeMap<String, usize>,
 ) -> Result<()> {
     let mut events = Vec::new();
-    let mut stamped = false;
+    let mut root_stamped = false;
     let mut in_html_comment = false;
     for event in Parser::new_ext(fragment.markdown(), BODY_MARKDOWN_OPTIONS) {
-        let event = match (root, stamped, event) {
+        let event = match (root, root_stamped, event) {
             (
                 RevealedMarkdownRoot::Heading,
                 false,
@@ -726,15 +737,15 @@ fn render_revealed_markdown_root(
                 if id.is_some() || !classes.is_empty() || !attrs.is_empty() {
                     unreachable!("heading attributes are not enabled in BODY_MARKDOWN_OPTIONS");
                 }
-                stamped = true;
+                root_stamped = true;
                 Event::Html(format!(r#"<{level} data-reveal-step="{step}">"#).into())
             }
             (RevealedMarkdownRoot::Paragraph, false, Event::Start(Tag::Paragraph)) => {
-                stamped = true;
+                root_stamped = true;
                 Event::Html(format!(r#"<p data-reveal-step="{step}">"#).into())
             }
             (RevealedMarkdownRoot::Blockquote, false, Event::Start(Tag::BlockQuote(_kind))) => {
-                stamped = true;
+                root_stamped = true;
                 Event::Html(format!(r#"<blockquote data-reveal-step="{step}">"#).into())
             }
             (_, _, event) => event,
@@ -745,15 +756,38 @@ fn render_revealed_markdown_root(
             events.push(event);
         }
     }
-    if !stamped {
-        let label = match root {
-            RevealedMarkdownRoot::Heading => "heading",
-            RevealedMarkdownRoot::Paragraph => "paragraph",
-            RevealedMarkdownRoot::Blockquote => "blockquote",
-        };
+    let missing_root = match (root, root_stamped) {
+        (RevealedMarkdownRoot::Heading, false) => Some("heading"),
+        (RevealedMarkdownRoot::Paragraph, false) => Some("paragraph"),
+        (RevealedMarkdownRoot::Blockquote, false) => Some("blockquote"),
+        (RevealedMarkdownRoot::Heading, true)
+        | (RevealedMarkdownRoot::Paragraph, true)
+        | (RevealedMarkdownRoot::Blockquote, true)
+        | (RevealedMarkdownRoot::Table, _) => None,
+    };
+    if let Some(label) = missing_root {
         unreachable!("revealed {label} fragment produced no {label} root");
     }
-    html::push_html(body, events.into_iter());
+
+    let mut rendered = String::new();
+    html::push_html(&mut rendered, events.into_iter());
+    if matches!(root, RevealedMarkdownRoot::Table) {
+        stamp_revealed_table_root(&mut rendered, step, fragment.line())?;
+    }
+    body.push_str(&rendered);
+    Ok(())
+}
+
+fn stamp_revealed_table_root(rendered: &mut String, step: usize, line: usize) -> Result<()> {
+    let Some(root_tag_end) = rendered.find('>').filter(|_| rendered.starts_with('<')) else {
+        return Err(BuildError::new(
+            ErrorKind::Layout,
+            Some(line),
+            "internal render error: revealed table has no root HTML tag",
+            "report this issue with the table Markdown that triggered it",
+        ));
+    };
+    rendered.insert_str(root_tag_end, &format!(r#" data-reveal-step="{step}""#));
     Ok(())
 }
 
@@ -1026,6 +1060,7 @@ fn render_image_fragment_inner(
         | FragmentKind::Footnotes { .. }
         | FragmentKind::List
         | FragmentKind::Blockquote
+        | FragmentKind::Table
         | FragmentKind::SlotGroup { .. } => unreachable!("validated by contract guard"),
     }
 }
@@ -1065,6 +1100,7 @@ fn accepts_fragment(accepts: Accepts, fragment: &SourceFragment<ResolvedImagePat
             | (Accepts::Blocks, FragmentKind::Paragraph)
             | (Accepts::Blocks, FragmentKind::List)
             | (Accepts::Blocks, FragmentKind::Blockquote)
+            | (Accepts::Blocks, FragmentKind::Table)
             | (Accepts::Blocks, FragmentKind::Math { .. })
             | (Accepts::Blocks, FragmentKind::EmbedCard { .. })
             | (Accepts::Blocks, FragmentKind::GenericEmbedCard { .. })
@@ -1092,8 +1128,11 @@ fn render_heading_inline(
                 };
                 events.push(Event::Html(render_footnote_reference(number).into()));
             }
-            event if in_heading => events.push(event),
-            _ => {}
+            event => {
+                if in_heading {
+                    events.push(event);
+                }
+            }
         }
     }
     let mut rendered = String::new();
@@ -2207,6 +2246,78 @@ mod tests {
         );
         assert!(html.contains("<ul>\n<li>nested item</li>\n</ul>"), "{html}");
         assert!(html.contains("<p>nested quote</p>"), "{html}");
+    }
+
+    #[test]
+    fn renders_table_structure_alignment_and_inline_markup() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n| Name | Score |\n| :--- | ---: |\n| *Ada* | `10` |",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains("<table>"), "{html}");
+        assert!(html.contains("<thead>"), "{html}");
+        assert!(html.contains("<tbody>"), "{html}");
+        assert!(html.contains(r#"style="text-align: right""#), "{html}");
+        assert!(html.contains("<em>Ada</em>"), "{html}");
+        assert!(html.contains("<code>10</code>"), "{html}");
+
+        let revealed = render_checked_deck_with_layout(
+            "# Title\n\n::: {reveal}\n\n| Name | Score |\n| :--- | ---: |\n| *Ada* | `10` |\n\n:::\n",
+            title_body_layout(),
+        );
+        let revealed_html = revealed.slides()[0].html();
+
+        assert!(
+            revealed_html.contains(r#"<table data-reveal-step="1">"#),
+            "{revealed_html}"
+        );
+        assert!(
+            revealed_html.contains(r#"style="text-align: right""#),
+            "{revealed_html}"
+        );
+    }
+
+    #[test]
+    fn revealed_table_stamp_tolerates_root_attributes_and_names_missing_root() {
+        let mut rendered = r#"<table class="wide"><tbody></tbody></table>"#.to_owned();
+
+        stamp_revealed_table_root(&mut rendered, 3, 7).unwrap();
+
+        assert_eq!(
+            rendered,
+            r#"<table class="wide" data-reveal-step="3"><tbody></tbody></table>"#
+        );
+
+        let err = stamp_revealed_table_root(&mut String::new(), 3, 7).unwrap_err();
+        assert_eq!(err.kind, ErrorKind::Layout);
+        assert_eq!(err.line, Some(7));
+        assert!(err.message.contains("revealed table"));
+    }
+
+    #[test]
+    fn renders_tables_inside_list_items_and_blockquotes() {
+        let cases = [
+            (
+                "# Title\n\n- Comparison:\n\n  | A | B |\n  | - | - |\n  | 1 | 2 |",
+                "<ul>",
+            ),
+            (
+                "# Title\n\n> Comparison:\n>\n> | A | B |\n> | - | - |\n> | 1 | 2 |",
+                "<blockquote>",
+            ),
+        ];
+
+        for (markdown, outer_tag) in cases {
+            let rendered = render_checked_deck_with_layout(markdown, title_body_layout());
+            let html = rendered.slides()[0].html();
+
+            assert!(html.contains(outer_tag), "{html}");
+            assert!(html.contains("<table>"), "{html}");
+            assert!(html.contains("<thead>"), "{html}");
+            assert!(html.contains("<tbody>"), "{html}");
+        }
     }
 
     #[test]

--- a/docs/plans/2026-08-17-table-support.md
+++ b/docs/plans/2026-08-17-table-support.md
@@ -1,0 +1,67 @@
+# Table support in slide bodies (Issue #425)
+
+Date: 2026-08-17
+Issue: #425
+
+## Problem
+
+Pipe tables fail the build with `unsupported construct 'table'` — the parse
+grammar has `ENABLE_TABLES` on purely so tables can be recognized and
+rejected. Comparison tables are bread-and-butter slide content
+(deck-writing report, 2026-08-16), and #424 left tables inside list items
+as a deliberate intermediate hard error for this issue to resolve.
+
+## Design
+
+Tables follow the `List`/`Blockquote` fragment pattern:
+`FragmentKind::Table` (unit variant), the fragment's markdown slice carries
+the source, and rendering re-parses through the shared `push_html` path.
+`BODY_MARKDOWN_OPTIONS` gains `ENABLE_TABLES`, which does double duty:
+
+- top-level tables render as `<table>` (alignment markers become
+  pulldown's `style="text-align: …"` attributes for free), and
+- table markdown riding a container fragment (list item, blockquote)
+  renders as a real table through the same option — so the container walk
+  now **allows** Table events instead of erroring, resolving #424's
+  documented intermediate state uniformly.
+
+Parser: top-level `Start(Tag::Table)` opens a table fragment; the walk
+consumes TableHead/TableRow/TableCell and inline content; images inside
+cells are a line-numbered error (images route to image slots — mirrors the
+container rule); everything else legal inline is legal in cells. Inside
+containers, Table events join the allowed set (no error arm remains).
+
+Mapping routes tables to body; `Accepts::Blocks` accepts `Table`. A table
+inside `::: {reveal}` is one step (fragment-level default). The
+`unsupported_construct` help gains "tables" in its rewrite list.
+
+Plain text: cell text accumulates with a space between cells and a newline
+between rows, so manifest body text stays readable.
+
+Theme: `themes/base.css` (and the verbatim example copy
+`examples/footnotes/css/base.css`) gain modest table rules — collapsed
+borders, header weight, cell padding — themeable via custom properties
+consistent with the blockquote rule.
+
+## Tests (TDD order)
+
+1. Parse: a pipe table produces a `Table` fragment with the source
+   markdown.
+2. Render: `<table>` with `<thead>`/`<tbody>`; alignment column renders
+   the text-align style.
+3. Emphasis/code spans inside cells render; image inside a cell is a
+   line-numbered error.
+4. Table inside a list item and inside a blockquote build and render as
+   real tables (the #424 intermediate errors are gone).
+5. Check: table mapped to a non-blocks slot is a check error.
+6. Reveal: a table inside `::: {reveal}` contributes exactly one step.
+7. Plain text: manifest body contains cell text with row separators, no
+   pipes.
+8. Help text: remaining unsupported constructs list tables among the
+   rewrite targets.
+
+## Non-goals
+
+- No column-width/layout vocabulary in Markdown (pillar ①: design belongs
+  to CSS).
+- No `colspan`/`rowspan` (pipe tables cannot express them).

--- a/examples/footnotes/css/base.css
+++ b/examples/footnotes/css/base.css
@@ -98,6 +98,23 @@
   margin-bottom: 0;
 }
 
+.slot-body table {
+  width: 100%;
+  margin: 0 0 var(--peitho-table-spacing, 24px);
+  border-collapse: collapse;
+}
+
+.slot-body th,
+.slot-body td {
+  padding: var(--peitho-table-cell-padding, 8px 12px);
+  border: 1px solid var(--peitho-table-border-color, #8a8578);
+  vertical-align: top;
+}
+
+.slot-body th {
+  font-weight: var(--peitho-table-header-weight, 600);
+}
+
 .slot-body ul {
   margin: 0;
   padding-left: 34px;
@@ -182,4 +199,33 @@
 
 .slot-code .hl-type {
   color: #0f766e;
+}
+
+/*
+ * Static code line emphasis — "these lines are the important ones".
+ *
+ * A separate layer from syntax highlighting above: `hl-*` colors code by what
+ * it is, emphasis points at what the speaker is discussing.
+ *
+ * Only the *static* form lives here, because it is baked into the build output
+ * and must render with no shell present (PDF, preview, dist/). Stepped
+ * emphasis is styled by the present shell itself, so that it keeps working for
+ * decks that ship their own CSS and thus never load this file.
+ */
+.slot-code .code-line {
+  display: inline-block;
+  width: 100%;
+}
+
+.slot-code .code-line-emphasis {
+  background: var(--peitho-emphasis-background, rgba(217, 163, 0, 0.18));
+  box-shadow: inset 3px 0 0 var(--peitho-emphasis-marker, #d9a300);
+}
+
+/*
+ * Dim the surrounding lines, scoped by `:has()` so a block with no emphasis
+ * never renders faded.
+ */
+.slot-code:has(.code-line-emphasis) .code-line:not(.code-line-emphasis) {
+  opacity: var(--peitho-emphasis-dim, 0.45);
 }

--- a/site/content/guide/writing-decks.md
+++ b/site/content/guide/writing-decks.md
@@ -42,6 +42,8 @@ Convention mapping turns Markdown into slots without extra notation:
 - An image-only paragraph maps to the image slot.
 - All other blocks map to `body`.
 
+A table ends at a blank line, so separate any following prose from it with one.
+
 Markdown images are deck-relative local files. They must use supported local
 image extensions (`png`, `jpg`, `jpeg`, `gif`, `webp`) and must map to a layout
 with exactly one unambiguous `accepts="image"` slot.

--- a/themes/base.css
+++ b/themes/base.css
@@ -98,6 +98,23 @@
   margin-bottom: 0;
 }
 
+.slot-body table {
+  width: 100%;
+  margin: 0 0 var(--peitho-table-spacing, 24px);
+  border-collapse: collapse;
+}
+
+.slot-body th,
+.slot-body td {
+  padding: var(--peitho-table-cell-padding, 8px 12px);
+  border: 1px solid var(--peitho-table-border-color, #8a8578);
+  vertical-align: top;
+}
+
+.slot-body th {
+  font-weight: var(--peitho-table-header-weight, 600);
+}
+
 .slot-body ul {
   margin: 0;
   padding-left: 34px;


### PR DESCRIPTION
Closes #425

## What

Pipe tables — bread-and-butter slide content — were `unsupported construct 'table'` (the parse grammar enabled tables purely to reject them). They now follow the List/Blockquote fragment pattern: `FragmentKind::Table`, markdown re-rendered through `push_html` with `ENABLE_TABLES` (alignment markers become `text-align` styles for free), routed to body, accepted by `Accepts::Blocks`, with modest themeable base-theme styling.

The same render option makes tables inside **containers** (list items, blockquotes) render as real tables — resolving #424's documented intermediate hard error uniformly. Stray `TableHead/Row/Cell` events outside a table are named loud errors; images inside cells error like the other container rules.

## Review hardening (8-finding adversarial pass, all applied and re-verified E2E)

- Manifest plain text: cells separated by spaces, rows by newlines, no leading whitespace on empty first header cells; paragraph boundaries now **always** separate (fixed a pre-existing loose-list word-fusion the rewrite had inherited).
- Revealed tables: alignment-preserving stamping kept (required — pulldown carries alignment on the Start event), but via a tolerant root-tag splice with a **named** internal error instead of an `unreachable!` coupled to pulldown's byte format.
- GFM's "a table absorbs following pipe-less prose until a blank line" is pinned by test and documented in the guide (a table ends at a blank line).
- `examples/footnotes/css/base.css` re-synced **byte-identical** to `themes/base.css` (it had silently drifted by 29 lines since the code-emphasis feature).
- Dead/over-permissive container arms removed or made loud; duplicate containment arms merged.

## Verification

- `cargo test --workspace` ×3 green (917 core tests incl. 12 new table tests), clippy `-D warnings`, fmt, bindings/dist drift, CSS parity check.
- E2E with the built binary: aligned tables, tables in list/quote, empty-first-header manifest text, revealed table root stamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV