### PR TITLE
docs: close guide gaps for page numbers, pointer, footnotes, and flags

### DIFF
--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -2,7 +2,7 @@
 title = "CLI"
 weight = 50
 template = "guide-page.html"
-description = "Scaffold, preview, lint, present, export, and publish a deck — plus inspection commands and shell completions."
+description = "Scaffold, preview, lint, present, export, and publish a deck — plus inspection commands, offline docs, and shell completions."
 +++
 
 Start a deck with `peitho new`; the day-to-day commands are `preview`,
@@ -39,6 +39,15 @@ peitho preview
 It watches the deck and its assets, serves locally, and reloads while
 preserving the current slide and overview state.
 
+`--port <PORT>` pins the server port, which is otherwise an ephemeral port
+chosen at startup. `--no-open` starts the server without launching a browser —
+useful when a browser is already pointed at a pinned port, or when nothing
+should open a window:
+
+```sh
+peitho preview --port 5173 --no-open
+```
+
 ## `peitho lint`
 
 Lint renders every slide in headless Chrome and warns when layout content
@@ -70,6 +79,37 @@ Use windowed presenter mode while debugging:
 peitho present --presenter-windowed
 ```
 
+### Keys during a talk
+
+| Key | Action |
+| --- | --- |
+| Space | Next step; in the presenter, starts or pauses the timer |
+| Arrows, PageUp / PageDown | Previous and next |
+| Home / End | First and last slide |
+| `f` | Fullscreen the current window |
+| `S` | Swap the slides and presenter displays |
+| Esc | Close the presentation and stop the server |
+
+`S` is the escape hatch for a misidentified display: each window navigates to
+its counterpart, so the windows stay where they are and only their roles swap.
+The presenter also exposes it as a Swap button. After a swap the slides window
+sits windowed, so press `f` to go back to fullscreen; the presenter timer
+resets. The shortcut is available only while the presenter is open, so a solo
+slides window cannot swap itself away.
+
+Keys combined with Cmd, Ctrl, or Alt are ignored, so browser shortcuts such as
+Cmd+F keep their usual meaning.
+
+### Controlling what opens
+
+| Flag | Effect |
+| --- | --- |
+| `--port <PORT>` | Pin the server port. Plain local runs otherwise use a random port; with `--host` the port is fixed at 6173. |
+| `--no-open` | Start the server without launching Chrome. |
+| `--no-presenter` | Open the slides window only, without the presenter view. |
+| `--no-serve` | Build the present cache and exit without serving. |
+| `--shell <PATH>` | Swap in a different present shell bundle. A development and debugging override; the built-in shell ships with the binary. |
+
 Use a phone as a clicker by exposing the present server on a reachable IP:
 
 ```sh
@@ -100,6 +140,20 @@ bar, in portrait or landscape, with iOS safe-area insets already accounted for:
 ![Peitho remote in landscape: preview on the left, notes in the center, Previous and Next on the right edge rail](/guide-shots/remote-landscape.png)
 
 </div>
+
+### Laser pointer
+
+The remote's Off / Pointer toggle turns its slide preview into a laser pointer.
+In Pointer mode, dragging a finger across the preview moves a pointer dot on the
+slide display; lifting the finger clears it. Switch back to Off to use the
+preview normally.
+
+Set the dot's color with the deck's
+[`pointer_color`](@/guide/frontmatter.md) frontmatter key:
+
+```yaml
+pointer_color: "#38bdf8"
+```
 
 Rehearse a talk with `--rehearsal` on a deck that declares
 `{"section":...}` markers, and Peitho records each section's actual time
@@ -150,8 +204,19 @@ moved or deleted.
 Export a PDF:
 
 ```sh
-peitho export pdf -o deck.pdf
+peitho export pdf
 ```
+
+`-o` / `--out` is optional; without it the PDF takes the deck's own path with a
+`.pdf` extension, so `deck.md` becomes `deck.pdf`:
+
+```sh
+peitho export pdf slides.md -o handout.pdf
+```
+
+Page size comes from the deck's [`resolution`](@/guide/frontmatter.md)
+frontmatter key when set. Export needs Chrome or Chromium, using the same
+discovery rules as `peitho lint` and `PEITHO_CHROME_PATH`.
 
 ## `peitho publish`
 
@@ -165,6 +230,32 @@ peitho publish -- aws s3 sync dist/ s3://your-bucket/
 `peitho publish` itself prints nothing on success — the output you see comes
 from the deploy command you passed after `--`, so you keep whatever progress
 reporting that command already gives you.
+
+`--dist <DIR>` inspects a directory other than `dist`. The inspection is a
+contamination check: it fails if presentation-shell or speaker-notes files
+reached the distributable output, so a deploy never ships notes.
+
+## `peitho docs`
+
+This guide is embedded in the binary, so it is readable offline and by agents
+driving Peitho without network access. With no argument, `peitho docs` lists the
+topic slugs and their descriptions:
+
+```sh
+peitho docs
+```
+
+Pass a slug to print one page as plain Markdown on stdout, or `--all` to print
+every page in guide order:
+
+```sh
+peitho docs writing-decks
+peitho docs --all
+```
+
+Output is unpaged plain Markdown with no ANSI escapes, so it pipes cleanly into
+a pager, a file, or another tool. An unknown topic exits non-zero and lists the
+valid slugs.
 
 ## `peitho completions`
 
