### PR TITLE
fix(render): stop Escape from navigating to the site root

### DIFF
--- a/crates/peitho-core/src/render.rs
+++ b/crates/peitho-core/src/render.rs
@@ -1603,17 +1603,19 @@ pub fn render_distribution_index(aspect_ratio: AspectRatio, lang: &DeckLang) -> 
       }
     }
 
+    // A same-origin referrer is the only evidence this deck was reached from a
+    // page worth returning to. peitho generates the deck directory and nothing
+    // above it, so there is no site root it can assume exists; a deck published
+    // under a subdirectory would otherwise strand viewers on an unrelated page.
+    // Without that evidence, Escape does nothing.
     function exitToIndex() {
       const referrer = document.referrer;
-      if (referrer !== '') {
-        try {
-          if (new URL(referrer).origin === window.location.origin) {
-            window.history.back();
-            return;
-          }
-        } catch (_error) {}
-      }
-      window.location.assign('/');
+      if (referrer === '') return;
+      try {
+        if (new URL(referrer).origin === window.location.origin) {
+          window.history.back();
+        }
+      } catch (_error) {}
     }
 
     document.addEventListener('keydown', (event) => {
@@ -5023,8 +5025,20 @@ Paragraph after heading.
         assert!(html.contains("event.key === 'Escape'"));
         assert!(html.contains("function exitToIndex()"));
         assert!(html.contains("window.history.back()"));
-        assert!(html.contains("window.location.assign('/')"));
         assert!(html.contains("new URL(referrer).origin === window.location.origin"));
+    }
+
+    #[test]
+    fn distribution_index_escape_never_navigates_to_site_root() {
+        let html = render_distribution_index(AspectRatio::Ratio16To9, &DeckLang::default());
+
+        // peitho only ever generates the deck directory, so it cannot know what
+        // (if anything) lives at the origin root. A deck published under a
+        // subdirectory of an existing site would send viewers to an unrelated
+        // page. Escape leaves the deck only when a same-origin referrer proves
+        // there is somewhere to go back to.
+        assert!(!html.contains("window.location.assign('/')"));
+        assert!(!html.contains("location.assign('/')"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #451.

## Problem

`exitToIndex()` in the distribution `index.html` fell back to `window.location.assign('/')` whenever the referrer was absent or cross-origin. Opening a published deck by direct link (deep link, link from another site, social media) leaves `document.referrer` empty, so Escape sent the viewer to the origin root.

Reported on a deck published at `https://stalins.club/assets/slides/go127-generic-methods/`, where Escape navigates to an unrelated blog top page.

The behavior came from #128, which assumed the site root is the deck listing (`decks.gosu.ke`). That only holds for a dedicated deck-hosting domain.

Two underlying problems:

1. `/` is outside what peitho generates — `publish` emits `index.html`, `manifest.json`, `slides/`, and `peitho.css` under the deck directory. peitho has no knowledge of what lives at the origin root, or whether anything does.
2. The fallback was inverted: the no-referrer case is exactly where there is nothing to go back to, yet it triggered the most destructive action, while the safe `history.back()` was gated on a referrer existing.

## Change

Escape leaves the deck only when a same-origin referrer proves there is somewhere to return to; otherwise it does nothing.

```js
function exitToIndex() {
  const referrer = document.referrer;
  if (referrer === '') return;
  try {
    if (new URL(referrer).origin === window.location.origin) {
      window.history.back();
    }
  } catch (_error) {}
}
```

A frontmatter key for an explicit deck-listing URL is deliberately out of scope; revisit if the need comes up.

## Tests

`distribution_index_maps_escape_to_index_navigation` asserted the `/` fallback was present, so that assertion is removed and a dedicated `distribution_index_escape_never_navigates_to_site_root` test pins the absence of any `location.assign('/')` in the emitted artifact.

## Verification

Built `examples/footnotes/deck.md` and staged it at `/assets/slides/demo/` under a server whose root is an unrelated page, reproducing the reported layout. Driven in real Chrome:

- **Direct link (`referrer: ""`)** — Escape stays on the deck. Previously navigated to the site root.
- **Same-origin referrer (clicked through from a listing page)** — Escape still returns to the listing, confirming no regression.

Note: synthetic `Escape` keypresses are swallowed by Chrome before reaching the page (verified: a `keydown` counter stayed at 0), so the handler was exercised by dispatching a `KeyboardEvent` through the page's own listener.

Gates: `cargo test --workspace` 3x green, clippy clean, fmt clean, `bindings/` no drift. Rust-only change, so the TS bundles cannot drift.