### PR TITLE
chore: bump version to 1.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,7 +1883,7 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "peitho"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "peitho-core"
-version = "1.24.0"
+version = "1.24.1"
 dependencies = [
  "html-escape",
  "katex-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "1.24.0"
+version = "1.24.1"
 
 [workspace.dependencies]
 base64 = "0.22"


### PR DESCRIPTION
Patch release.

## Included since v1.24.0

- #452 — fix(render): stop Escape from navigating to the site root (fixes #451)

A published deck's Escape handler fell back to `window.location.assign('/')` whenever the referrer was absent or cross-origin, so opening a deck by direct link sent the viewer to the origin root — an unrelated page for any deck published under a subdirectory of an existing site. Escape now leaves the deck only when a same-origin referrer proves there is somewhere to return to.

Only `fix:` commits since the last release, so this is a patch bump.

## Gates

- `cargo test --workspace` — 3x green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `git diff --exit-code bindings/` — no drift
- `npm run build && npm test && npm run typecheck` — 328 tests pass, typecheck clean
- `dist/shell.js`, `dist/preview.js`, `dist/remote.js` — no drift