@@ -184,6 +275,9 @@ pipeline:
 ```sh
 peitho build --watch
 ```
+
+`--watch` rebuilds on every change to the deck or its assets. `--out <DIR>`
+writes somewhere other than `dist`.
 
 ## `peitho layouts`
 

--- a/site/content/guide/frontmatter.md
+++ b/site/content/guide/frontmatter.md
@@ -18,8 +18,9 @@ by a missing closing `---` all stop the build.
 
 ## Keys
 
-Supported keys are `time`, `aspect_ratio`, `resolution`, `breaks`, `lang`,
-`layouts`, `css`, `syntaxes`, `fonts`, and `code_images`.
+Supported keys are `time`, `aspect_ratio`, `resolution`, `breaks`,
+`page_numbers`, `pointer_color`, `lang`, `layouts`, `css`, `syntaxes`, `fonts`,
+and `code_images`.
 
 | Key | Purpose |
 | --- | --- |
@@ -27,6 +28,8 @@ Supported keys are `time`, `aspect_ratio`, `resolution`, `breaks`, `lang`,
 | `aspect_ratio` | Slide canvas aspect ratio: `16:9` (default) or `4:3`. |
 | `resolution` | PDF-only physical page size in `WxH` CSS pixels. |
 | `breaks` | Render single newlines in slide body Markdown as hard line breaks: `true` or `false` (default). |
+| `page_numbers` | Show a page number on every slide: `current` or `current_of_total`. Omitted means no page numbers. |
+| `pointer_color` | Color of the laser pointer overlay driven from the phone remote: `#RGB`, `#RRGGBB`, `#RGBA`, `#RRGGBBAA`, or a CSS named color. |
 | `lang` | Deck language as a BCP 47 tag, emitted as `<html lang>` on every page that renders slides: `en` (default), `ja`, `zh-Hans`, … Language-sensitive CSS such as `word-break: auto-phrase` keys off this. |
 | `layouts` | Layout HTML file or directory. |
 | `css` | Theme CSS file or directory. |
@@ -44,6 +47,42 @@ time: 8m
 aspect_ratio: 16:9
 resolution: 1920x1080
 ```
+
+## Page numbers
+
+`page_numbers` turns on a page number for the whole deck. `current` renders the
+slide's own number; `current_of_total` renders it against the deck total:
+
+```yaml
+page_numbers: current_of_total
+```
+
+Individual slides opt out in their page settings comment with
+`"page_number":false` — useful for a cover or a closing slide:
+
+```markdown
+<!-- {"page_number":false} -->
+
+# Title slide
+```
+
+Only `false` is accepted there; `"page_number":true` is a build error, because
+the deck-level key is what turns numbering on. Using `"page_number":false`
+without a deck-level `page_numbers` is also a line-numbered error rather than a
+silent no-op.
+
+## Remote pointer color
+
+`pointer_color` sets the color of the laser pointer overlay driven from the
+phone remote:
+
+```yaml
+pointer_color: "#38bdf8"
+```
+
+Accepted values are `#RGB`, `#RRGGBB`, `#RGBA`, `#RRGGBBAA`, and CSS named
+colors such as `cyan`. See [CLI](@/guide/cli.md) for turning the pointer on
+during a talk.
 
 ## Code images
 

--- a/site/content/guide/writing-decks.md
+++ b/site/content/guide/writing-decks.md
@@ -261,10 +261,59 @@ rendered as plaintext.
 
 ![Notes appear in the presenter view alongside the current and next slides](/guide-shots/presenter-view.png)
 
