### PR TITLE
docs: explain highlighting, custom syntaxes, fonts, and PEITHO_DIST

### DIFF
--- a/site/content/guide/cli.md
+++ b/site/content/guide/cli.md
@@ -235,6 +235,14 @@ reporting that command already gives you.
 contamination check: it fails if presentation-shell or speaker-notes files
 reached the distributable output, so a deploy never ships notes.
 
+The deploy command runs with `PEITHO_DIST` set to the inspected directory, so a
+script can find the built output without hardcoding a path — useful together
+with `--dist`:
+
+```sh
+peitho publish -- sh -c 'aws s3 sync "$PEITHO_DIST" s3://your-bucket/'
+```
+
 ## `peitho docs`
 
 This guide is embedded in the binary, so it is readable offline and by agents

--- a/site/content/guide/frontmatter.md
+++ b/site/content/guide/frontmatter.md
@@ -33,8 +33,8 @@ and `code_images`.
 | `lang` | Deck language as a BCP 47 tag, emitted as `<html lang>` on every page that renders slides: `en` (default), `ja`, `zh-Hans`, … Language-sensitive CSS such as `word-break: auto-phrase` keys off this. |
 | `layouts` | Layout HTML file or directory. |
 | `css` | Theme CSS file or directory. |
-| `syntaxes` | Custom syntect syntax file or directory. |
-| `fonts` | Font asset file or directory. |
+| `syntaxes` | Custom `.sublime-syntax` grammar file or directory, augmenting the built-in set. See [Syntax highlighting](@/guide/writing-decks.md#syntax-highlighting). |
+| `fonts` | Font asset file or directory, copied verbatim for your own `@font-face` rules. |
 | `code_images` | External commands or overrides that turn matching fenced code blocks into SVG images. |
 
 Examples in the repository include:
@@ -192,6 +192,34 @@ Layouts read `*.html`. CSS reads `*.css`. Syntaxes read
 `*.sublime-syntax` and augment the built-in syntax set. Fonts copy files
 verbatim without an extension filter, so `.woff2`, `.ttf`, and `@font-face` CSS
 files can live side by side.
+
+## Using custom fonts
+
+Peitho copies font assets; it does not declare them. Put the files in a
+`fonts/` directory next to the deck (or point `fonts:` at a file or directory),
+then write the `@font-face` rule yourself in your theme CSS.
+
+The copied `fonts/` directory sits next to the emitted `peitho.css`, so a
+relative URL resolves:
+
+```css
+@font-face {
+  font-family: "Playfair Display";
+  src: url("fonts/playfair-display-latin.woff2") format("woff2");
+  font-weight: 400 700;
+  font-display: swap;
+}
+
+.slot-title {
+  font-family: "Playfair Display", serif;
+}
+```
+
+Because fonts are copied without an extension filter, a font license or an
+`@font-face` stylesheet can sit in `fonts/` alongside the `.woff2` files and is
+copied too. See the
+[Custom Fonts example](https://peitho.gosu.ke/examples/custom-fonts/) for a
+complete deck.
 
 ## Error behavior
 

--- a/site/content/guide/writing-decks.md
+++ b/site/content/guide/writing-decks.md
@@ -192,6 +192,67 @@ Markdown fuses them to a marker, and the build fails with a line-numbered error.
 `{reveal=value}`, empty groups, unclosed fences, nested fences, and
 multi-attribute fences are line-numbered build errors.
 
+## Syntax highlighting
+
+Tag a fenced code block with a language and Peitho highlights it:
+
+````markdown
+```rust
+fn main() {
+    println!("hello");
+}
+```
+````
+
+Highlighting runs at build time with syntect, so slides carry no client-side
+highlighter and code never flashes unstyled before coloring in.
+
+A fence with no language tag stays plain text. A tag Peitho cannot resolve is a
+line-numbered build error rather than silently unhighlighted code:
+
+```
+error: slide 1 ('cover'), line 6: unknown code language 'crn'
+ help: use a language name syntect recognizes (e.g. rust, js, ts, py, sh, toml,
+       json, yaml, html, css, md, go, c, cpp, java, rb) or remove the tag
+```
+
+### Coloring code from CSS
+
+Highlighting emits `<span>` elements carrying `hl-`-prefixed classes rather
+than inline colors, so the palette lives in theme CSS like everything else. The
+classes are syntax scope names — `hl-keyword`, `hl-string`, `hl-comment`,
+`hl-function`, `hl-type`, `hl-constant`, `hl-storage`, and others depending on
+the grammar:
+
+```css
+.slot-code .hl-keyword { color: #c678dd; }
+.slot-code .hl-string  { color: #98c379; }
+.slot-code .hl-comment { color: #7f848e; font-style: italic; }
+```
+
+The `hl-` prefix keeps these from colliding with layout or slot classes.
+
+### Teaching Peitho a new language
+
+To highlight a language syntect does not ship, put a `.sublime-syntax` grammar
+in a `syntaxes/` directory next to the deck, or point the
+[`syntaxes`](@/guide/frontmatter.md) frontmatter key at a file or directory.
+Custom grammars augment the built-in set rather than replacing it.
+
+A fence tag resolves against the grammar's name **and** its declared
+`file_extensions`, so a grammar declaring:
+
+```yaml
+name: Carina
+file_extensions:
+  - crn
+scope: source.crn
+```
+
+highlights ```` ```crn ```` blocks. Adding the grammar is what turns that tag
+from a build error into highlighted code — see the
+[Custom Syntax example](https://peitho.gosu.ke/examples/custom-syntax/).
+
 ## Code line emphasis
 
 Point at specific lines of a code block — "the line I'm talking about right


### PR DESCRIPTION
Closes #448

## What

Follow-up to #446, which closed the gaps where a feature was missing from the
guide entirely. This covers the remaining category: features that had a
frontmatter table row but no working explanation, plus one undocumented
environment variable.

Guide-only — no code changes. `docs.rs` enumerates the guide directory at test
time, so the additions flow into `peitho docs` automatically.

## writing-decks.md — Syntax highlighting

Highlighting is a build-time feature with visible, themeable output, and its
only substantive mention was a contrast inside the code-emphasis section. New
section covering:

- Build-time syntect highlighting (no client-side highlighter, no flash of
  unstyled code).
- Untagged fences stay plain text; an unresolvable tag is a line-numbered build
  error, shown with the real error text.
- **`hl-*` span classes** — the seam an author styles to recolor code, with a
  CSS example. These existed in `themes/base.css` but appeared nowhere in the
  guide.
- **Teaching Peitho a new language**: a fence tag resolves against the grammar's
  name *and* its declared `file_extensions`. That is what makes ```` ```crn ````
  highlight once `syntaxes/crn.sublime-syntax` exists — the missing link between
  the `syntaxes:` key and a working deck.

## frontmatter.md — Using custom fonts

`fonts:` had one table row plus the copy rule. The missing half is how a font is
actually used: Peitho copies files but declares nothing, the copied directory
sits next to the emitted `peitho.css` so a relative `url()` resolves, and the
author writes the `@font-face` rule in their own theme CSS. Added with a worked
example, and noted that the no-extension-filter copy is why licenses and font
CSS can live in `fonts/` too.

The `syntaxes` and `fonts` table rows now say what the key does and link to the
new sections.

## cli.md — PEITHO_DIST

`peitho publish` runs the deploy command with `PEITHO_DIST` set to the inspected
directory (`main.rs:3288`) — a deliberate outbound contract with the user's own
command, documented nowhere. Added to the publish section next to the `--dist`
flag from #446, with a `sh -c` example showing why it pairs with `--dist`.

## Verification

- `cargo test --workspace` x3 green (14 test binaries); clippy `-D warnings`,
  fmt, `bindings/` clean.
- `zola build` clean (22 pages, 0 orphan); confirmed the new
  `#syntax-highlighting` anchor resolves against a real heading id in the built
  HTML.
- Checked the rendered `peitho docs writing-decks` output for the new section.
- **Verified the highlighting claims by building the example deck**: `peitho
  build` on `examples/custom-syntax/` emits `hl-comment`, `hl-constant`,
  `hl-declaration` and friends for its ```` ```crn ```` block, confirming both
  the `file_extensions` tag matching and the `hl-*` class emission as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV
