### PR TITLE
chore: bump version to 1.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.23.0"
+version = "1.24.0"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.23.0"
+version = "1.24.0"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Release 1.24.0.

## Why a minor bump

Everything merged since v1.23.0 is documentation (#447, #449) and an example
deck (#445) — but the guide is **compiled into the binary**. `crates/peitho/src/docs.rs`
pulls all five guide pages in with `include_str!`, so `peitho docs` output is
part of the shipped artifact, and this release genuinely changes it:

| Page | v1.23.0 | 1.24.0 |
| --- | --- | --- |
| `cli.md` | 212 lines | 314 |
| `frontmatter.md` | 162 lines | 229 |
| `writing-decks.md` | 333 lines | 448 |

That is ~40% more embedded guide (707 → 991 lines), all of it user-facing
content a Homebrew user reads offline via `peitho docs`. New material includes
the footnotes section, syntax highlighting and `hl-*` theming, custom syntax
grammars, `@font-face` usage, page numbers, the remote laser pointer,
present-mode keyboard shortcuts, previously undocumented flags, `PEITHO_DIST`,
and `peitho docs` itself.

No behavior changes: `crates/*/src` (other than `docs.rs`'s embedded content),
`packages/`, `layouts/`, `themes/`, and `bindings/` are unchanged since v1.23.0.

## Gates

- `cargo test --workspace` x3 green; clippy `-D warnings`, fmt, `bindings/` clean.
- `npm run build` + `npm test` (328 tests, 25 files) + `npm run typecheck` clean.
- `shell.js` / `preview.js` / `remote.js` embedded bundle drift: all clean.
- `Cargo.lock` updated via `cargo update --workspace` (the release workflow builds
  with `--locked`).
- Verified the built binary reports `peitho 1.24.0` and that `peitho docs --all`
  contains the new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TWnsEu5z4VELhqhcMKUUV