+## Footnotes
+
+Footnotes keep a claim short while the supporting detail stays on the slide.
+Reference a label inline with `[^label]` and define it with `[^label]: body`:
+
+```markdown
+# Claims stay short
+
+- A claim can stay crisp while the evidence stays nearby[^study]
+- The same source can support a second point without a new number[^study]
+- A separate source receives the next number by first reference[^survey]
+
+[^study]: The same label keeps the same number every time it appears here.
+[^survey]: Numbering follows first-reference order, not definition order.
+```
+
+Footnotes are scoped to a single slide, so the same label may be reused on
+another slide without collision. Markers are numbered by first-reference order
+rather than definition order, and a label referenced several times keeps one
+number. Bodies take inline Markdown — emphasis, `code`, and links.
+
+A footnote body is one paragraph. Leave a blank line after the definition;
+a definition with no paragraph content is a build error.
+
+Every reference needs a definition and every definition needs a reference:
+undefined references, unused definitions, and duplicate definitions of the same
+label are all line-numbered build errors, so a missing citation never ships
+silently.
+
+Markers inside code spans and code blocks stay literal, so a regex character
+class such as `` `/^[^a-z]+$/` `` is not read as a citation.
+
+### Placing footnotes with a slot
+
+By default footnote entries render as body content. A layout that declares a
+`footnotes` slot receives them there instead, which pins them to a footer:
+
+```html
+<footer class="footnotes">
+  <slot name="footnotes" accepts="blocks" arity="0..1"></slot>
+</footer>
+```
+
+Routing is automatic — no explicit slot syntax is needed on the Markdown side.
+
+With [incremental reveal](#incremental-reveal), a footnote entry appears with
+the step of its earliest reference. If any reference sits in content that is
+never revealed step-by-step, the entry stays visible from the start.
+
 ## Page settings comments
 
 JSON HTML comments carry page settings. The supported settings are `key`,
-`layout`, `section`, `time`, `draft`, `skip`, and `include`.
+`layout`, `section`, `time`, `draft`, `skip`, `page_number`, and `include`.
 
 ```markdown
 <!-- {"key":"checks","layout":"agenda","section":"Contracts","time":"3m"} -->
@@ -285,6 +334,11 @@ navigation, and overview grid selection can still land on skipped slides.
 
 Draft slides cannot also be skipped or declare section markers. If every slide
 is marked draft, the build fails instead of producing an empty deck.
+
+`page_number:false` hides the page number on one slide when the deck sets
+[`page_numbers`](@/guide/frontmatter.md). Only `false` is accepted; `true` is a
+build error, as is using `page_number` on a deck that never turned page numbers
+on.
 
 ## Agenda sections
 


### PR DESCRIPTION
Closes #446

## What

The guide is what `peitho docs` embeds (#429, PR #436), so a gap in
`site/content/guide/` is a gap in the offline and agent-facing documentation.
An audit against the code surface found seven; this closes all of them.

Guide-only — no code changes. `docs.rs` enumerates the guide directory at test
time, so the additions flow into `peitho docs` automatically.

## frontmatter.md

The page asserted a complete list of ten keys while the parser accepts twelve
(`parser.rs:1097-1110`) — worse than silence, since a reader has no reason to
look further. Added `page_numbers` and `pointer_color` to both the prose list
and the table, plus two worked sections:

- **Page numbers**: `current` / `current_of_total`, the per-slide
  `"page_number":false` opt-out, and both error cases (`true` is rejected;
  `page_number` without deck-level `page_numbers` is a line-numbered error).
- **Remote pointer color**: accepted value forms, cross-linked to the CLI page.

## writing-decks.md

- `page_number` was missing from the page-settings list; added, with its rules.
- **Footnotes had no coverage at all** despite a dedicated `footnotes` slot,
  their own error class, and an example deck. New section covering reference and
  definition syntax, per-slide scoping, first-reference numbering, reuse of one
  label, the one-paragraph body rule, the undefined/unused/duplicate errors,
  literal markers in code spans, `footnotes` slot auto-routing, and
  reveal-step behavior (#367).

## cli.md

- **Keys during a talk**: only preview's keys were documented. Added the table
  for Space, arrows, PageUp/PageDown, Home/End, `f`, `S`, and Esc, with the
  swap escape hatch (windowed-after-swap and timer-reset tradeoffs, presenter-open
  gating) and the chord-modifier rule.
- **Laser pointer**: the remote's Off/Pointer toggle and its drag interaction —
  previously undocumented, and the sole consumer of `pointer_color`.
- **Flags**: `build --out`, `preview --port` / `--no-open`, `present --port` /
  `--no-open` / `--no-serve` / `--no-presenter` / `--shell`, `publish --dist`,
  and `export pdf --out` as optional with its default output name.
- **`peitho docs`**: PR #436 wired the command into `--help`, the README, and
  completions, but not into the guide it ships, so `peitho docs cli` did not
  describe `peitho docs`.

## Verification

- `cargo test --workspace` x3 green; clippy `-D warnings`, fmt, `bindings/` clean.
- All 14 `docs::tests` pass, including `rendered_topic_bodies_have_no_zola_internal_links`
  and `embedded_topics_match_guide_pages`, so the new `@/guide/...` links rewrite
  correctly for the embedded output.
- `zola build` clean (22 pages, 0 orphan); confirmed the new
  `#incremental-reveal` anchor resolves in the built HTML.
- Every documented key and flag was read back against its source: `keyboard.ts`
  (arrows/Space/Home/End/PageUp/PageDown/Escape), `controls.ts:184` (`f`),
  `swap.ts` + `presenter.ts` (`S`), `remote.ts:227-233` (pointer toggle),
  `main.rs:748-819` (flags), `main.rs:993` (default PDF name),
  `parser.rs:644-664` (page_number rules), `mapping.rs:306` (footnotes slot).

## Not included

The audit also flagged thin-but-present coverage for custom syntaxes, custom
fonts, and built-in syntax highlighting (each has a table row but no worked
example despite an example deck existing), and an undocumented `PEITHO_DIST`
env var. Left out to keep this scoped to the missing-entirely gaps; noted in
#446 as candidates for separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV
