### PR TITLE
Showcase v1.23.0 Markdown features in the peitho-tour example

### DIFF
--- a/crates/peitho/tests/build.rs
+++ b/crates/peitho/tests/build.rs
@@ -1462,20 +1462,20 @@ fn peitho_tour_example_exercises_dispatch_and_agenda_sections() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("built 23 slide(s)"));
+        .stdout(predicate::str::contains("built 25 slide(s)"));
 
     let manifest: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(out.path().join("manifest.json")).unwrap())
             .unwrap();
-    assert_eq!(manifest["plannedDurationMs"].as_u64(), Some(1_380_000));
+    assert_eq!(manifest["plannedDurationMs"].as_u64(), Some(1_500_000));
     let sections = manifest["sections"].as_array().unwrap();
     let expected = [
         ("Intro", 0, 3, 180_000),
         ("Install", 4, 4, 60_000),
-        ("Write", 5, 10, 360_000),
-        ("Design", 11, 14, 300_000),
-        ("Run", 15, 21, 420_000),
-        ("Close", 22, 22, 60_000),
+        ("Write", 5, 12, 480_000),
+        ("Design", 13, 16, 300_000),
+        ("Run", 17, 23, 420_000),
+        ("Close", 24, 24, 60_000),
     ];
     assert_eq!(sections.len(), expected.len());
     for (section, (name, start, end, planned)) in sections.iter().zip(expected) {
@@ -1485,10 +1485,25 @@ fn peitho_tour_example_exercises_dispatch_and_agenda_sections() {
         assert_eq!(section["plannedDurationMs"].as_u64(), Some(planned));
     }
 
+    // The GFM showcase is body-only, so type-driven dispatch must select the
+    // `topic` layout while preserving the rendered table.
+    let gfm_body = fs::read_to_string(out.path().join("slides/006-gfm-body.html")).unwrap();
+    assert!(gfm_body.contains("guide-topic"));
+    assert!(gfm_body.contains("<table>"));
+
+    // The top-level source fence selects `code`; the TOML fence inside the
+    // blockquote must still run through the highlighting pipeline.
+    let container_code =
+        fs::read_to_string(out.path().join("slides/007-container-code.html")).unwrap();
+    assert!(container_code.contains("guide-code"));
+    let quote_start = container_code.find("<blockquote>").unwrap();
+    let quote_end = container_code[quote_start..].find("</blockquote>").unwrap() + quote_start;
+    assert!(container_code[quote_start..quote_end].contains("hl-toml"));
+
     // The preview slide holds only text + a single image; type-driven dispatch
     // must land it on the `shot` layout (with the image slot) instead of
     // `topic`, without any explicit `layout` pin.
-    let preview = fs::read_to_string(out.path().join("slides/015-preview.html")).unwrap();
+    let preview = fs::read_to_string(out.path().join("slides/017-preview.html")).unwrap();
     assert!(preview.contains("guide-shot"));
 }
 

--- a/docs/plans/2026-08-17-peitho-tour-v1230-showcase.md
+++ b/docs/plans/2026-08-17-peitho-tour-v1230-showcase.md
@@ -1,0 +1,12 @@
+# Peitho v1.23.0 tour showcase
+
+Add two slides immediately after “A slide is just Markdown” in `examples/peitho-tour/deck.md`. Keep the existing type-driven dispatch and give each slide a page-settings comment with only its unique `key`—never an explicit `layout`.
+
+- **“Tables, quotes, and edits render natively”** (`key: "gfm-body"`): render a compact GFM table, a real blockquote, and a sentence containing real `~~strikethrough~~`; none of these examples should be hidden inside a code fence. Use concise explanatory copy and, if useful, a speaker note calling out the resulting `<table>`, `<blockquote>`, and `<del>` elements. Title plus body content dispatches to `topic`.
+- **“Code blocks stay highlighted in quotes”** (`key: "container-code"`): render a small `toml` fence inside a real blockquote in the body, then pair it with a short top-level Markdown source fence in the code panel. The quote visibly exercises the container-code pipeline while the source fence makes the authoring pattern explicit. Title, body, and top-level code dispatch to `code`.
+
+Include the extended highlighting set (#434) and container-code pipeline (#443) together on the second slide: one quoted TOML example demonstrates both without adding a third slide.
+
+Increase the Write section budget from `6m` to `8m` and the frontmatter total from `23m` to `25m`; the section sum remains exact: `3 + 1 + 8 + 5 + 7 + 1 = 25m`.
+
+Verify with `cargo run -q -p peitho -- build examples/peitho-tour/deck.md`; it must succeed without timing, slot, or dispatch errors. Then inspect the generated `dist/` output and confirm the table, `<del>`, quoted TOML highlighting, and both expected layouts.

--- a/examples/peitho-tour/css/base.css
+++ b/examples/peitho-tour/css/base.css
@@ -136,12 +136,89 @@ samp {
   font-weight: 700;
 }
 
+.slot-body table {
+  width: 100%;
+  margin: 0 0 20px;
+  border-collapse: collapse;
+  font-size: 0.84em;
+  line-height: 1.45;
+}
+
+.slot-body th,
+.slot-body td {
+  padding: 0.35em 1em;
+  text-align: left;
+}
+
+.slot-body th {
+  color: #f2f6fd;
+  font-weight: 600;
+  border-bottom: 2px solid rgba(56, 189, 248, 0.65);
+}
+
+.slot-body td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.slot-body tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.slot-body blockquote {
+  position: relative;
+  margin: 0 0 20px;
+  padding-left: 24px;
+  color: #95a4be;
+}
+
+.slot-body blockquote::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4px;
+  border-radius: 2px;
+  background: linear-gradient(180deg, #38bdf8, #8b5cf6);
+}
+
+.slot-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.slot-body del {
+  color: #8391aa;
+  text-decoration-color: #a78bfa;
+}
+
 .slot-body code {
   font-size: 0.88em;
   color: #a5ddff;
   background: #17233e;
   padding: 2px 8px;
   border-radius: 6px;
+}
+
+.slot-body pre {
+  display: block;
+  margin: 10px 0 0;
+  padding: 16px 20px;
+  overflow: hidden;
+  border: 1px solid #223052;
+  border-radius: 12px;
+  background: rgba(9, 14, 28, 0.85);
+  color: #dbe5f5;
+  font-family: "JetBrains Mono", ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+  font-size: 17px;
+  line-height: 1.5;
+}
+
+.slot-body pre code {
+  display: block;
+  padding: 0;
+  border-radius: 0;
+  background: none;
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
 }
 
 .slot-body ul {
@@ -192,29 +269,29 @@ samp {
   color: #dbe5f5;
 }
 
-.code-panel .hl-comment {
+.peitho-slide .hl-comment {
   color: #5d6d8c;
 }
 
-.code-panel .hl-string {
+.peitho-slide .hl-string {
   color: #8fe3b0;
 }
 
-.code-panel .hl-keyword,
-.code-panel .hl-storage {
+.peitho-slide .hl-keyword,
+.peitho-slide .hl-storage {
   color: #c4b5fd;
 }
 
-.code-panel .hl-constant {
+.peitho-slide .hl-constant {
   color: #fda4af;
 }
 
-.code-panel .hl-function {
+.peitho-slide .hl-function {
   color: #93c5fd;
 }
 
-.code-panel .hl-type,
-.code-panel .hl-entity {
+.peitho-slide .hl-type,
+.peitho-slide .hl-entity {
   color: #5eead4;
 }
 

--- a/examples/peitho-tour/deck.md
+++ b/examples/peitho-tour/deck.md
@@ -1,5 +1,5 @@
 ---
-time: 23m
+time: 25m
 ---
 
 <!-- {"key":"cover","section":"Intro","time":"3m"} -->
@@ -54,7 +54,7 @@ brew install mizzy/tap/peitho
 
 ---
 
-<!-- {"key":"markdown","section":"Write","time":"6m"} -->
+<!-- {"key":"markdown","section":"Write","time":"8m"} -->
 # A slide is just Markdown
 
 Split slides on `---`. The shallowest heading becomes the title, fenced code blocks become code, and everything else becomes body content — each dropped into its own slot. The slots themselves are declared by the layout HTML, which we come back to in Design.
@@ -70,6 +70,48 @@ A body paragraph.
 
 # Second slide
 ```
+
+---
+
+<!-- {"key":"gfm-body"} -->
+# Tables, quotes, and edits render natively
+
+| Construct | Best for |
+| --- | --- |
+| Tables | Side-by-side comparisons |
+| Blockquotes | Context in another voice |
+| Strikethrough | Visible revisions |
+
+> Structure should be visible, not hidden in source.
+
+A plan can move from ~~draft~~ to **ready** without leaving Markdown.
+
+<!-- These are live body fragments: the build emits semantic table, blockquote, and del elements. -->
+
+---
+
+<!-- {"key":"container-code"} -->
+# Code blocks stay highlighted in quotes
+
+A quoted `toml` fence still gets bundled highlighting and full code validation.
+
+> A configuration example:
+>
+> ```toml
+> [tour]
+> version = "1.23.0"
+> format = "markdown"
+> ```
+
+````markdown
+> ```toml
+> [tour]
+> version = "1.23.0"
+> format = "markdown"
+> ```
+````
+
+<!-- TOML comes from the bundled extended syntax set. Even inside a blockquote, the fence follows the same validation and highlighting pipeline as top-level code. -->
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two showcase slides to `examples/peitho-tour` for the Markdown features shipped in v1.23.0, per the author's approval of extending the tour deck rather than adding a new example (no `DEMO_DECKS`/site wiring needed — the deck is already on the demo site and its source copy regenerates automatically).

- **"Tables, quotes, and edits render natively"** (`gfm-body`): a live GFM table (#441), blockquote (#438), and `~~strikethrough~~` (#432) rendered in the slide body; dispatches to the `topic` layout by type.
- **"Code blocks stay highlighted in quotes"** (`container-code`): a `toml` fence nested inside a blockquote goes through the real highlighting pipeline (#443), with the tag supplied by the bundled extended syntax set (#434); the code panel shows the quote-nested authoring source, dispatching to the `code` layout.

Both slides keep the deck's pure type-driven dispatch (no `layout` pins) and its key-per-slide convention. The Write section budget grows 6m → 8m and the deck total 23m → 25m (section sums stay exact).

## Theme

The tour theme had no styling for the new constructs (raw browser defaults: borderless table, indent-only quote) and rendered nested body code as per-line inline-code chips (inline `code` background wrapping each line box). `css/base.css` gains deck-scoped `table` / `blockquote` / `del` styling and a body code-panel treatment with a `pre code` block reset; `hl-*` color rules widen from `.code-panel` to `.peitho-slide` scope (same shape as the built-in theme's #437 decision) so nested code keeps the palette. Existing slides have no body tables/quotes/pre, so their rendering is unchanged — verified visually.

## Tests

`peitho_tour_example_exercises_dispatch_and_agenda_sections` re-pins the new deck shape (25 slides, 1,500,000 ms, shifted section ranges, `017-preview.html`) and adds dispatch/rendering assertions for both new slides, including `hl-toml` inside the rendered `<blockquote>`.

## Verification

- Full gate set green in the worktree: `cargo test --workspace` ×3 (14 suites, 0 failures), clippy `-D warnings`, `fmt --check`, bindings drift, npm build/test/typecheck, embedded shell/preview/remote dist drift.
- End-to-end visual check in real Chrome against a built copy of the deck: both new slides render as intended (styled table, accent-bar quote, highlighted quoted TOML, no overflow) and an existing code slide is unchanged.

Plan: `docs/plans/2026-08-17-peitho-tour-v1230-showcase.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV