### PR TITLE
Route fenced code inside containers through the real code pipeline

### DIFF
--- a/crates/peitho-core/src/domain.rs
+++ b/crates/peitho-core/src/domain.rs
@@ -641,6 +641,19 @@ pub struct FootnoteEntry {
     reveal_step: Option<usize>,
 }
 
+/// Parse-validated highlighting metadata for one code block nested inside a
+/// container fragment.
+///
+/// Entries are stored in source order on [`SourceFragment`] and consumed in
+/// the same order while that fragment's Markdown is rendered. Keeping plain
+/// blocks in the sequence makes the parse-to-render contract positional,
+/// without requiring render to inspect fence info strings again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ContainerCodeLanguage {
+    Plain,
+    Highlighted(String),
+}
+
 impl FootnoteEntry {
     pub(crate) fn new(
         number: usize,
@@ -797,6 +810,7 @@ pub struct SourceFragment<S = RawImagePath> {
     kind: FragmentKind<S>,
     reveal_span: Option<RevealSpan>,
     emphasis: Option<LineEmphasis>,
+    container_code_languages: Vec<ContainerCodeLanguage>,
     embed_options: Option<EmbedOptions>,
     markdown: String,
     text: String,
@@ -816,6 +830,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Heading { level },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: markdown.into(),
             text: text.into(),
@@ -830,6 +845,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Paragraph,
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: markdown.into(),
             text: String::new(),
@@ -844,6 +860,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::List,
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: markdown.into(),
             text: String::new(),
@@ -858,6 +875,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Blockquote,
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: markdown.into(),
             text: String::new(),
@@ -872,6 +890,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Table,
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: markdown.into(),
             text: String::new(),
@@ -887,6 +906,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Code,
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: code.clone(),
             text: String::new(),
@@ -906,6 +926,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Math { html: html.into() },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: latex_source.clone(),
             text: String::new(),
@@ -924,6 +945,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::EmbedCard { html: html.into() },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: String::new(),
             text: plain_text.into(),
@@ -938,6 +960,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::Footnotes { entries },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: String::new(),
             text: String::new(),
@@ -956,6 +979,7 @@ impl SourceFragment<RawImagePath> {
             kind: FragmentKind::SlotGroup { name, children },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: String::new(),
             text: String::new(),
@@ -976,6 +1000,14 @@ impl SourceFragment<RawImagePath> {
     /// what is emphasized comes from the deck source.
     pub(crate) fn with_emphasis(mut self, emphasis: LineEmphasis) -> Self {
         self.emphasis = Some(emphasis);
+        self
+    }
+
+    pub(crate) fn with_container_code_languages(
+        mut self,
+        languages: Vec<ContainerCodeLanguage>,
+    ) -> Self {
+        self.container_code_languages = languages;
         self
     }
 
@@ -1003,6 +1035,7 @@ impl<S> SourceFragment<S> {
             },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: String::new(),
             text: String::new(),
@@ -1034,6 +1067,7 @@ impl<S> SourceFragment<S> {
             },
             reveal_span: None,
             emphasis: None,
+            container_code_languages: Vec::new(),
             embed_options: None,
             markdown: String::new(),
             text: plain_text.into(),
@@ -1061,6 +1095,7 @@ impl<S> SourceFragment<S> {
             kind,
             reveal_span,
             emphasis,
+            container_code_languages,
             embed_options,
             markdown,
             text,
@@ -1113,6 +1148,7 @@ impl<S> SourceFragment<S> {
             kind,
             reveal_span,
             emphasis,
+            container_code_languages,
             embed_options,
             markdown,
             text,
@@ -1135,6 +1171,10 @@ impl<S> SourceFragment<S> {
 
     pub(crate) fn emphasis(&self) -> Option<&LineEmphasis> {
         self.emphasis.as_ref()
+    }
+
+    pub(crate) fn container_code_languages(&self) -> &[ContainerCodeLanguage] {
+        &self.container_code_languages
     }
 
     #[cfg(test)]

--- a/crates/peitho-core/src/parser.rs
+++ b/crates/peitho-core/src/parser.rs
@@ -11,9 +11,9 @@ use serde::Deserialize;
 
 use crate::{
     domain::{
-        AspectRatio, CodeImageCommand, CodeImageRenderer, CodeImagesConfig, EmbedMode,
-        EmbedOptions, ExplicitSlot, FootnoteEntry, FragmentKind, RawImagePath, Resolution,
-        RevealSpan, SlideKey, SlotName, SourceFragment,
+        AspectRatio, CodeImageCommand, CodeImageRenderer, CodeImagesConfig, ContainerCodeLanguage,
+        EmbedMode, EmbedOptions, ExplicitSlot, FootnoteEntry, FragmentKind, RawImagePath,
+        Resolution, RevealSpan, SlideKey, SlotName, SourceFragment,
     },
     emphasis,
     error::{BuildError, ErrorKind, Result},
@@ -257,6 +257,7 @@ impl ContainerKind {
 struct OpenContainer {
     kind: ContainerKind,
     start: usize,
+    code_languages: Vec<ContainerCodeLanguage>,
 }
 
 type ContainerState = Vec<OpenContainer>;
@@ -1487,7 +1488,7 @@ fn scan_div_markers(
     source: &str,
 ) -> Result<std::collections::HashMap<usize, DivMarker>> {
     let mut markers = std::collections::HashMap::new();
-    let mut in_code_fence: Option<(char, usize)> = None;
+    let mut in_code_fence: Option<(char, usize, bool)> = None;
     let mut in_html_comment = false;
     let mut line_start = 0usize;
 
@@ -1497,16 +1498,25 @@ fn scan_div_markers(
         let line_offset = slice_start_offset + line_start;
         let line_no = line_for_offset(source, line_offset);
 
-        // Track fenced code blocks so ::: inside them is not a marker.
-        if let Some((fence_char, fence_len)) = in_code_fence {
-            if is_closing_code_fence(trimmed, fence_char, fence_len) {
+        // Track fenced code blocks so ::: inside them is not a marker. Strip
+        // Markdown container prefixes before checking both ends: list
+        // openers carry their marker only on the first line, while blockquote
+        // lines carry `>` on every line.
+        let (fence_line, has_blockquote_prefix) = strip_container_prefixes(trimmed);
+        if let Some((fence_char, fence_len, strip_blockquote_prefix)) = in_code_fence {
+            let closing_line = if strip_blockquote_prefix {
+                strip_blockquote_prefixes(trimmed)
+            } else {
+                trimmed
+            };
+            if is_closing_code_fence(closing_line, fence_char, fence_len) {
                 in_code_fence = None;
             }
             line_start += raw_line.len();
             continue;
         }
-        if let Some((ch, len)) = opening_code_fence(trimmed) {
-            in_code_fence = Some((ch, len));
+        if let Some((ch, len)) = opening_code_fence(fence_line) {
+            in_code_fence = Some((ch, len, has_blockquote_prefix));
             line_start += raw_line.len();
             continue;
         }
@@ -1555,6 +1565,57 @@ fn scan_div_markers(
         line_start += raw_line.len();
     }
     Ok(markers)
+}
+
+/// Remove a run of Markdown quote/list prefixes from the start of a source
+/// line, leaving the content pulldown-cmark treats as the container body.
+/// List markers require following whitespace; ordered markers are `N.`.
+fn strip_container_prefixes(mut line: &str) -> (&str, bool) {
+    let mut has_blockquote_prefix = false;
+    loop {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix('>') {
+            has_blockquote_prefix = true;
+            line = rest;
+            continue;
+        }
+
+        if let Some(marker) = trimmed
+            .chars()
+            .next()
+            .filter(|marker| matches!(marker, '-' | '*' | '+'))
+        {
+            let rest = &trimmed[marker.len_utf8()..];
+            if rest.starts_with(char::is_whitespace) {
+                line = rest;
+                continue;
+            }
+        }
+
+        let digit_len = trimmed
+            .bytes()
+            .take_while(|byte| byte.is_ascii_digit())
+            .count();
+        if digit_len > 0
+            && trimmed.as_bytes().get(digit_len) == Some(&b'.')
+            && trimmed[digit_len + 1..].starts_with(char::is_whitespace)
+        {
+            line = &trimmed[digit_len + 1..];
+            continue;
+        }
+
+        return (trimmed, has_blockquote_prefix);
+    }
+}
+
+fn strip_blockquote_prefixes(mut line: &str) -> &str {
+    loop {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix('>') else {
+            return trimmed;
+        };
+        line = rest;
+    }
 }
 
 fn opens_unclosed_html_comment(line: &str) -> bool {
@@ -1917,7 +1978,79 @@ fn push_checked_fragment(
 }
 
 fn enter_container(container: &mut ContainerState, kind: ContainerKind, start: usize) {
-    container.push(OpenContainer { kind, start });
+    container.push(OpenContainer {
+        kind,
+        start,
+        code_languages: Vec::new(),
+    });
+}
+
+fn validate_code_fence_info<'info, 'config>(
+    info: &'info str,
+    line: usize,
+    highlighter: &Highlighter,
+    code_images: &'config CodeImagesConfig,
+) -> Result<(
+    emphasis::InfoString<'info>,
+    Option<CodeImageRenderer<'config>>,
+)> {
+    let split = emphasis::split_info_string(info, line)?;
+    let renderer = split
+        .language
+        .and_then(|language| code_images.renderer_for(language));
+    if let Some(language) = split.language {
+        if renderer.is_none() {
+            highlighter.validate_language(language, line)?;
+        }
+    }
+    Ok((split, renderer))
+}
+
+fn validate_container_code_fence(
+    container: ContainerKind,
+    kind: &CodeBlockKind<'_>,
+    line: usize,
+    highlighter: &Highlighter,
+    code_images: &CodeImagesConfig,
+) -> Result<ContainerCodeLanguage> {
+    let info = match kind {
+        CodeBlockKind::Fenced(info) => info.as_ref(),
+        CodeBlockKind::Indented => "",
+    };
+    let (split, renderer) = validate_code_fence_info(info, line, highlighter, code_images)?;
+
+    if renderer.is_some() {
+        let language = split
+            .language
+            .expect("a code_images renderer is resolved from a language tag");
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            Some(line),
+            format!(
+                "code_images block '{language}' is not supported inside a {}",
+                container.name()
+            ),
+            "move the block to the top level",
+        ));
+    }
+    if split.emphasis.is_some() {
+        return Err(BuildError::new(
+            ErrorKind::Parse,
+            Some(line),
+            format!(
+                "line emphasis is not supported inside a {}",
+                container.name()
+            ),
+            "remove the emphasis spec or move the block to the top level",
+        ));
+    }
+    if let Some(tail) = split.tail {
+        return Err(emphasis::unexpected_info_tail_error(tail, line));
+    }
+    Ok(match split.language {
+        Some(language) => ContainerCodeLanguage::Highlighted(language.to_owned()),
+        None => ContainerCodeLanguage::Plain,
+    })
 }
 
 fn close_container(
@@ -1949,7 +2082,8 @@ fn close_container(
         ContainerKind::List => SourceFragment::list(line, markdown),
         ContainerKind::Blockquote => SourceFragment::blockquote(line, markdown),
         ContainerKind::Table => SourceFragment::table(line, markdown),
-    };
+    }
+    .with_container_code_languages(open.code_languages);
     Ok(Some((open.start, fragment)))
 }
 
@@ -2175,23 +2309,19 @@ fn parse_slide(
             continue;
         }
 
-        if let Some(open) = container.last() {
-            if open.kind == ContainerKind::Blockquote {
-                if let Event::Start(Tag::CodeBlock(_kind)) = &event {
-                    let message = format!("code block inside a {}", open.kind.name());
-                    let err = BuildError::new(
-                        ErrorKind::Parse,
-                        Some(line_for_offset(source, global_start)),
-                        message,
-                        "move the code block out of the quote",
-                    );
-                    return Err(attach_slide_context(
-                        err,
-                        index,
-                        explicit_key.as_ref(),
-                        &fragments,
-                    ));
-                }
+        if let (Some(open), Event::Start(Tag::CodeBlock(kind))) = (container.last(), &event) {
+            if matches!(open.kind, ContainerKind::List | ContainerKind::Blockquote) {
+                let line = line_for_offset(source, global_start);
+                let language =
+                    validate_container_code_fence(open.kind, kind, line, highlighter, code_images)
+                        .map_err(|err| {
+                            attach_slide_context(err, index, explicit_key.as_ref(), &fragments)
+                        })?;
+                container
+                    .first_mut()
+                    .expect("container code starts inside an open root container")
+                    .code_languages
+                    .push(language);
             }
         }
 
@@ -2502,20 +2632,10 @@ fn parse_slide(
                     // `code_images::transform_fragment`, which rebuilds the
                     // fragment and would silently drop the annotation.
                     let info = language.as_deref().unwrap_or_default();
-                    let split =
-                        emphasis::split_info_string(info, code_line).map_err(&mut slide_err)?;
+                    let (split, renderer) =
+                        validate_code_fence_info(info, code_line, highlighter, code_images)
+                            .map_err(&mut slide_err)?;
                     let language = split.language.map(str::to_owned);
-
-                    let renderer = language
-                        .as_deref()
-                        .and_then(|language| code_images.renderer_for(language));
-                    if let Some(language) = &language {
-                        if renderer.is_none() {
-                            highlighter
-                                .validate_language(language, code_line)
-                                .map_err(&mut slide_err)?;
-                        }
-                    }
 
                     let embed_options = match (renderer.as_ref(), split.tail) {
                         (Some(CodeImageRenderer::BuiltinEmbed), tail) => Some(
@@ -3438,14 +3558,14 @@ fn event_allowed_inside_container(kind: ContainerKind, event: &Event<'_>) -> boo
             | Event::End(TagEnd::TableCell)
     );
     match kind {
-        ContainerKind::List => {
+        ContainerKind::List | ContainerKind::Blockquote => {
             allowed_in_any_container
                 || matches!(
                     event,
                     Event::Start(Tag::CodeBlock(_)) | Event::End(TagEnd::CodeBlock)
                 )
         }
-        ContainerKind::Blockquote | ContainerKind::Table => allowed_in_any_container,
+        ContainerKind::Table => allowed_in_any_container,
     }
 }
 
@@ -5533,40 +5653,126 @@ After list
     }
 
     #[test]
-    fn rejects_fenced_code_inside_blockquote_before_language_or_renderer_dispatch() {
-        for language in ["notalang", "mermaid", "rust"] {
-            let markdown = format!("# Title\n\n> ```{language}\n> value\n> ```");
-            let err =
-                parse_markdown(&markdown, &crate::highlight::Highlighter::defaults()).unwrap_err();
+    fn container_code_parses_fenced_blockquote_as_markdown() {
+        let deck = parse_markdown(
+            "# Title\n\n> ```rust\n> fn quoted() {}\n> ```",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let fragment = &deck.parsed_slides()[0].fragments[1];
 
-            assert_eq!(err.kind, ErrorKind::Parse, "{language}");
-            assert_eq!(err.line, Some(3), "{language}");
-            assert!(
-                err.to_string().contains("code block inside a blockquote"),
-                "{language}: {err}"
-            );
+        assert_eq!(fragment.kind(), &FragmentKind::Blockquote);
+        assert_eq!(fragment.line(), 3);
+        assert!(fragment.markdown().contains("```rust"));
+        assert!(fragment.markdown().contains("fn quoted() {}"));
+    }
+
+    #[test]
+    fn container_code_parses_blockquote_nested_in_list() {
+        let deck = parse_markdown(
+            "# Title\n\n- > ```rust\n  > fn nested() {}\n  > ```",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let fragment = &deck.parsed_slides()[0].fragments[1];
+
+        assert_eq!(fragment.kind(), &FragmentKind::List);
+        assert_eq!(fragment.line(), 3);
+        assert!(fragment.markdown().contains("> ```rust"));
+        assert!(fragment.markdown().contains("fn nested() {}"));
+    }
+
+    #[test]
+    fn container_code_carries_validated_languages_in_source_order() {
+        let deck = parse_markdown(
+            "# Title\n\n- ```rust\n  fn highlighted() {}\n  ```\n- ```\n  plain\n  ```",
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
+        let fragment = &deck.parsed_slides()[0].fragments[1];
+
+        assert_eq!(
+            fragment.container_code_languages(),
+            &[
+                ContainerCodeLanguage::Highlighted("rust".to_owned()),
+                ContainerCodeLanguage::Plain,
+            ]
+        );
+    }
+
+    #[test]
+    fn container_code_rejects_unknown_languages_with_source_lines() {
+        for (container, markdown) in [
+            ("list", "# Title\n\n- ```notalang\n  value\n  ```"),
+            ("blockquote", "# Title\n\n> ```notalang\n> value\n> ```"),
+        ] {
+            let err =
+                parse_markdown(markdown, &crate::highlight::Highlighter::defaults()).unwrap_err();
+
+            assert_eq!(err.kind, ErrorKind::Parse, "{container}: {err}");
+            assert_eq!(err.line, Some(3), "{container}: {err}");
             assert_eq!(
-                err.help, "move the code block out of the quote",
-                "{language}"
+                err.message, "unknown code language 'notalang'",
+                "{container}: {err}"
             );
         }
     }
 
     #[test]
-    fn rejects_unknown_language_fence_inside_blockquote_nested_in_list() {
-        let err = parse_markdown(
-            "# Title\n\n- > ```notalang\n  > value\n  > ```",
-            &crate::highlight::Highlighter::defaults(),
-        )
-        .unwrap_err();
+    fn container_code_rejects_code_images_with_named_source_errors() {
+        let cases = [
+            (
+                "# Title\n\n- ```mermaid\n  graph TD\n  ```",
+                3,
+                "code_images block 'mermaid' is not supported inside a list",
+            ),
+            (
+                "# Title\n\n> ```mermaid\n> graph TD\n> ```",
+                3,
+                "code_images block 'mermaid' is not supported inside a blockquote",
+            ),
+            (
+                "---\ncode_images:\n  dot: dot -Tsvg\n---\n# Title\n\n> ```dot\n> digraph {}\n> ```",
+                7,
+                "code_images block 'dot' is not supported inside a blockquote",
+            ),
+        ];
 
-        assert_eq!(err.kind, ErrorKind::Parse);
-        assert_eq!(err.line, Some(3));
-        assert!(
-            err.to_string().contains("code block inside a blockquote"),
-            "{err}"
-        );
-        assert_eq!(err.help, "move the code block out of the quote");
+        for (markdown, line, message) in cases {
+            let err =
+                parse_markdown(markdown, &crate::highlight::Highlighter::defaults()).unwrap_err();
+
+            assert_eq!(err.kind, ErrorKind::Parse, "{err}");
+            assert_eq!(err.line, Some(line), "{err}");
+            assert_eq!(err.message, message, "{err}");
+            assert_eq!(err.help, "move the block to the top level", "{err}");
+        }
+    }
+
+    #[test]
+    fn container_code_rejects_line_emphasis_with_named_source_errors() {
+        for (container, markdown) in [
+            ("list", "# Title\n\n- ```rust {2}\n  one\n  two\n  ```"),
+            (
+                "blockquote",
+                "# Title\n\n> ```rust {2}\n> one\n> two\n> ```",
+            ),
+        ] {
+            let err =
+                parse_markdown(markdown, &crate::highlight::Highlighter::defaults()).unwrap_err();
+
+            assert_eq!(err.kind, ErrorKind::Parse, "{container}: {err}");
+            assert_eq!(err.line, Some(3), "{container}: {err}");
+            assert_eq!(
+                err.message,
+                format!("line emphasis is not supported inside a {container}"),
+                "{err}"
+            );
+            assert_eq!(
+                err.help, "remove the emphasis spec or move the block to the top level",
+                "{err}"
+            );
+        }
     }
 
     #[test]
@@ -5605,15 +5811,16 @@ After list
     }
 
     #[test]
-    fn keeps_fenced_code_swallowing_for_list_nested_in_blockquote() {
-        let deck = parse_markdown(
+    fn container_code_rejects_unknown_language_in_list_nested_in_blockquote() {
+        let err = parse_markdown(
             "# Title\n\n> - ```notalang\n>   value\n>   ```",
             &crate::highlight::Highlighter::defaults(),
         )
-        .expect("list-context fenced code remains deferred to #437");
-        let slide = &deck.parsed_slides()[0];
+        .unwrap_err();
 
-        assert_eq!(slide.fragments[1].kind(), &FragmentKind::Blockquote);
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(3));
+        assert_eq!(err.message, "unknown code language 'notalang'");
     }
 
     #[test]
@@ -7749,6 +7956,54 @@ After list
         assert_eq!(children.len(), 1);
         assert!(matches!(children[0].kind(), FragmentKind::Paragraph));
         assert_eq!(group.line(), 3);
+    }
+
+    #[test]
+    fn list_fence_before_slot_group_does_not_desynchronize_div_scanner() {
+        for markdown in [
+            "# Title\n\n- ```rust\n  fn in_list() {}\n  ```\n\n::: {slot=body}\n\nRouted body.\n\n:::\n",
+            "# Title\n\n> - ```rust\n>   fn nested() {}\n>   ```\n\n::: {slot=body}\n\nRouted body.\n\n:::\n",
+        ] {
+            let slide = parse_first_slide(markdown);
+
+            let group = slide
+                .fragments
+                .iter()
+                .find(|fragment| matches!(fragment.kind(), FragmentKind::SlotGroup { .. }))
+                .expect("expected the post-list div to route as a slot group");
+            let FragmentKind::SlotGroup { name, children } = group.kind() else {
+                unreachable!();
+            };
+            assert_eq!(name.as_slot_name().as_str(), "body");
+            assert_eq!(children.len(), 1);
+            assert_eq!(children[0].markdown(), "Routed body.");
+        }
+    }
+
+    #[test]
+    fn fence_like_container_prefix_inside_real_fence_does_not_toggle_scanner() {
+        let slide = parse_first_slide(
+            "# Title\n\n```\n- ```text\n::: {slot=literal}\n```\n\n::: {slot=body}\n\nRouted body.\n\n:::\n",
+        );
+
+        let code = slide
+            .fragments
+            .iter()
+            .find(|fragment| matches!(fragment.kind(), FragmentKind::Code))
+            .expect("outer code fragment");
+        assert!(code.code_text().contains("- ```text"));
+        assert!(code.code_text().contains("::: {slot=literal}"));
+
+        let groups = slide
+            .fragments
+            .iter()
+            .filter(|fragment| matches!(fragment.kind(), FragmentKind::SlotGroup { .. }))
+            .collect::<Vec<_>>();
+        assert_eq!(groups.len(), 1);
+        let FragmentKind::SlotGroup { name, .. } = groups[0].kind() else {
+            unreachable!();
+        };
+        assert_eq!(name.as_slot_name().as_str(), "body");
     }
 
     #[test]

--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -4,12 +4,12 @@ use html_escape::{encode_double_quoted_attribute, encode_text};
 use lol_html::{
     element, errors::RewritingError, html_content::ContentType, HtmlRewriter, Settings,
 };
-use pulldown_cmark::{html, Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{html, CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
 
 use crate::{
     domain::{
-        Accepts, AspectRatio, FootnoteEntry, FragmentKind, RenderedSlide, ResolvedImagePath,
-        RevealSpan, SlideKey, SlotName, SourceFragment,
+        Accepts, AspectRatio, ContainerCodeLanguage, FootnoteEntry, FragmentKind, RenderedSlide,
+        ResolvedImagePath, RevealSpan, SlideKey, SlotName, SourceFragment,
     },
     embed_card::{generic_embed_card_css, EmbedCardAssets},
     emphasis::LineEmphasis,
@@ -374,9 +374,10 @@ fn render_code_slot(
             .map(|fragment| render_code_fragment(fragment, highlighter))
             .collect::<Result<Vec<_>>>()?
             .join("\n");
-        return Ok(format!(
-            r#"<pre class="{class_name}"><code>{body}</code></pre>"#
-        ));
+        let language = (fragments.len() == 1)
+            .then(|| fragments[0].language())
+            .flatten();
+        return Ok(render_code_block(class_name, &body, language, None));
     }
 
     let mut body = String::new();
@@ -420,15 +421,63 @@ fn flush_code_run(
         .map(|fragment| render_code_fragment(fragment, highlighter))
         .collect::<Result<Vec<_>>>()?
         .join("\n");
-    body.push_str(&format!(
-        r#"<pre class="{class_name}"><code>{code}</code></pre>"#
-    ));
+    let language = (code_run.len() == 1)
+        .then(|| code_run[0].language())
+        .flatten();
+    body.push_str(&render_code_block(class_name, &code, language, None));
     Ok(())
+}
+
+fn render_code_block(
+    class_name: &str,
+    code: &str,
+    language: Option<&str>,
+    reveal_step: Option<usize>,
+) -> String {
+    let mut html = format!(r#"<pre class="{class_name}""#);
+    if let Some(step) = reveal_step {
+        html.push_str(&format!(r#" data-reveal-step="{step}""#));
+    }
+    html.push_str("><code");
+    if let Some(language) = language {
+        html.push_str(r#" class="language-"#);
+        html.push_str(&encode_double_quoted_attribute(language));
+        html.push('"');
+    }
+    html.push('>');
+    html.push_str(code);
+    html.push_str("</code></pre>");
+    html
 }
 
 fn append_code_separator(body: &mut String) {
     if !body.is_empty() {
         body.push('\n');
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BodyMarkdownFragment<'a> {
+    markdown: &'a str,
+    line: usize,
+    code_languages: &'a [ContainerCodeLanguage],
+}
+
+impl<'a> BodyMarkdownFragment<'a> {
+    fn from_source(fragment: &'a SourceFragment<ResolvedImagePath>) -> Self {
+        Self {
+            markdown: fragment.markdown(),
+            line: fragment.line(),
+            code_languages: fragment.container_code_languages(),
+        }
+    }
+
+    fn plain(markdown: &'a str, line: usize) -> Self {
+        Self {
+            markdown,
+            line,
+            code_languages: &[],
+        }
     }
 }
 
@@ -447,7 +496,13 @@ fn render_block_slot(
     let mut markdown_run = Vec::new();
     for fragment in fragments {
         if let Some(span) = fragment.reveal_span() {
-            render_markdown_run(&mut body, &markdown_run, breaks, footnote_numbers)?;
+            render_markdown_run(
+                &mut body,
+                &markdown_run,
+                breaks,
+                footnote_numbers,
+                highlighter,
+            )?;
             markdown_run.clear();
             render_revealed_fragment(
                 &mut body,
@@ -462,14 +517,26 @@ fn render_block_slot(
         }
         match fragment.kind() {
             FragmentKind::Math { html } => {
-                render_markdown_run(&mut body, &markdown_run, breaks, footnote_numbers)?;
+                render_markdown_run(
+                    &mut body,
+                    &markdown_run,
+                    breaks,
+                    footnote_numbers,
+                    highlighter,
+                )?;
                 markdown_run.clear();
                 body.push_str(r#"<div class="peitho-math">"#);
                 body.push_str(html);
                 body.push_str("</div>");
             }
             FragmentKind::EmbedCard { html } => {
-                render_markdown_run(&mut body, &markdown_run, breaks, footnote_numbers)?;
+                render_markdown_run(
+                    &mut body,
+                    &markdown_run,
+                    breaks,
+                    footnote_numbers,
+                    highlighter,
+                )?;
                 markdown_run.clear();
                 body.push_str(r#"<div class="peitho-embed-card">"#);
                 body.push_str(html);
@@ -483,7 +550,13 @@ fn render_block_slot(
                 provider_html,
                 permalink_attr,
             } => {
-                render_markdown_run(&mut body, &markdown_run, breaks, footnote_numbers)?;
+                render_markdown_run(
+                    &mut body,
+                    &markdown_run,
+                    breaks,
+                    footnote_numbers,
+                    highlighter,
+                )?;
                 markdown_run.clear();
                 body.push_str(r#"<div class="peitho-embed-card">"#);
                 body.push_str(&render_generic_embed_card_content(
@@ -497,22 +570,36 @@ fn render_block_slot(
                 body.push_str("</div>");
             }
             FragmentKind::Footnotes { entries } => {
-                render_markdown_run(&mut body, &markdown_run, breaks, footnote_numbers)?;
+                render_markdown_run(
+                    &mut body,
+                    &markdown_run,
+                    breaks,
+                    footnote_numbers,
+                    highlighter,
+                )?;
                 markdown_run.clear();
-                render_footnotes_block(&mut body, entries, breaks, footnote_numbers)?;
+                render_footnotes_block(&mut body, entries, breaks, footnote_numbers, highlighter)?;
             }
             FragmentKind::Heading { .. }
             | FragmentKind::Paragraph
             | FragmentKind::Text
             | FragmentKind::List
             | FragmentKind::Blockquote
-            | FragmentKind::Table => markdown_run.push(fragment.markdown()),
+            | FragmentKind::Table => {
+                markdown_run.push(BodyMarkdownFragment::from_source(fragment));
+            }
             FragmentKind::Code | FragmentKind::Image { .. } | FragmentKind::SlotGroup { .. } => {
                 unreachable!("validated by contract guard")
             }
         }
     }
-    render_markdown_run(&mut body, &markdown_run, breaks, footnote_numbers)?;
+    render_markdown_run(
+        &mut body,
+        &markdown_run,
+        breaks,
+        footnote_numbers,
+        highlighter,
+    )?;
     Ok(format!(r#"<div class="{class_name}">{body}</div>"#))
 }
 
@@ -594,6 +681,7 @@ fn render_revealed_fragment(
             span.start,
             breaks,
             footnote_numbers,
+            highlighter,
         ),
         FragmentKind::Paragraph => render_revealed_markdown_root(
             body,
@@ -602,6 +690,7 @@ fn render_revealed_fragment(
             span.start,
             breaks,
             footnote_numbers,
+            highlighter,
         ),
         FragmentKind::Blockquote => render_revealed_markdown_root(
             body,
@@ -610,6 +699,7 @@ fn render_revealed_fragment(
             span.start,
             breaks,
             footnote_numbers,
+            highlighter,
         ),
         FragmentKind::Table => render_revealed_markdown_root(
             body,
@@ -618,6 +708,7 @@ fn render_revealed_fragment(
             span.start,
             breaks,
             footnote_numbers,
+            highlighter,
         ),
         FragmentKind::Text => unreachable!("revealed Text fragments are not renderable"),
         FragmentKind::Code => {
@@ -630,13 +721,18 @@ fn render_revealed_fragment(
                 .emphasis()
                 .is_some_and(|emphasis| emphasis.stepped());
             if stepped_emphasis {
-                body.push_str(&format!(
-                    r#"<pre class="{class_name}"><code>{code}</code></pre>"#
+                body.push_str(&render_code_block(
+                    class_name,
+                    &code,
+                    fragment.language(),
+                    None,
                 ));
             } else {
-                body.push_str(&format!(
-                    r#"<pre class="{class_name}" data-reveal-step="{}"><code>{code}</code></pre>"#,
-                    span.start
+                body.push_str(&render_code_block(
+                    class_name,
+                    &code,
+                    fragment.language(),
+                    Some(span.start),
                 ));
             }
             Ok(())
@@ -694,9 +790,14 @@ fn render_revealed_fragment(
             )?);
             Ok(())
         }
-        FragmentKind::List => {
-            render_revealed_list_fragment(body, fragment, span, breaks, footnote_numbers)
-        }
+        FragmentKind::List => render_revealed_list_fragment(
+            body,
+            fragment,
+            span,
+            breaks,
+            footnote_numbers,
+            highlighter,
+        ),
         FragmentKind::SlotGroup { .. } => {
             unreachable!("revealed SlotGroup fragments are not renderable")
         }
@@ -718,11 +819,13 @@ fn render_revealed_markdown_root(
     step: usize,
     breaks: bool,
     footnote_numbers: &BTreeMap<String, usize>,
+    highlighter: &Highlighter,
 ) -> Result<()> {
     let mut events = Vec::new();
     let mut root_stamped = false;
-    let mut in_html_comment = false;
-    for event in Parser::new_ext(fragment.markdown(), BODY_MARKDOWN_OPTIONS) {
+    for (event, range) in
+        Parser::new_ext(fragment.markdown(), BODY_MARKDOWN_OPTIONS).into_offset_iter()
+    {
         let event = match (root, root_stamped, event) {
             (
                 RevealedMarkdownRoot::Heading,
@@ -750,11 +853,7 @@ fn render_revealed_markdown_root(
             }
             (_, _, event) => event,
         };
-        if let Some(event) =
-            normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
-        {
-            events.push(event);
-        }
+        events.push((event, range));
     }
     let missing_root = match (root, root_stamped) {
         (RevealedMarkdownRoot::Heading, false) => Some("heading"),
@@ -770,7 +869,18 @@ fn render_revealed_markdown_root(
     }
 
     let mut rendered = String::new();
-    html::push_html(&mut rendered, events.into_iter());
+    let sources = [BodyMarkdownSource {
+        range: 0..fragment.markdown().len(),
+        fragment: BodyMarkdownFragment::from_source(fragment),
+    }];
+    render_body_markdown_events(
+        &mut rendered,
+        &sources,
+        events,
+        breaks,
+        footnote_numbers,
+        highlighter,
+    )?;
     if matches!(root, RevealedMarkdownRoot::Table) {
         stamp_revealed_table_root(&mut rendered, step, fragment.line())?;
     }
@@ -797,37 +907,43 @@ fn render_revealed_list_fragment(
     span: RevealSpan,
     breaks: bool,
     footnote_numbers: &BTreeMap<String, usize>,
+    highlighter: &Highlighter,
 ) -> Result<()> {
     let mut raw_events = Vec::new();
-    let mut events = Vec::new();
     let mut top_level_item_index = 0usize;
-    let mut in_html_comment = false;
-    walk_body_markdown_list_items(fragment.markdown(), |event, top_level_item| {
-        if top_level_item {
-            let step = span.start + top_level_item_index;
-            top_level_item_index += 1;
-            raw_events.push(Event::Html(
-                format!(r#"<li data-reveal-step="{step}">"#).into(),
-            ));
-        } else {
-            raw_events.push(event);
-        }
-    });
+    walk_body_markdown_list_items_with_ranges(
+        fragment.markdown(),
+        |event, range, top_level_item| {
+            if top_level_item {
+                let step = span.start + top_level_item_index;
+                top_level_item_index += 1;
+                raw_events.push((
+                    Event::Html(format!(r#"<li data-reveal-step="{step}">"#).into()),
+                    range,
+                ));
+            } else {
+                raw_events.push((event, range));
+            }
+        },
+    );
     if top_level_item_index != span.len {
         unreachable!(
             "revealed list span length mismatch: stamped {top_level_item_index} top-level items but span.len is {}",
             span.len
         );
     }
-    for event in raw_events {
-        if let Some(event) =
-            normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
-        {
-            events.push(event);
-        }
-    }
-    html::push_html(body, events.into_iter());
-    Ok(())
+    let sources = [BodyMarkdownSource {
+        range: 0..fragment.markdown().len(),
+        fragment: BodyMarkdownFragment::from_source(fragment),
+    }];
+    render_body_markdown_events(
+        body,
+        &sources,
+        raw_events,
+        breaks,
+        footnote_numbers,
+        highlighter,
+    )
 }
 
 fn render_footnotes_block(
@@ -835,6 +951,7 @@ fn render_footnotes_block(
     entries: &[FootnoteEntry],
     breaks: bool,
     footnote_numbers: &BTreeMap<String, usize>,
+    highlighter: &Highlighter,
 ) -> Result<()> {
     if let Some(step) = wrapper_reveal_step(entries) {
         body.push_str(&format!(
@@ -849,7 +966,13 @@ fn render_footnotes_block(
         } else {
             body.push_str("<li>");
         }
-        render_markdown_run(body, &[entry.markdown()], breaks, footnote_numbers)?;
+        render_markdown_run(
+            body,
+            &[BodyMarkdownFragment::plain(entry.markdown(), entry.line())],
+            breaks,
+            footnote_numbers,
+            highlighter,
+        )?;
         body.push_str("</li>");
     }
     body.push_str("</ol></div>");
@@ -865,25 +988,189 @@ fn wrapper_reveal_step(entries: &[FootnoteEntry]) -> Option<usize> {
 
 fn render_markdown_run(
     body: &mut String,
-    markdown_run: &[&str],
+    markdown_run: &[BodyMarkdownFragment<'_>],
     breaks: bool,
     footnote_numbers: &BTreeMap<String, usize>,
+    highlighter: &Highlighter,
 ) -> Result<()> {
     if markdown_run.is_empty() {
         return Ok(());
     }
-    let markdown = markdown_run.join("\n\n");
-    let mut events = Vec::new();
+    let mut markdown = String::new();
+    let mut sources = Vec::with_capacity(markdown_run.len());
+    for (index, fragment) in markdown_run.iter().copied().enumerate() {
+        if index > 0 {
+            markdown.push_str("\n\n");
+        }
+        let start = markdown.len();
+        markdown.push_str(fragment.markdown);
+        let end = markdown.len();
+        sources.push(BodyMarkdownSource {
+            range: start..end,
+            fragment,
+        });
+    }
+    let events = Parser::new_ext(&markdown, BODY_MARKDOWN_OPTIONS).into_offset_iter();
+    render_body_markdown_events(
+        body,
+        &sources,
+        events,
+        breaks,
+        footnote_numbers,
+        highlighter,
+    )
+}
+
+struct BodyMarkdownSource<'a> {
+    range: Range<usize>,
+    fragment: BodyMarkdownFragment<'a>,
+}
+
+struct HighlightedContainerCode<'a> {
+    kind: CodeBlockKind<'a>,
+    language: String,
+    text: String,
+    line: usize,
+}
+
+fn render_body_markdown_events<'a>(
+    body: &mut String,
+    sources: &[BodyMarkdownSource<'_>],
+    events: impl IntoIterator<Item = (Event<'a>, Range<usize>)>,
+    breaks: bool,
+    footnote_numbers: &BTreeMap<String, usize>,
+    highlighter: &Highlighter,
+) -> Result<()> {
+    let mut normalized = Vec::new();
     let mut in_html_comment = false;
-    for event in Parser::new_ext(&markdown, BODY_MARKDOWN_OPTIONS) {
-        if let Some(event) =
-            normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
-        {
-            events.push(event);
+    let mut highlighted_code: Option<HighlightedContainerCode<'a>> = None;
+    let mut consumed_code_languages = vec![0usize; sources.len()];
+
+    for (event, range) in events {
+        if highlighted_code.is_some() {
+            match event {
+                Event::Text(text) => {
+                    highlighted_code
+                        .as_mut()
+                        .expect("highlighted code state is open")
+                        .text
+                        .push_str(text.as_ref());
+                    continue;
+                }
+                Event::End(TagEnd::CodeBlock) => {
+                    let code = highlighted_code
+                        .take()
+                        .expect("highlighted code state is open");
+                    let highlighted = render_highlighted_code(
+                        highlighter,
+                        &code.text,
+                        &code.language,
+                        code.line,
+                    )?;
+                    normalized.push(Event::Start(Tag::CodeBlock(code.kind)));
+                    normalized.push(Event::Html(highlighted.into()));
+                    normalized.push(Event::End(TagEnd::CodeBlock));
+                    continue;
+                }
+                _ => {
+                    let line = highlighted_code
+                        .as_ref()
+                        .expect("highlighted code state is open")
+                        .line;
+                    return Err(container_code_metadata_mismatch_error(Some(line)));
+                }
+            }
+        }
+
+        match event {
+            Event::Start(Tag::CodeBlock(kind)) => {
+                let Some((source_index, source)) =
+                    body_markdown_source_for_offset(sources, range.start)
+                else {
+                    return Err(container_code_metadata_mismatch_error(
+                        sources.first().map(|source| source.fragment.line),
+                    ));
+                };
+                let line = body_markdown_line_for_offset(source, range.start);
+                let language_index = consumed_code_languages[source_index];
+                let Some(language) = source.fragment.code_languages.get(language_index) else {
+                    return Err(container_code_metadata_mismatch_error(Some(line)));
+                };
+                consumed_code_languages[source_index] += 1;
+
+                match language {
+                    ContainerCodeLanguage::Highlighted(language) => {
+                        highlighted_code = Some(HighlightedContainerCode {
+                            kind,
+                            language: language.clone(),
+                            text: String::new(),
+                            line,
+                        });
+                    }
+                    ContainerCodeLanguage::Plain => {
+                        if let Some(event) = normalize_markdown_event(
+                            Event::Start(Tag::CodeBlock(kind)),
+                            breaks,
+                            footnote_numbers,
+                            &mut in_html_comment,
+                        )? {
+                            normalized.push(event);
+                        }
+                    }
+                }
+            }
+            event => {
+                if let Some(event) =
+                    normalize_markdown_event(event, breaks, footnote_numbers, &mut in_html_comment)?
+                {
+                    normalized.push(event);
+                }
+            }
         }
     }
-    html::push_html(body, events.into_iter());
+
+    if let Some(code) = highlighted_code {
+        return Err(container_code_metadata_mismatch_error(Some(code.line)));
+    }
+
+    for (source, consumed) in sources.iter().zip(consumed_code_languages) {
+        if consumed != source.fragment.code_languages.len() {
+            return Err(container_code_metadata_mismatch_error(Some(
+                source.fragment.line,
+            )));
+        }
+    }
+
+    html::push_html(body, normalized.into_iter());
     Ok(())
+}
+
+fn body_markdown_source_for_offset<'a, 'source>(
+    sources: &'a [BodyMarkdownSource<'source>],
+    offset: usize,
+) -> Option<(usize, &'a BodyMarkdownSource<'source>)> {
+    sources
+        .iter()
+        .enumerate()
+        .find(|(_, source)| source.range.contains(&offset))
+}
+
+fn body_markdown_line_for_offset(source: &BodyMarkdownSource<'_>, offset: usize) -> usize {
+    let local_offset = offset - source.range.start;
+    source.fragment.line
+        + source.fragment.markdown.as_bytes()[..local_offset]
+            .iter()
+            .filter(|byte| **byte == b'\n')
+            .count()
+}
+
+fn container_code_metadata_mismatch_error(line: Option<usize>) -> BuildError {
+    BuildError::new(
+        ErrorKind::Layout,
+        line,
+        "internal render error: container code metadata count/order mismatch",
+        "report this issue with the container Markdown that triggered it",
+    )
 }
 
 fn normalize_markdown_event<'a>(
@@ -964,9 +1251,12 @@ fn render_code_fragment(
 
     let Some(emphasis) = fragment.emphasis() else {
         return match fragment.language() {
-            Some(language) => highlighter
-                .highlight_html(fragment.code_text(), language, fragment.line())
-                .map(|html| html.trim_end().to_owned()),
+            Some(language) => render_highlighted_code(
+                highlighter,
+                fragment.code_text(),
+                language,
+                fragment.line(),
+            ),
             None => Ok(encode_text(fragment.code_text().trim_end()).into_owned()),
         };
     };
@@ -985,6 +1275,20 @@ fn render_code_fragment(
     // the step of the first group.
     let base_step = fragment.reveal_span().map(|span| span.start);
     Ok(wrap_emphasis_lines(&lines, emphasis, base_step))
+}
+
+/// The one non-emphasis highlighting seam for top-level and container code.
+/// Syntect preserves the source's final newline; rendered code blocks do not,
+/// so trim it here before either caller adds its `<pre><code>` wrappers.
+fn render_highlighted_code(
+    highlighter: &Highlighter,
+    code: &str,
+    language: &str,
+    line: usize,
+) -> Result<String> {
+    highlighter
+        .highlight_html(code, language, line)
+        .map(|html| html.trim_end().to_owned())
 }
 
 /// Wrap each code line in a `code-line` span, marking emphasized lines.
@@ -2070,6 +2374,30 @@ mod tests {
         parse_markdown_impl(source, frontmatter, highlighter)
     }
 
+    fn highlight_class_vocabulary(html: &str) -> std::collections::BTreeSet<String> {
+        let mut classes = std::collections::BTreeSet::new();
+        let mut rest = html;
+        while let Some(start) = rest.find("class=\"") {
+            rest = &rest[start + "class=\"".len()..];
+            let Some(end) = rest.find('"') else {
+                break;
+            };
+            for class in rest[..end].split_ascii_whitespace() {
+                if class.starts_with("hl-") {
+                    classes.insert(class.to_owned());
+                }
+            }
+            rest = &rest[end + 1..];
+        }
+        classes
+    }
+
+    fn first_pre_block(html: &str) -> &str {
+        let start = html.find("<pre").expect("rendered pre block");
+        let end = html[start..].find("</pre>").expect("closed pre block") + start + "</pre>".len();
+        &html[start..end]
+    }
+
     fn javascript_timeout_ms(source: &str, name: &str) -> u64 {
         let prefix = format!("var {name} = ");
         source
@@ -2246,6 +2574,102 @@ mod tests {
         );
         assert!(html.contains("<ul>\n<li>nested item</li>\n</ul>"), "{html}");
         assert!(html.contains("<p>nested quote</p>"), "{html}");
+    }
+
+    #[test]
+    fn container_code_matches_top_level_highlighted_block_html() {
+        let top_level = render_code_html(
+            "# Title\n\n```rust\nfn example(value: usize) -> usize { value + 1 }\n```",
+        );
+        let expected =
+            first_pre_block(&top_level).replacen(r#"<pre class="slot-code">"#, "<pre>", 1);
+        assert!(expected.contains("hl-"), "{expected}");
+        assert!(
+            expected.contains(r#"<code class="language-rust">"#),
+            "{expected}"
+        );
+
+        for (container, markdown) in [
+            (
+                "list",
+                "# Title\n\n- ```rust\n  fn example(value: usize) -> usize { value + 1 }\n  ```",
+            ),
+            (
+                "blockquote",
+                "# Title\n\n> ```rust\n> fn example(value: usize) -> usize { value + 1 }\n> ```",
+            ),
+        ] {
+            let rendered = render_checked_deck_with_layout(markdown, title_body_layout());
+            let html = rendered.slides()[0].html();
+
+            assert_eq!(first_pre_block(html), expected, "{container}: {html}");
+            assert_eq!(
+                highlight_class_vocabulary(html),
+                highlight_class_vocabulary(&top_level),
+                "{container}: {html}"
+            );
+        }
+    }
+
+    #[test]
+    fn container_code_untagged_stays_plain_and_is_never_markdown_parsed() {
+        for markdown in [
+            "# Title\n\n- ```\n  **literal** <!-- code comment -->\n  ```",
+            "# Title\n\n> ```\n> **literal** <!-- code comment -->\n> ```",
+        ] {
+            let rendered = render_checked_deck_with_layout(markdown, title_body_layout());
+            let html = rendered.slides()[0].html();
+
+            assert!(
+                html.contains("**literal** &lt;!-- code comment --&gt;"),
+                "{html}"
+            );
+            assert!(!html.contains("<strong>literal</strong>"), "{html}");
+            assert!(!html.contains("hl-"), "{html}");
+        }
+    }
+
+    #[test]
+    fn container_code_highlights_list_nested_in_blockquote() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n> - ```rust\n>   fn nested() {}\n>   ```",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains("<blockquote>"), "{html}");
+        assert!(html.contains("<ul>"), "{html}");
+        assert!(html.contains(r#"<code class="language-rust">"#), "{html}");
+        assert!(html.contains("hl-"), "{html}");
+    }
+
+    #[test]
+    fn indented_code_inside_blockquote_renders_as_plain_block() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n>     plain <code>\n>     second line",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(
+            html.contains("<pre><code>plain &lt;code&gt;\nsecond line</code></pre>"),
+            "{html}"
+        );
+        assert!(!html.contains("hl-"), "{html}");
+    }
+
+    #[test]
+    fn container_code_reveal_list_keeps_item_steps_and_highlighting() {
+        let rendered = render_checked_deck_with_layout(
+            "# Title\n\n::: {reveal}\n\n- first\n\n  ```rust\n  fn inside() {}\n  ```\n\n- second\n\n:::",
+            title_body_layout(),
+        );
+        let html = rendered.slides()[0].html();
+
+        assert!(html.contains(r#"data-reveal-steps="2""#), "{html}");
+        assert!(html.contains(r#"<li data-reveal-step="1">"#), "{html}");
+        assert!(html.contains(r#"<li data-reveal-step="2">"#), "{html}");
+        assert!(html.contains("hl-"), "{html}");
     }
 
     #[test]
@@ -2437,7 +2861,12 @@ mod tests {
     fn extract_line_spans(html: &str) -> Vec<String> {
         // Isolate the <code> body first: line spans are newline-separated
         // there, so splitting on '\n' yields exactly one wrapper per line.
-        let start = html.find("<code>").expect("rendered code slot") + "<code>".len();
+        let code_start = html.find("<code").expect("rendered code slot");
+        let start = code_start
+            + html[code_start..]
+                .find('>')
+                .expect("closed code opening tag")
+            + 1;
         let end = html[start..].find("</code>").expect("closed code slot") + start;
 
         html[start..end]
@@ -2700,8 +3129,9 @@ mod tests {
         );
         let html = rendered.slides()[0].html();
 
-        let plain_prefix = r#"<pre class="slot-code"><code>"#;
-        let revealed_prefix = r#"<pre class="slot-code" data-reveal-step="1"><code>"#;
+        let plain_prefix = r#"<pre class="slot-code"><code class="language-rust">"#;
+        let revealed_prefix =
+            r#"<pre class="slot-code" data-reveal-step="1"><code class="language-rust">"#;
         let plain_start = html.find(plain_prefix).unwrap();
         let revealed_start = html.find(revealed_prefix).unwrap();
         assert!(plain_start < revealed_start, "{html}");
@@ -2915,6 +3345,62 @@ mod tests {
     }
 
     #[test]
+    fn container_code_metadata_count_mismatches_share_one_internal_error() {
+        let cases = [
+            SourceFragment::list(7, "- ```rust\n  fn missing() {}\n  ```"),
+            SourceFragment::list(7, "- plain item")
+                .with_container_code_languages(vec![ContainerCodeLanguage::Plain]),
+        ];
+
+        for fragment in cases {
+            let fragments = resolve_fragments(vec![fragment]);
+            let err = render_block_slot(
+                "slot-body",
+                Accepts::Blocks,
+                &fragments,
+                false,
+                &BTreeMap::new(),
+                &Highlighter::defaults(),
+            )
+            .unwrap_err();
+
+            assert_eq!(err.kind, ErrorKind::Layout);
+            assert_eq!(err.line, Some(7));
+            assert_eq!(
+                err.message,
+                "internal render error: container code metadata count/order mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn container_highlight_error_uses_own_fragment_line_in_joined_run() {
+        // The source-line gap models a speaker-note comment between these
+        // fragments. Joined-buffer newline counts must not collapse that gap.
+        let fragments = resolve_fragments(vec![
+            SourceFragment::paragraph(3, "Before."),
+            SourceFragment::list(10, "- intro\n\n  ```rust\n  fn highlighted() {}\n  ```")
+                .with_container_code_languages(vec![ContainerCodeLanguage::Highlighted(
+                    "notalang".to_owned(),
+                )]),
+        ]);
+
+        let err = render_block_slot(
+            "slot-body",
+            Accepts::Blocks,
+            &fragments,
+            false,
+            &BTreeMap::new(),
+            &Highlighter::defaults(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ErrorKind::Parse);
+        assert_eq!(err.line, Some(12));
+        assert_eq!(err.message, "unknown code language 'notalang'");
+    }
+
+    #[test]
     fn block_slot_splices_math_between_markdown_runs() {
         let fragments = resolve_fragments(vec![
             SourceFragment::paragraph(3, "Before."),
@@ -3046,7 +3532,14 @@ mod tests {
         ];
         let mut body = String::new();
 
-        render_footnotes_block(&mut body, &entries, false, &BTreeMap::new()).unwrap();
+        render_footnotes_block(
+            &mut body,
+            &entries,
+            false,
+            &BTreeMap::new(),
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
 
         assert_eq!(
             body,
@@ -3069,7 +3562,14 @@ mod tests {
         ];
         let mut body = String::new();
 
-        render_footnotes_block(&mut body, &entries, false, &BTreeMap::new()).unwrap();
+        render_footnotes_block(
+            &mut body,
+            &entries,
+            false,
+            &BTreeMap::new(),
+            &crate::highlight::Highlighter::defaults(),
+        )
+        .unwrap();
 
         assert_eq!(
             body,
@@ -3189,7 +3689,10 @@ mod tests {
         let body_region = &html[body_start..figure_start];
         assert!(body_region.contains(r#"<sup class="peitho-footnote-ref">1</sup>"#));
         assert!(!body_region.contains("peitho-footnotes"), "{html}");
-        assert!(html.contains(r#"<pre class="slot-code"><code>"#), "{html}");
+        assert!(
+            html.contains(r#"<pre class="slot-code"><code class="language-rust">"#),
+            "{html}"
+        );
         assert!(html.contains(r#"<li><p>Supporting note.</p>"#), "{html}");
         assert!(!html.contains("data-empty-slots"), "{html}");
     }

--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -62,6 +62,57 @@ fn build_writes_index_html_and_css() {
 }
 
 #[test]
+fn build_emits_highlighted_code_inside_body_list() {
+    let dir = tempdir().unwrap();
+    let deck = dir.path().join("deck.md");
+    let out = dir.path().join("dist");
+
+    fs::write(
+        &deck,
+        "<!-- {\"key\":\"container-code\"} -->\n# Container code\n\n- ```rust\n  // visible comment\n  fn answer() -> usize { 42 }\n  ```",
+    )
+    .unwrap();
+
+    Command::cargo_bin("peitho")
+        .unwrap()
+        .args([
+            "build",
+            deck.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let slide = fs::read_to_string(out.join("slides/000-container-code.html")).unwrap();
+    assert!(
+        slide.contains(r#"<pre><code class="language-rust">"#),
+        "{slide}"
+    );
+    assert!(slide.contains(r#"class="hl-comment "#), "{slide}");
+
+    let css = fs::read_to_string(out.join("peitho.css")).unwrap();
+    assert!(
+        css.contains(
+            r#".slot-code,
+.slot-body pre {
+  display: block;
+  margin: 0;
+  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 22px;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}"#
+        ),
+        "{css}"
+    );
+    assert!(!css.contains("--peitho-code-"), "{css}");
+    assert!(css.contains(".peitho-slide .hl-comment {"), "{css}");
+    assert!(css.contains(".peitho-slide .hl-keyword,"), "{css}");
+}
+
+#[test]
 fn build_renders_footnote_reference_and_footnotes_block() {
     let dir = tempdir().unwrap();
     let deck = dir.path().join("deck.md");

--- a/docs/plans/2026-08-17-container-code-pipeline.md
+++ b/docs/plans/2026-08-17-container-code-pipeline.md
@@ -1,0 +1,98 @@
+# Route fenced code inside containers through the real pipeline (Issue #437)
+
+Date: 2026-08-17
+Issue: #437
+
+## Problem
+
+Fenced code that sits inside a container fragment (list item, blockquote)
+rides the container's markdown and is re-rendered by `push_html` — it never
+becomes `FragmentKind::Code`, so it bypasses unknown-language validation,
+syntect highlighting, code line emphasis, and `code_images` dispatch. For
+lists this is a long-standing silent gap (` ```notalang ` in a list builds
+clean; ` ```rust ` renders with zero `hl-*` spans). #424 closed the
+blockquote side with a hard error as a stopgap; this issue makes both
+containers uniform with real support.
+
+## Design
+
+**Parse-time validation** (single seam, both containers): while a container
+is open, fenced-code events are validated exactly like top-level fences:
+
+- unknown language tag → the existing line-numbered `unknown code language`
+  error;
+- a tag that resolves to a `code_images` renderer (built-in mermaid/math/
+  embed or a frontmatter-declared external command) → named line-numbered
+  error: these produce image/embed fragments that cannot ride inside a
+  container ("move the block to the top level");
+- a positional `{…}` emphasis spec on a container fence → named
+  line-numbered error (emphasis is a fragment-level feature; supporting it
+  inside containers would need per-fence step spaces — out of scope, loud).
+
+The #424 "code block inside a blockquote" hard error is replaced by this
+support; lists lose their silent path the same way (a deck with a bad tag
+inside a list now errors — the breaking change this issue exists to make,
+loud and line-numbered).
+
+**Render-time highlighting** (single seam): the container-markdown
+re-render intercepts `CodeBlock` events and emits the same
+syntect-highlighted `hl-*` span HTML as top-level code (shared helper with
+the existing code path — one highlighting authority, not a second copy).
+Plain (untagged) fences stay unhighlighted, exactly like top level.
+
+**Plain text**: container code text stays in the body text stream (it is
+part of the item/quote flow, unlike top-level code which routes to the
+`code` field) — unchanged from today, documented here as deliberate.
+
+## Tests (TDD order)
+
+1. ` ```rust ` inside a list item renders `hl-*` spans identical in class
+   vocabulary to the same fence at top level; same inside a blockquote.
+2. ` ```notalang ` inside a list item and inside a quote → line-numbered
+   unknown-language error (was silent for lists).
+3. ` ```mermaid ` inside a container → named code_images error with line.
+4. ` ```rust {2} ` inside a container → named emphasis error with line.
+5. Untagged fence inside a container renders as plain code (no spans), and
+   the fence content is never markdown-parsed.
+6. The #424 blockquote-code error tests are replaced by support tests;
+   existing container tests stay green.
+7. Reveal: a list with a code fence inside `::: {reveal}` keeps its step
+   counting unchanged.
+
+## Non-goals
+
+- No emphasis/steps inside containers (loud error instead).
+- No code_images rendering inside containers (loud error instead).
+- No change to top-level code handling or the `code` slot contract.
+
+## Amendments (2026-08-17, after adversarial review)
+
+- **Theme reach**: the built-in theme's `hl-*` color rules were scoped
+  `.slot-code .hl-*`, so container code carried classes but no colors (and
+  none of the code box styling) — visually indistinguishable from before
+  the feature. The color rules widen to slide scope (the `hl-` prefix
+  already guarantees no collision — that is its documented purpose), and
+  body-slot `pre` gains the same box styling / `pre-wrap` treatment as the
+  code slot. `examples/footnotes/css/base.css` stays byte-identical.
+- **Div-marker scanner symmetry**: the line-first `:::` scanner missed a
+  fence OPENED under a list/quote prefix (`- ```rust`) but its trimmed
+  CLOSER matched as an opener, desyncing fence state and silently
+  swallowing later `:::` markers as fence interior. Opening detection now
+  strips container prefixes (`>`, list markers) symmetrically with the
+  closer's whitespace handling, closing the mangling path.
+- **Typed parse→render carry**: container fences validated at parse ride
+  the fragment as an ordered list of validated languages; render consumes
+  them positionally from that single seam instead of re-parsing fence info
+  under a three-site convention. A count/order mismatch is one named
+  internal error.
+- **Line numbers**: container-code errors derive from each fragment's own
+  line, not run-start plus joined-buffer newlines.
+- **Indented code inside a blockquote is accepted** as an untagged plain
+  block (uniform with lists), pinned by test — replacing #424's stopgap
+  rejection wholesale, not just for fenced blocks.
+- Trailing-newline trim lives in the shared highlight seam so container
+  and top-level output match byte-for-byte; error kinds on the container
+  path mirror the top-level highlight path's conventions.
+- Restored coverage: bare `mermaid` in a blockquote, `> - ```rust`
+  nesting, and wrapper-class (`language-*`) assertions alongside the
+  hl-vocabulary parity test.

--- a/examples/footnotes/css/base.css
+++ b/examples/footnotes/css/base.css
@@ -166,7 +166,8 @@
   overflow: hidden;
 }
 
-.slot-code {
+.slot-code,
+.slot-body pre {
   display: block;
   margin: 0;
   font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -176,28 +177,32 @@
   overflow-wrap: anywhere;
 }
 
-.slot-code .hl-comment {
+.slot-body pre {
+  margin-bottom: 24px;
+}
+
+.peitho-slide .hl-comment {
   color: #8a8578;
 }
 
-.slot-code .hl-string {
+.peitho-slide .hl-string {
   color: #2f7d4f;
 }
 
-.slot-code .hl-keyword,
-.slot-code .hl-storage {
+.peitho-slide .hl-keyword,
+.peitho-slide .hl-storage {
   color: #7141d8;
 }
 
-.slot-code .hl-constant {
+.peitho-slide .hl-constant {
   color: #b45309;
 }
 
-.slot-code .hl-function {
+.peitho-slide .hl-function {
   color: #1d4ed8;
 }
 
-.slot-code .hl-type {
+.peitho-slide .hl-type {
   color: #0f766e;
 }
 

--- a/themes/base.css
+++ b/themes/base.css
@@ -166,7 +166,8 @@
   overflow: hidden;
 }
 
-.slot-code {
+.slot-code,
+.slot-body pre {
   display: block;
   margin: 0;
   font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -176,28 +177,32 @@
   overflow-wrap: anywhere;
 }
 
-.slot-code .hl-comment {
+.slot-body pre {
+  margin-bottom: 24px;
+}
+
+.peitho-slide .hl-comment {
   color: #8a8578;
 }
 
-.slot-code .hl-string {
+.peitho-slide .hl-string {
   color: #2f7d4f;
 }
 
-.slot-code .hl-keyword,
-.slot-code .hl-storage {
+.peitho-slide .hl-keyword,
+.peitho-slide .hl-storage {
   color: #7141d8;
 }
 
-.slot-code .hl-constant {
+.peitho-slide .hl-constant {
   color: #b45309;
 }
 
-.slot-code .hl-function {
+.peitho-slide .hl-function {
   color: #1d4ed8;
 }
 
-.slot-code .hl-type {
+.peitho-slide .hl-type {
   color: #0f766e;
 }
 


### PR DESCRIPTION
Closes #437

## What

Fenced code inside containers (list items, blockquotes) bypassed the entire code pipeline — ` ```notalang ` in a list built clean, ` ```rust ` rendered with zero highlighting, ` ```mermaid ` emitted raw source. #424 stopgapped the blockquote side with a hard error; this makes both containers uniform with real support.

- **Parse-time**: container fences validate through the same `validate_language` / `renderer_for` seams as top level (no tag carve-outs). `code_images` tags and `{…}` emphasis specs on container fences are named line-numbered errors. Validated languages ride the fragment as **typed ordered metadata** consumed positionally at render — the unvalidated-at-render state is unrepresentable; a mismatch is one named internal error.
- **Render-time**: container code highlights through the same `highlight_html` path, trimmed identically (full-HTML parity test, wrapper class included), error lines derived per fragment.
- **Theme**: `hl-*` color rules widen from `.slot-code` scope to slide scope (the `hl-` prefix exists precisely so it can't collide) and `.slot-body pre` shares `.slot-code`'s typography — without this the spans carried classes but no colors (confirmed empirically). `.slot-code`'s own declarations are untouched, so existing decks keep their exact look; the footnotes example CSS stays byte-identical.
- **Scanner fix riding along**: the line-first `:::` scanner missed fences opened under list/quote prefixes but matched their indented closers as openers — desyncing state and silently rendering later `:::` markers literally (confirmed). Opening detection now strips container prefixes symmetrically.
- Indented code inside a blockquote is accepted as plain code (uniform with lists), pinned by test.

## Breaking (deliberate, loud)

Unknown language tags inside lists now fail the build with line numbers — that silent pass is the bug this issue exists to remove.

## Verification

- `cargo test --workspace` ×3 green (940 core tests), clippy `-D warnings`, fmt, bindings/dist drift, theme/example CSS byte-parity.
- 8-finding adversarial review applied (2 confirmed-empirical findings: theme scoping no-op, scanner desync) and re-verified with built-binary E2E (colored spans in body slots, slot routing after list fences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV