### PR TITLE
Release 1.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.22.1"
+version = "1.23.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.22.1"
+version = "1.23.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.22.1"
+version = "1.23.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Bump version to 1.23.0.

## Included since 1.22.1

Real-world deck-writing feedback (https://stalins.club/notes/peitho-slide-tool) plus follow-ups:

- #433 include splice seam made construct-proof (silently merged slides fixed; unclosed fences/HTML blocks in included files are loud errors)
- #432 GFM strikethrough renders `<del>`
- #434 two-face bundled syntax set (typescript/ts, toml, dockerfile, text/plaintext, +200 more; pinned =0.5.2)
- #435 `data-empty-slots` on slide roots (validated selector vocabulary; base theme's `.footnotes:empty` migrated)
- #436 `peitho docs` — the full guide embedded in the binary for offline/agent reference
- #438 blockquote support (loud container boundaries; notes-in-container dist leak fixed)
- #441 table support (incl. inside lists/quotes; alignment; themeable styling)
- #442 tight paragraphs around `:::` fence markers
- #443 fenced code inside containers goes through the real code pipeline (validation + highlighting; theme hl-* scope widened)
- #439 load-independent CDP/present tests; #440 user-syntax relink cache (215ms → 0.3ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV